### PR TITLE
Use a more robust CLI color detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,6 @@ version = "0.0.2"
 name = "bws"
 version = "0.2.1"
 dependencies = [
- "atty",
  "bat",
  "bitwarden",
  "chrono",
@@ -463,6 +462,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.21",
+ "supports-color",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1558,6 +1558,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
@@ -2861,6 +2867,16 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "supports-color"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1.28.2", features = ["rt-multi-thread", "macros"] }
 log = "0.4.18"
 bitwarden = { path = "../bitwarden", version = "0.2.1" }
 env_logger = "0.10.0"
-atty = "0.2"
+supports-color = "2.0.0"
 thiserror = "1.0.40"
 serde = "^1.0.163"
 serde_json = "^1.0.96"

--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -27,13 +27,7 @@ impl Color {
         match self {
             Color::No => false,
             Color::Yes => true,
-            Color::Auto => {
-                if std::env::var("NO_COLOR").is_ok() {
-                    false
-                } else {
-                    atty::is(atty::Stream::Stdout)
-                }
-            }
+            Color::Auto => supports_color::on(supports_color::Stream::Stdout).is_some(),
         }
     }
 }


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Previously we only did a simple check for `NO_COLOR` to disable the terminal coloring, and we fell back to `isatty` otherwise. This would cause it to emit colors in dumb interactive terminals, and at the same time it wouldn't allow for a way to force colors while piping the output.

Switching to the `supports-color` crate, we don't have to do these checks ourselves while also getting others for free:
- Support for the http://bixense.com/clicolors/ spec, in addition to the https://no-color.org/ spec which we already supported. We can now use `CLICOLOR_FORCE=[true|false]` to force enable or disable the color regardless of terminal capabilities or interactive status.
- Support for dumb interactive terminals that can't handle colors properly (`TERM=dumb`).
