### PR TITLE
Remove the unused oldtime feature from chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,11 +519,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -2104,7 +2101,7 @@ dependencies = [
  "line-wrap",
  "quick-xml",
  "serde",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -2987,17 +2984,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
@@ -3316,12 +3302,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -30,7 +30,7 @@ directories = "5.0.1"
 color-eyre = "0.6"
 toml = "0.7.4"
 comfy-table = "^6.1.4"
-chrono = "0.4.24"
+chrono = { version = "0.4.24", features = ["clock", "std"], default-features = false }
 uuid = { version = "^1.0", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove the oldtime feature from chrono, which is bringing the time 0.1 crate and causing some dependabot alerts.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
