### PR TITLE
Change names for GitHub release in release CLI workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -94,7 +94,7 @@ jobs:
             packages/bws-aarch64-unknown-linux-gnu-${{ env.PKG_VERSION }}.zip,
             packages/bws-sha256-checksums-${{ env.PKG_VERSION }}.txt"
           commit: ${{ github.sha }}
-          tag: bws-cli-v${{ env.PKG_VERSION }}
+          tag: bws-v${{ env.PKG_VERSION }}
           name: bws CLI v${{ env.PKG_VERSION }}
           body: "<insert release notes here>"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -94,8 +94,8 @@ jobs:
             packages/bws-aarch64-unknown-linux-gnu-${{ env.PKG_VERSION }}.zip,
             packages/bws-sha256-checksums-${{ env.PKG_VERSION }}.txt"
           commit: ${{ github.sha }}
-          tag: cli-v${{ env.PKG_VERSION }}
-          name: CLI v${{ env.PKG_VERSION }}
+          tag: bws-cli-v${{ env.PKG_VERSION }}
+          name: bws CLI v${{ env.PKG_VERSION }}
           body: "<insert release notes here>"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true


### PR DESCRIPTION
Add `bws` to tag and release name for the CLI, to distinguish it for the future with `bw` cli.