### PR TITLE
Remove unnecessary string copy

### DIFF
--- a/crates/bitwarden-json/src/response.rs
+++ b/crates/bitwarden-json/src/response.rs
@@ -30,10 +30,10 @@ impl<T: Serialize + JsonSchema> Response<T> {
         }
     }
 
-    pub fn error(message: &str) -> Self {
+    pub fn error(message: String) -> Self {
         Self {
             success: false,
-            error_message: Some(message.into()),
+            error_message: Some(message),
             data: None,
         }
     }
@@ -47,7 +47,7 @@ impl<T: Serialize + JsonSchema, E: Error> ResponseIntoString for Result<T, E> {
     fn into_string(self) -> String {
         match serde_json::to_string(&Response::new(self)) {
             Ok(ser) => ser,
-            Err(e) => serde_json::to_string(&Response::<T>::error(&format!(
+            Err(e) => serde_json::to_string(&Response::<T>::error(format!(
                 "Failed to serialize Response: {}",
                 e
             )))


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The error message `String` in `bitwarden-json` was passed as reference and then converted again into a `String`, by passing it directly we avoid a copy.
