### PR TITLE
[PM-2076] Properly handle error responses in send_identity_connect_request

### DIFF
--- a/crates/bitwarden/src/auth/api/request/mod.rs
+++ b/crates/bitwarden/src/auth/api/request/mod.rs
@@ -43,13 +43,13 @@ async fn send_identity_connect_request(
         request = request.header("Auth-Email", BASE64_ENGINE.encode(email.as_bytes()));
     }
 
-    let raw_response = request
+    let response = request
         .body(serde_qs::to_string(&body).unwrap())
         .send()
-        .await?
-        .error_for_status()?
-        .text()
         .await?;
 
-    parse_identity_response(&raw_response)
+    let status = response.status();
+    let text = response.text().await?;
+
+    parse_identity_response(status, &text)
 }

--- a/crates/bitwarden/src/auth/api/request/mod.rs
+++ b/crates/bitwarden/src/auth/api/request/mod.rs
@@ -47,6 +47,7 @@ async fn send_identity_connect_request(
         .body(serde_qs::to_string(&body).unwrap())
         .send()
         .await?
+        .error_for_status()?
         .text()
         .await?;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Ensure any server error is handled properly in the SDK instead of silently ignored by converting it to an error using `reqwest` `error_for_status` fn.

Resolves #87 

A network error now resolves into 

```
Error:
   0: HTTP status server error (504 Gateway Timeout) for url (https://localhost:8080/identity/connect/token)
```

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
