### PR TITLE
Improve errors in bitwarden_json

### DIFF
--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -20,5 +20,6 @@ internal = ["bitwarden/internal"] # Internal testing methods
 schemars = ">=0.8.12, <0.9"
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
+log = ">=0.4.18, <0.5"
 
 bitwarden = { path = "../bitwarden" }

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -2,7 +2,7 @@ use bitwarden::client::client_settings::ClientSettings;
 
 use crate::{
     command::{Command, ProjectsCommand, SecretsCommand},
-    response::ResponseIntoString,
+    response::{Response, ResponseIntoString},
 };
 
 pub struct Client(bitwarden::Client);
@@ -17,7 +17,9 @@ impl Client {
         const SUBCOMMANDS_TO_CLEAN: &[&str] = &["Secrets"];
         let mut cmd_value: serde_json::Value = match serde_json::from_str(input_str) {
             Ok(cmd) => cmd,
-            Err(e) => return format!("{:#?}", e),
+            Err(e) => {
+                return Response::error(format!("Invalid command string: {}", e)).into_string()
+            }
         };
 
         if let Some(cmd_value_map) = cmd_value.as_object_mut() {
@@ -35,7 +37,9 @@ impl Client {
 
         let cmd: Command = match serde_json::from_value(cmd_value) {
             Ok(cmd) => cmd,
-            Err(e) => return format!("{:#?}", e),
+            Err(e) => {
+                return Response::error(format!("Invalid command value: {}", e)).into_string()
+            }
         };
 
         match cmd {
@@ -71,8 +75,11 @@ impl Client {
 
     fn parse_settings(settings_input: Option<String>) -> Option<ClientSettings> {
         if let Some(input) = settings_input.as_ref() {
-            if let Ok(settings) = serde_json::from_str(input) {
-                return Some(settings);
+            match serde_json::from_str(input) {
+                Ok(settings) => return Some(settings),
+                Err(e) => {
+                    eprintln!("Failed to parse settings: {}", e);
+                }
             }
         }
         None

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -78,7 +78,7 @@ impl Client {
             match serde_json::from_str(input) {
                 Ok(settings) => return Some(settings),
                 Err(e) => {
-                    eprintln!("Failed to parse settings: {}", e);
+                    log::error!("Failed to parse settings: {}", e);
                 }
             }
         }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
`bitwarden_json` handles the errors from `Client` calls correctly and returns a JSON like `{success: false, errorMessage: "whatever"}`.

This is not the case if the command sent to the `run_command` is malformed, in this case it would just return the error as a String. I've changed this so the error returned is in the same JSON format as the `Client` calls.

`parse_settings` would also silently start using the defaults if the provided settings where malformed, I've printed an error message in that case, but it might be best to change the return type of `Client::new`, though this means updating all the language bindings as well.
