### PR TITLE
Enable some optimization flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,22 @@
 [workspace]
 
 members = ["crates/*"]
+
+# Compile all dependencies with some optimizations when building this crate on debug
+# This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster
+# As clean builds won't occur very often, this won't slow down the development process
+[profile.dev.package."*"]
+opt-level = 2
+
+# Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
+# if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
+[profile.dev]
+opt-level = 1
+
+# Turn on LTO on release mode
+[profile.release]
+lto = "thin"
+codegen-units = 1
+# Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore. 
+# This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
+# strip = true


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
I've done some performance analysis on the SDK, by using a test crate that creates a `bitwarden_json` client to login to an account with 7k items, doing a sync and decrypting all the ciphers. This is based on my state management PR so note that not all the sync data is decrypted which means these numbers aren't representative of what the final result is going to be once the SDK is complete.

| Operation           | Before                | After |
|-----------------|-------|-------|
| Debug - /sync    | 21s   | **1.5s** |
| Debug - decrypt | 500ms | **52ms**|
| Debug - binary size | 24 MB | **8.8 MB** |
| Debug - clean build | **25s** | 38s |
| Debug - incremental build | 0,8s | 0,8s |

| Operation           | Before                | After |
|-----------------|-------|-------|
| Release - /sync    | 1.1s   | 1.0s|
| Release - decrypt | 43ms | 41ms|
| Release - binary size | 7.4 MB | **4.8 MB - 3.4 MB (stripped)** |
| Release - clean build | **31s** | 59s |

In debug, clean build times are about 1.5x slower, but incremental builds are the same, while the resulting binary is an order of magnitude faster.

In release, clean build times are about 2x slower, while runtime is the same. The resulting binary is 40% smaller, and could be improved further by stripping the binary symbols.

We can look into creating a separate CI profile with zero optimizations if the increased compilation time turns out to be too big for CI as well.

I've also tried to analyze memory usage of the binary while both in debug and release, and also before and after this change, and that seems pretty much constant, and just under 60MB maximum.
I've used the command `/usr/bin/time -l ../../target/release/test_json`, not sure how precise that is.
