### PR TITLE
Argon2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +292,7 @@ name = "bitwarden"
 version = "0.2.1"
 dependencies = [
  "aes",
+ "argon2",
  "assert_matches",
  "base64 0.21.2",
  "bitwarden-api-api",
@@ -393,6 +404,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -35,6 +35,7 @@ rsa = "0.9.2"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 pbkdf2 = { version = "0.12.1", default-features = false }
+argon2 = { version = "0.5.0", features = ["alloc"], default-features = false }
 rand = "0.8.5"
 num-bigint = "0.4"
 num-traits = "0.2.15"

--- a/crates/bitwarden/src/auth/api/response/identity_success_response.rs
+++ b/crates/bitwarden/src/auth/api/response/identity_success_response.rs
@@ -22,7 +22,7 @@ pub struct IdentityTokenSuccessResponse {
     #[serde(
         rename = "kdfIterations",
         alias = "KdfIterations",
-        default = "crate::util::default_kdf_iterations"
+        default = "crate::util::default_pbkdf2_iterations"
     )]
     kdf_iterations: NonZeroU32,
 
@@ -54,7 +54,7 @@ mod test {
                 key: Default::default(),
                 two_factor_token: Default::default(),
                 kdf: KdfType::Variant0,
-                kdf_iterations: crate::util::default_kdf_iterations(),
+                kdf_iterations: crate::util::default_pbkdf2_iterations(),
                 reset_master_password: Default::default(),
                 force_password_reset: Default::default(),
                 api_use_key_connector: Default::default(),

--- a/crates/bitwarden/src/auth/commands/login.rs
+++ b/crates/bitwarden/src/auth/commands/login.rs
@@ -162,7 +162,7 @@ async fn determine_password_hash(
 ) -> Result<String> {
     let pre_login = request_prelogin(client, email.to_owned()).await?;
     let auth_settings = AuthSettings::new(pre_login, email.to_owned());
-    let password_hash = auth_settings.make_user_password_hash(password);
+    let password_hash = auth_settings.make_user_password_hash(password)?;
     client.set_auth_settings(auth_settings);
 
     Ok(password_hash)

--- a/crates/bitwarden/src/client/encryption_settings.rs
+++ b/crates/bitwarden/src/client/encryption_settings.rs
@@ -104,9 +104,8 @@ impl EncryptionSettings {
         let (key, mac_key) = crate::crypto::stretch_key_password(
             password.as_bytes(),
             auth.email.as_bytes(),
-            auth.kdf_iterations,
-        )
-        .map_err(|_| CryptoError::KeyStretch)?;
+            &auth.kdf,
+        )?;
 
         // Decrypt the user key with the stretched key
         let user_key = {

--- a/crates/bitwarden/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden/src/platform/get_user_api_key.rs
@@ -21,7 +21,7 @@ pub(crate) async fn get_user_api_key(
     debug!("{:?}", input);
 
     let auth_settings = get_auth_settings(client)?;
-    let request = get_secret_verification_request(auth_settings, input);
+    let request = get_secret_verification_request(auth_settings, input)?;
 
     let config = client.get_api_configurations().await;
 
@@ -44,17 +44,18 @@ fn get_auth_settings(client: &Client) -> Result<&AuthSettings> {
 fn get_secret_verification_request(
     auth_settings: &AuthSettings,
     input: &SecretVerificationRequest,
-) -> SecretVerificationRequestModel {
+) -> Result<SecretVerificationRequestModel> {
     let master_password_hash = input
         .master_password
         .as_ref()
-        .map(|p| auth_settings.make_user_password_hash(p));
-    SecretVerificationRequestModel {
+        .map(|p| auth_settings.make_user_password_hash(p))
+        .transpose()?;
+    Ok(SecretVerificationRequestModel {
         master_password_hash,
         otp: input.otp.as_ref().cloned(),
         secret: None,
         auth_request_access_code: None,
-    }
+    })
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/crates/bitwarden/src/util.rs
+++ b/crates/bitwarden/src/util.rs
@@ -8,8 +8,17 @@ use base64::{
 
 use crate::error::Result;
 
-pub fn default_kdf_iterations() -> NonZeroU32 {
+pub fn default_pbkdf2_iterations() -> NonZeroU32 {
     NonZeroU32::new(600_000).unwrap()
+}
+pub fn default_argon2_iterations() -> NonZeroU32 {
+    NonZeroU32::new(3).unwrap()
+}
+pub fn default_argon2_memory() -> NonZeroU32 {
+    NonZeroU32::new(64).unwrap()
+}
+pub fn default_argon2_parallelism() -> NonZeroU32 {
+    NonZeroU32::new(4).unwrap()
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Support for Argon2id key derivation. 

## Code changes
- **auth_settings.rs:** Replaced the current KdfType and kdf_iterations for a nicer enum, extracted the KDF functions and moved them to `crypto.rs`, to remove duplication.
- **crypto.rs:**: Create new `hash_kdf` function with support for argon2, used both in this file and `auth_settings.rs`
- **utils.rs:**: Added default values
