### PR TITLE
Fix invalid return types in schemas

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,3 +55,8 @@ jobs:
             >&2 echo "Failed: Found untracked files!"
             exit 1
           fi
+
+      - name: Verify rust documentation links
+        run: cargo doc --no-deps --features internal
+        env:
+          RUSTDOCFLAGS: "-D warnings"

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -32,7 +32,7 @@ pub enum Command {
     ///
     /// This command is not capable of handling authentication requiring 2fa or captcha.
     ///
-    /// Returns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)
+    /// Returns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)
     ///
     PasswordLogin(PasswordLoginRequest),
 
@@ -41,7 +41,7 @@ pub enum Command {
     ///
     /// This command is for initiating an authentication handshake with Bitwarden.
     ///
-    /// Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    /// Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     ///
     ApiKeyLogin(ApiKeyLoginRequest),
 
@@ -49,7 +49,7 @@ pub enum Command {
     ///
     /// This command is for initiating an authentication handshake with Bitwarden.
     ///
-    /// Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    /// Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     ///
     AccessTokenLogin(AccessTokenLoginRequest),
 
@@ -57,7 +57,7 @@ pub enum Command {
     /// > Requires Authentication
     /// Get the API key of the currently authenticated user
     ///
-    /// Returns: [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)
+    /// Returns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)
     ///
     GetUserApiKey(SecretVerificationRequest),
 
@@ -72,7 +72,7 @@ pub enum Command {
     /// > Requires Authentication
     /// Retrieve all user data, ciphers and organizations the user is a part of
     ///
-    /// Returns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)
+    /// Returns: [SyncResponse](bitwarden::platform::SyncResponse)
     ///
     Sync(SyncRequest),
 
@@ -87,7 +87,7 @@ pub enum SecretsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Retrieve a secret by the provided identifier
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     Get(SecretGetRequest),
 
@@ -95,7 +95,7 @@ pub enum SecretsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Creates a new secret in the provided organization using the given data
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     Create(SecretCreateRequest),
 
@@ -103,7 +103,7 @@ pub enum SecretsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Lists all secret identifiers of the given organization, to then retrieve each secret, use `CreateSecret`
     ///
-    /// Returns: [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)
+    /// Returns: [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)
     ///
     List(SecretIdentifiersRequest),
 
@@ -111,7 +111,7 @@ pub enum SecretsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Updates an existing secret with the provided ID using the given data
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     Update(SecretPutRequest),
 
@@ -119,7 +119,7 @@ pub enum SecretsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Deletes all the secrets whose IDs match the provided ones
     ///
-    /// Returns: [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)
+    /// Returns: [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)
     ///
     Delete(SecretsDeleteRequest),
 }
@@ -131,7 +131,7 @@ pub enum ProjectsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Retrieve a project by the provided identifier
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     Get(ProjectGetRequest),
 
@@ -139,7 +139,7 @@ pub enum ProjectsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Creates a new project in the provided organization using the given data
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     Create(ProjectCreateRequest),
 
@@ -147,7 +147,7 @@ pub enum ProjectsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Lists all projects of the given organization
     ///
-    /// Returns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)
+    /// Returns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)
     ///
     List(ProjectsListRequest),
 
@@ -155,7 +155,7 @@ pub enum ProjectsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Updates an existing project with the provided ID using the given data
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     Update(ProjectPutRequest),
 
@@ -163,7 +163,7 @@ pub enum ProjectsCommand {
     /// > Requires using an Access Token for login or calling Sync at least once
     /// Deletes all the projects whose IDs match the provided ones
     ///
-    /// Returns: [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)
+    /// Returns: [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
     ///
     Delete(ProjectsDeleteRequest),
 }

--- a/crates/bitwarden-napi/src-ts/bitwarden_client/schemas.ts
+++ b/crates/bitwarden-napi/src-ts/bitwarden_client/schemas.ts
@@ -86,24 +86,23 @@ export enum DeviceType {
  *
  * This command is not capable of handling authentication requiring 2fa or captcha.
  *
- * Returns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)
+ * Returns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)
  *
  * Login with API Key
  *
  * This command is for initiating an authentication handshake with Bitwarden.
  *
- * Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+ * Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
  *
  * Login with Secrets Manager Access Token
  *
  * This command is for initiating an authentication handshake with Bitwarden.
  *
- * Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+ * Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
  *
  * > Requires Authentication Get the API key of the currently authenticated user
  *
- * Returns:
- * [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)
+ * Returns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)
  *
  * Get the user's passphrase
  *
@@ -112,7 +111,7 @@ export enum DeviceType {
  * > Requires Authentication Retrieve all user data, ciphers and organizations the user is a
  * part of
  *
- * Returns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)
+ * Returns: [SyncResponse](bitwarden::platform::SyncResponse)
  */
 export interface Command {
     passwordLogin?:    PasswordLoginRequest;
@@ -196,28 +195,28 @@ export interface PasswordLoginRequest {
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Retrieve a project by the provided identifier
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Creates a new project in the provided organization using the given data
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Lists all projects of the given organization
  *
- * Returns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)
+ * Returns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Updates an existing project with the provided ID using the given data
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Deletes all the projects whose IDs match the provided ones
  *
  * Returns:
- * [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)
+ * [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
  */
 export interface ProjectsCommand {
     get?:    ProjectGetRequest;
@@ -272,30 +271,30 @@ export interface ProjectPutRequest {
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Retrieve a secret by the provided identifier
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Creates a new secret in the provided organization using the given data
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Lists all secret identifiers of the given organization, to then retrieve each
  * secret, use `CreateSecret`
  *
  * Returns:
- * [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)
+ * [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Updates an existing secret with the provided ID using the given data
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Deletes all the secrets whose IDs match the provided ones
  *
  * Returns:
- * [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)
+ * [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)
  */
 export interface SecretsCommand {
     get?:    SecretGetRequest;

--- a/languages/csharp/schemas.cs
+++ b/languages/csharp/schemas.cs
@@ -74,24 +74,23 @@ namespace Bit.Sdk
     ///
     /// This command is not capable of handling authentication requiring 2fa or captcha.
     ///
-    /// Returns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)
+    /// Returns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)
     ///
     /// Login with API Key
     ///
     /// This command is for initiating an authentication handshake with Bitwarden.
     ///
-    /// Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    /// Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     ///
     /// Login with Secrets Manager Access Token
     ///
     /// This command is for initiating an authentication handshake with Bitwarden.
     ///
-    /// Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    /// Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     ///
     /// > Requires Authentication Get the API key of the currently authenticated user
     ///
-    /// Returns:
-    /// [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)
+    /// Returns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)
     ///
     /// Get the user's passphrase
     ///
@@ -100,7 +99,7 @@ namespace Bit.Sdk
     /// > Requires Authentication Retrieve all user data, ciphers and organizations the user is a
     /// part of
     ///
-    /// Returns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)
+    /// Returns: [SyncResponse](bitwarden::platform::SyncResponse)
     /// </summary>
     public partial class Command
     {
@@ -220,28 +219,28 @@ namespace Bit.Sdk
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Retrieve a project by the provided identifier
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Creates a new project in the provided organization using the given data
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Lists all projects of the given organization
     ///
-    /// Returns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)
+    /// Returns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Updates an existing project with the provided ID using the given data
     ///
-    /// Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    /// Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Deletes all the projects whose IDs match the provided ones
     ///
     /// Returns:
-    /// [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)
+    /// [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
     /// </summary>
     public partial class ProjectsCommand
     {
@@ -322,30 +321,30 @@ namespace Bit.Sdk
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Retrieve a secret by the provided identifier
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Creates a new secret in the provided organization using the given data
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Lists all secret identifiers of the given organization, to then retrieve each
     /// secret, use `CreateSecret`
     ///
     /// Returns:
-    /// [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)
+    /// [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Updates an existing secret with the provided ID using the given data
     ///
-    /// Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    /// Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     ///
     /// > Requires Authentication > Requires using an Access Token for login or calling Sync at
     /// least once Deletes all the secrets whose IDs match the provided ones
     ///
     /// Returns:
-    /// [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)
+    /// [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)
     /// </summary>
     public partial class SecretsCommand
     {

--- a/languages/js_webassembly/bitwarden_client/schemas.ts
+++ b/languages/js_webassembly/bitwarden_client/schemas.ts
@@ -86,24 +86,23 @@ export enum DeviceType {
  *
  * This command is not capable of handling authentication requiring 2fa or captcha.
  *
- * Returns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)
+ * Returns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)
  *
  * Login with API Key
  *
  * This command is for initiating an authentication handshake with Bitwarden.
  *
- * Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+ * Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
  *
  * Login with Secrets Manager Access Token
  *
  * This command is for initiating an authentication handshake with Bitwarden.
  *
- * Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+ * Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
  *
  * > Requires Authentication Get the API key of the currently authenticated user
  *
- * Returns:
- * [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)
+ * Returns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)
  *
  * Get the user's passphrase
  *
@@ -112,7 +111,7 @@ export enum DeviceType {
  * > Requires Authentication Retrieve all user data, ciphers and organizations the user is a
  * part of
  *
- * Returns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)
+ * Returns: [SyncResponse](bitwarden::platform::SyncResponse)
  */
 export interface Command {
     passwordLogin?:    PasswordLoginRequest;
@@ -196,28 +195,28 @@ export interface PasswordLoginRequest {
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Retrieve a project by the provided identifier
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Creates a new project in the provided organization using the given data
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Lists all projects of the given organization
  *
- * Returns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)
+ * Returns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Updates an existing project with the provided ID using the given data
  *
- * Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+ * Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Deletes all the projects whose IDs match the provided ones
  *
  * Returns:
- * [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)
+ * [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
  */
 export interface ProjectsCommand {
     get?:    ProjectGetRequest;
@@ -272,30 +271,30 @@ export interface ProjectPutRequest {
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Retrieve a secret by the provided identifier
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Creates a new secret in the provided organization using the given data
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Lists all secret identifiers of the given organization, to then retrieve each
  * secret, use `CreateSecret`
  *
  * Returns:
- * [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)
+ * [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Updates an existing secret with the provided ID using the given data
  *
- * Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+ * Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
  *
  * > Requires Authentication > Requires using an Access Token for login or calling Sync at
  * least once Deletes all the secrets whose IDs match the provided ones
  *
  * Returns:
- * [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)
+ * [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)
  */
 export interface SecretsCommand {
     get?:    SecretGetRequest;

--- a/languages/python/BitwardenClient/schemas.py
+++ b/languages/python/BitwardenClient/schemas.py
@@ -334,28 +334,28 @@ class ProjectsCommand:
     """> Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Retrieve a project by the provided identifier
     
-    Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Creates a new project in the provided organization using the given data
     
-    Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Lists all projects of the given organization
     
-    Returns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)
+    Returns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Updates an existing project with the provided ID using the given data
     
-    Returns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)
+    Returns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Deletes all the projects whose IDs match the provided ones
     
     Returns:
-    [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)
+    [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
     """
     get: Optional[ProjectGetRequest] = None
     create: Optional[ProjectCreateRequest] = None
@@ -505,30 +505,30 @@ class SecretsCommand:
     """> Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Retrieve a secret by the provided identifier
     
-    Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Creates a new secret in the provided organization using the given data
     
-    Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Lists all secret identifiers of the given organization, to then retrieve each
     secret, use `CreateSecret`
     
     Returns:
-    [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)
+    [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Updates an existing secret with the provided ID using the given data
     
-    Returns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)
+    Returns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)
     
     > Requires Authentication > Requires using an Access Token for login or calling Sync at
     least once Deletes all the secrets whose IDs match the provided ones
     
     Returns:
-    [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)
+    [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)
     """
     get: Optional[SecretGetRequest] = None
     create: Optional[SecretCreateRequest] = None
@@ -589,24 +589,23 @@ class Command:
     
     This command is not capable of handling authentication requiring 2fa or captcha.
     
-    Returns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)
+    Returns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)
     
     Login with API Key
     
     This command is for initiating an authentication handshake with Bitwarden.
     
-    Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     
     Login with Secrets Manager Access Token
     
     This command is for initiating an authentication handshake with Bitwarden.
     
-    Returns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)
+    Returns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)
     
     > Requires Authentication Get the API key of the currently authenticated user
     
-    Returns:
-    [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)
+    Returns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)
     
     Get the user's passphrase
     
@@ -615,7 +614,7 @@ class Command:
     > Requires Authentication Retrieve all user data, ciphers and organizations the user is a
     part of
     
-    Returns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)
+    Returns: [SyncResponse](bitwarden::platform::SyncResponse)
     """
     password_login: Optional[PasswordLoginRequest] = None
     api_key_login: Optional[APIKeyLoginRequest] = None

--- a/support/schemas/bitwarden_json/Command.json
+++ b/support/schemas/bitwarden_json/Command.json
@@ -3,7 +3,7 @@
   "title": "Command",
   "oneOf": [
     {
-      "description": "Login with username and password\n\nThis command is for initiating an authentication handshake with Bitwarden. Authorization may fail due to requiring 2fa or captcha challenge completion despite accurate credentials.\n\nThis command is not capable of handling authentication requiring 2fa or captcha.\n\nReturns: [PasswordLoginResponse](crate::sdk::auth::response::PasswordLoginResponse)",
+      "description": "Login with username and password\n\nThis command is for initiating an authentication handshake with Bitwarden. Authorization may fail due to requiring 2fa or captcha challenge completion despite accurate credentials.\n\nThis command is not capable of handling authentication requiring 2fa or captcha.\n\nReturns: [PasswordLoginResponse](bitwarden::auth::response::PasswordLoginResponse)",
       "type": "object",
       "required": [
         "passwordLogin"
@@ -16,7 +16,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Login with API Key\n\nThis command is for initiating an authentication handshake with Bitwarden.\n\nReturns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)",
+      "description": "Login with API Key\n\nThis command is for initiating an authentication handshake with Bitwarden.\n\nReturns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)",
       "type": "object",
       "required": [
         "apiKeyLogin"
@@ -29,7 +29,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Login with Secrets Manager Access Token\n\nThis command is for initiating an authentication handshake with Bitwarden.\n\nReturns: [ApiKeyLoginResponse](crate::sdk::auth::response::ApiKeyLoginResponse)",
+      "description": "Login with Secrets Manager Access Token\n\nThis command is for initiating an authentication handshake with Bitwarden.\n\nReturns: [ApiKeyLoginResponse](bitwarden::auth::response::ApiKeyLoginResponse)",
       "type": "object",
       "required": [
         "accessTokenLogin"
@@ -42,7 +42,7 @@
       "additionalProperties": false
     },
     {
-      "description": "> Requires Authentication Get the API key of the currently authenticated user\n\nReturns: [UserApiKeyResponse](crate::sdk::response::user_api_key_response::UserApiKeyResponse)",
+      "description": "> Requires Authentication Get the API key of the currently authenticated user\n\nReturns: [UserApiKeyResponse](bitwarden::platform::UserApiKeyResponse)",
       "type": "object",
       "required": [
         "getUserApiKey"
@@ -68,7 +68,7 @@
       "additionalProperties": false
     },
     {
-      "description": "> Requires Authentication Retrieve all user data, ciphers and organizations the user is a part of\n\nReturns: [SyncResponse](crate::sdk::response::sync_response::SyncResponse)",
+      "description": "> Requires Authentication Retrieve all user data, ciphers and organizations the user is a part of\n\nReturns: [SyncResponse](bitwarden::platform::SyncResponse)",
       "type": "object",
       "required": [
         "sync"
@@ -240,7 +240,7 @@
     "ProjectsCommand": {
       "oneOf": [
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Retrieve a project by the provided identifier\n\nReturns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Retrieve a project by the provided identifier\n\nReturns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)",
           "type": "object",
           "required": [
             "get"
@@ -253,7 +253,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Creates a new project in the provided organization using the given data\n\nReturns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Creates a new project in the provided organization using the given data\n\nReturns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)",
           "type": "object",
           "required": [
             "create"
@@ -266,7 +266,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Lists all projects of the given organization\n\nReturns: [ProjectsResponse](crate::sdk::response::projects_response::ProjectsResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Lists all projects of the given organization\n\nReturns: [ProjectsResponse](bitwarden::secrets_manager::projects::ProjectsResponse)",
           "type": "object",
           "required": [
             "list"
@@ -279,7 +279,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Updates an existing project with the provided ID using the given data\n\nReturns: [ProjectResponse](crate::sdk::response::projects_response::ProjectResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Updates an existing project with the provided ID using the given data\n\nReturns: [ProjectResponse](bitwarden::secrets_manager::projects::ProjectResponse)",
           "type": "object",
           "required": [
             "update"
@@ -292,7 +292,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Deletes all the projects whose IDs match the provided ones\n\nReturns: [ProjectsDeleteResponse](crate::sdk::response::projects_response::ProjectsDeleteResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Deletes all the projects whose IDs match the provided ones\n\nReturns: [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)",
           "type": "object",
           "required": [
             "delete"
@@ -457,7 +457,7 @@
     "SecretsCommand": {
       "oneOf": [
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Retrieve a secret by the provided identifier\n\nReturns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Retrieve a secret by the provided identifier\n\nReturns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)",
           "type": "object",
           "required": [
             "get"
@@ -470,7 +470,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Creates a new secret in the provided organization using the given data\n\nReturns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Creates a new secret in the provided organization using the given data\n\nReturns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)",
           "type": "object",
           "required": [
             "create"
@@ -483,7 +483,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Lists all secret identifiers of the given organization, to then retrieve each secret, use `CreateSecret`\n\nReturns: [SecretIdentifiersResponse](crate::sdk::response::secrets_response::SecretIdentifiersResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Lists all secret identifiers of the given organization, to then retrieve each secret, use `CreateSecret`\n\nReturns: [SecretIdentifiersResponse](bitwarden::secrets_manager::secrets::SecretIdentifiersResponse)",
           "type": "object",
           "required": [
             "list"
@@ -496,7 +496,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Updates an existing secret with the provided ID using the given data\n\nReturns: [SecretResponse](crate::sdk::response::secrets_response::SecretResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Updates an existing secret with the provided ID using the given data\n\nReturns: [SecretResponse](bitwarden::secrets_manager::secrets::SecretResponse)",
           "type": "object",
           "required": [
             "update"
@@ -509,7 +509,7 @@
           "additionalProperties": false
         },
         {
-          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Deletes all the secrets whose IDs match the provided ones\n\nReturns: [SecretsDeleteResponse](crate::sdk::response::secrets_response::SecretsDeleteResponse)",
+          "description": "> Requires Authentication > Requires using an Access Token for login or calling Sync at least once Deletes all the secrets whose IDs match the provided ones\n\nReturns: [SecretsDeleteResponse](bitwarden::secrets_manager::secrets::SecretsDeleteResponse)",
           "type": "object",
           "required": [
             "delete"


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The recent folder reorganisation didn't change the links to the return types of the Command schema, this PR fixes this.

We can validate this in CI if we wanted by setting `#[deny(rustdoc::broken_intra_doc_links)]` and running `cargo doc --workspace --features internal`.
