### PR TITLE
Disable error coloring when specified by the user

### DIFF
--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -22,19 +22,29 @@ pub(crate) enum Color {
     Auto,
 }
 
+impl Color {
+    pub(crate) fn is_enabled(self) -> bool {
+        match self {
+            Color::No => false,
+            Color::Yes => true,
+            Color::Auto => {
+                if std::env::var("NO_COLOR").is_ok() {
+                    false
+                } else {
+                    atty::is(atty::Stream::Stdout)
+                }
+            }
+        }
+    }
+}
+
 const ASCII_HEADER_ONLY: &str = "     --            ";
 
 pub(crate) fn serialize_response<T: Serialize + TableSerialize<N>, const N: usize>(
     data: T,
     output: Output,
-    color: Color,
+    color: bool,
 ) {
-    let color = match color {
-        Color::No => false,
-        Color::Yes => true,
-        Color::Auto => atty::is(atty::Stream::Stdout),
-    };
-
     match output {
         Output::JSON => {
             let text = serde_json::to_string_pretty(&data).unwrap();


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes #50. Also added support for NO_COLOR, which clap already respects, but we didn't.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
