### PR TITLE
Renovate: Disable non-breaking updates for rust

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,19 +16,16 @@
     {
       "groupName": "npm minor",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "matchManagers": ["cargo"],
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["patch"],
       "groupName": "rust non-breaking",
       "enabled": false
     },
     {
       "matchManagers": ["cargo"],
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": ">=1.0.0",
       "groupName": "rust non-breaking",
@@ -43,7 +40,6 @@
     {
       "groupName": "nuget minor",
       "matchManagers": ["nuget"],
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:monthly", ":maintainLockFilesWeekly"],
+  "extends": [
+    "config:base",
+    "schedule:monthly",
+    ":dependencyDashboard",
+    ":maintainLockFilesWeekly"
+  ],
   "separateMajorMinor": true,
+  "enabledManagers": ["cargo", "github-actions", "npm", "nuget"],
   "packageRules": [
     {
+      "groupName": "npm minor",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "node non-major"
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "matchManagers": ["cargo"],
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "rust non-major"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor"],
+      "matchCurrentVersion": ">=1.0.0",
       "groupName": "rust non-major"
     },
     {
@@ -22,15 +35,15 @@
       "groupName": "pyo3 non-major"
     },
     {
+      "groupName": "nuget minor",
       "matchManagers": ["nuget"],
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "dotnet non-major"
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "groupName": "gh minor",
       "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["*"],
-      "groupName": "gh actions all"
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,12 @@
   "extends": [
     "config:base",
     "schedule:weekends",
+    ":combinePatchMinorReleases",
     ":dependencyDashboard",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    ":prConcurrentLimit10",
+    ":rebaseStalePrs",
+    ":separateMajorReleases"
   ],
   "separateMajorMinor": true,
   "enabledManagers": ["cargo", "github-actions", "npm", "nuget"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,14 +19,16 @@
       "matchManagers": ["cargo"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["patch"],
-      "groupName": "rust non-major"
+      "groupName": "rust non-breaking",
+      "enabled": false
     },
     {
       "matchManagers": ["cargo"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": ">=1.0.0",
-      "groupName": "rust non-major"
+      "groupName": "rust non-breaking",
+      "enabled": false
     },
     {
       "matchManagers": ["cargo"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "schedule:monthly",
+    "schedule:weekends",
     ":dependencyDashboard",
     ":maintainLockFilesWeekly"
   ],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Configure renovate to not propose non-breaking changes of dependencies. To avoid always updating to the latest versions since Bitwarden will act as a library. (We will get the latest versions through the lockfile refresh)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
