### PR TITLE
[PM-3125] Initial setup on smaller mobile-only sdk

### DIFF
--- a/crates/bitwarden-c/Cargo.toml
+++ b/crates/bitwarden-c/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 tokio = { version = ">=1.28.2, <2.0", features = ["rt-multi-thread", "macros"] }
 
-bitwarden-json = { path = "../bitwarden-json" }
+bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 
 [dependencies]
 env_logger = ">=0.10.0, <0.11"

--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.57"
 
 [features]
 internal = ["bitwarden/internal"] # Internal testing methods
+secrets = ["bitwarden/secrets"] # Secrets manager API
 
 [dependencies]
 schemars = ">=0.8.12, <0.9"

--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -15,7 +15,8 @@ rust-version = "1.57"
 
 [features]
 internal = ["bitwarden/internal"] # Internal testing methods
-secrets = ["bitwarden/secrets"] # Secrets manager API
+secrets = ["bitwarden/secrets"]   # Secrets manager API
+mobile = ["bitwarden/mobile"]     # Mobile-specific features
 
 [dependencies]
 schemars = ">=0.8.12, <0.9"

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -8,8 +8,10 @@ use crate::{
 #[cfg(feature = "secrets")]
 use crate::command::{ProjectsCommand, SecretsCommand};
 
+#[cfg(all(feature = "internal", feature = "mobile"))]
+use crate::command::MobileCryptoCommand;
 #[cfg(feature = "mobile")]
-use crate::command::{MobileCommand, MobileCryptoCommand, MobileKdfCommand};
+use crate::command::{MobileCommand, MobileKdfCommand};
 
 pub struct Client(bitwarden::Client);
 

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -88,6 +88,7 @@ impl Client {
                     }
                 },
                 MobileCommand::Crypto(cmd) => match cmd {
+                    #[cfg(feature = "internal")]
                     MobileCryptoCommand::InitCrypto(req) => {
                         self.0.crypto().initialize_crypto(req).await.into_string()
                     }

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -8,6 +8,9 @@ use crate::{
 #[cfg(feature = "secrets")]
 use crate::command::{ProjectsCommand, SecretsCommand};
 
+#[cfg(feature = "mobile")]
+use crate::command::{MobileCommand, MobileCryptoCommand, MobileKdfCommand};
+
 pub struct Client(bitwarden::Client);
 
 impl Client {
@@ -74,6 +77,32 @@ impl Client {
                 ProjectsCommand::List(req) => self.0.projects().list(&req).await.into_string(),
                 ProjectsCommand::Update(req) => self.0.projects().update(&req).await.into_string(),
                 ProjectsCommand::Delete(req) => self.0.projects().delete(req).await.into_string(),
+            },
+
+            #[cfg(feature = "mobile")]
+            Command::Mobile(cmd) => match cmd {
+                MobileCommand::Kdf(cmd) => match cmd {
+                    MobileKdfCommand::SetKdfParams(req) => {
+                        self.0.kdf().set_kdf_params(req).await.into_string()
+                    }
+                    MobileKdfCommand::GetUserPasswordHash(req) => {
+                        self.0.kdf().get_user_password_hash(req).await.into_string()
+                    }
+                },
+                MobileCommand::Crypto(cmd) => match cmd {
+                    MobileCryptoCommand::InitUserCrypto(req) => self
+                        .0
+                        .crypto()
+                        .initialize_user_crypto(req)
+                        .await
+                        .into_string(),
+                    MobileCryptoCommand::InitOrgCrypto(req) => self
+                        .0
+                        .crypto()
+                        .initialize_org_crypto(req)
+                        .await
+                        .into_string(),
+                },
             },
         }
     }

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -83,9 +83,6 @@ impl Client {
             #[cfg(feature = "mobile")]
             Command::Mobile(cmd) => match cmd {
                 MobileCommand::Kdf(cmd) => match cmd {
-                    MobileKdfCommand::SetKdfParams(req) => {
-                        self.0.kdf().set_kdf_params(req).await.into_string()
-                    }
                     MobileKdfCommand::HashPassword(req) => {
                         self.0.kdf().hash_password(req).await.into_string()
                     }

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -51,6 +51,7 @@ impl Client {
         match cmd {
             #[cfg(feature = "internal")]
             Command::PasswordLogin(req) => self.0.password_login(&req).await.into_string(),
+            #[cfg(feature = "secrets")]
             Command::AccessTokenLogin(req) => self.0.access_token_login(&req).await.into_string(),
             #[cfg(feature = "internal")]
             Command::GetUserApiKey(req) => self.0.get_user_api_key(&req).await.into_string(),
@@ -85,23 +86,14 @@ impl Client {
                     MobileKdfCommand::SetKdfParams(req) => {
                         self.0.kdf().set_kdf_params(req).await.into_string()
                     }
-                    MobileKdfCommand::GetUserPasswordHash(req) => {
-                        self.0.kdf().get_user_password_hash(req).await.into_string()
+                    MobileKdfCommand::HashPassword(req) => {
+                        self.0.kdf().hash_password(req).await.into_string()
                     }
                 },
                 MobileCommand::Crypto(cmd) => match cmd {
-                    MobileCryptoCommand::InitUserCrypto(req) => self
-                        .0
-                        .crypto()
-                        .initialize_user_crypto(req)
-                        .await
-                        .into_string(),
-                    MobileCryptoCommand::InitOrgCrypto(req) => self
-                        .0
-                        .crypto()
-                        .initialize_org_crypto(req)
-                        .await
-                        .into_string(),
+                    MobileCryptoCommand::InitCrypto(req) => {
+                        self.0.crypto().initialize_crypto(req).await.into_string()
+                    }
                 },
             },
         }

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -1,9 +1,12 @@
 use bitwarden::client::client_settings::ClientSettings;
 
 use crate::{
-    command::{Command, ProjectsCommand, SecretsCommand},
+    command::Command,
     response::{Response, ResponseIntoString},
 };
+
+#[cfg(feature = "secrets")]
+use crate::command::{ProjectsCommand, SecretsCommand};
 
 pub struct Client(bitwarden::Client);
 
@@ -55,6 +58,7 @@ impl Client {
             #[cfg(feature = "internal")]
             Command::Fingerprint(req) => self.0.fingerprint(&req).into_string(),
 
+            #[cfg(feature = "secrets")]
             Command::Secrets(cmd) => match cmd {
                 SecretsCommand::Get(req) => self.0.secrets().get(&req).await.into_string(),
                 SecretsCommand::Create(req) => self.0.secrets().create(&req).await.into_string(),
@@ -63,6 +67,7 @@ impl Client {
                 SecretsCommand::Delete(req) => self.0.secrets().delete(req).await.into_string(),
             },
 
+            #[cfg(feature = "secrets")]
             Command::Projects(cmd) => match cmd {
                 ProjectsCommand::Get(req) => self.0.projects().get(&req).await.into_string(),
                 ProjectsCommand::Create(req) => self.0.projects().create(&req).await.into_string(),

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -1,14 +1,15 @@
-use bitwarden::auth::request::AccessTokenLoginRequest;
-
 #[cfg(feature = "secrets")]
-use bitwarden::secrets_manager::{
-    projects::{
-        ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsDeleteRequest,
-        ProjectsListRequest,
-    },
-    secrets::{
-        SecretCreateRequest, SecretGetRequest, SecretIdentifiersRequest, SecretPutRequest,
-        SecretsDeleteRequest,
+use bitwarden::{
+    auth::request::AccessTokenLoginRequest,
+    secrets_manager::{
+        projects::{
+            ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsDeleteRequest,
+            ProjectsListRequest,
+        },
+        secrets::{
+            SecretCreateRequest, SecretGetRequest, SecretIdentifiersRequest, SecretPutRequest,
+            SecretsDeleteRequest,
+        },
     },
 };
 
@@ -20,7 +21,7 @@ use bitwarden::{
 
 #[cfg(feature = "mobile")]
 use bitwarden::mobile::{
-    crypto::{InitOrgCryptoRequest, InitUserCryptoRequest},
+    crypto::InitCryptoRequest,
     kdf::{KdfParamRequest, PasswordHashRequest},
 };
 
@@ -52,6 +53,7 @@ pub enum Command {
     ///
     ApiKeyLogin(ApiKeyLoginRequest),
 
+    #[cfg(feature = "secrets")]
     /// Login with Secrets Manager Access Token
     ///
     /// This command is for initiating an authentication handshake with Bitwarden.
@@ -202,7 +204,7 @@ pub enum MobileKdfCommand {
     ///
     /// Returns: String
     ///
-    GetUserPasswordHash(PasswordHashRequest),
+    HashPassword(PasswordHashRequest),
 }
 
 #[cfg(feature = "mobile")]
@@ -210,11 +212,7 @@ pub enum MobileKdfCommand {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum MobileCryptoCommand {
     /// > Requires having previously set the KDF parameters
-    /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users items
+    /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users vault
     ///
-    InitUserCrypto(InitUserCryptoRequest),
-    /// > Requires having previously initialized the user crypto
-    /// Decrypts the users organization keys, allowing for the encryption/decryption of the items in the users organizations
-    ///
-    InitOrgCrypto(InitOrgCryptoRequest),
+    InitCrypto(InitCryptoRequest),
 }

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -20,7 +20,10 @@ use bitwarden::{
 };
 
 #[cfg(feature = "mobile")]
-use bitwarden::mobile::{crypto::InitCryptoRequest, kdf::PasswordHashRequest};
+use bitwarden::mobile::kdf::PasswordHashRequest;
+
+#[cfg(all(feature = "mobile", feature = "internal"))]
+use bitwarden::mobile::crypto::InitCryptoRequest;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -20,10 +20,7 @@ use bitwarden::{
 };
 
 #[cfg(feature = "mobile")]
-use bitwarden::mobile::{
-    crypto::InitCryptoRequest,
-    kdf::{KdfParamRequest, PasswordHashRequest},
-};
+use bitwarden::mobile::{crypto::InitCryptoRequest, kdf::PasswordHashRequest};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -196,11 +193,7 @@ pub enum MobileCommand {
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum MobileKdfCommand {
-    /// Sets the KDF parameters that are received in the prelogin request
-    ///
-    SetKdfParams(KdfParamRequest),
-    /// > Requires having previously set the KDF parameters
-    /// Calculates the user master password hash based on the provided password
+    /// Calculates the user master password hash based on the provided password and KDF parametes
     ///
     /// Returns: String
     ///
@@ -211,7 +204,6 @@ pub enum MobileKdfCommand {
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum MobileCryptoCommand {
-    /// > Requires having previously set the KDF parameters
     /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users vault
     ///
     InitCrypto(InitCryptoRequest),

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -1,16 +1,17 @@
-use bitwarden::{
-    auth::request::AccessTokenLoginRequest,
-    secrets_manager::{
-        projects::{
-            ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsDeleteRequest,
-            ProjectsListRequest,
-        },
-        secrets::{
-            SecretCreateRequest, SecretGetRequest, SecretIdentifiersRequest, SecretPutRequest,
-            SecretsDeleteRequest,
-        },
+use bitwarden::auth::request::AccessTokenLoginRequest;
+
+#[cfg(feature = "secrets")]
+use bitwarden::secrets_manager::{
+    projects::{
+        ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsDeleteRequest,
+        ProjectsListRequest,
+    },
+    secrets::{
+        SecretCreateRequest, SecretGetRequest, SecretIdentifiersRequest, SecretPutRequest,
+        SecretsDeleteRequest,
     },
 };
+
 #[cfg(feature = "internal")]
 use bitwarden::{
     auth::request::{ApiKeyLoginRequest, PasswordLoginRequest},
@@ -75,10 +76,13 @@ pub enum Command {
     ///
     Sync(SyncRequest),
 
+    #[cfg(feature = "secrets")]
     Secrets(SecretsCommand),
+    #[cfg(feature = "secrets")]
     Projects(ProjectsCommand),
 }
 
+#[cfg(feature = "secrets")]
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum SecretsCommand {
@@ -123,6 +127,7 @@ pub enum SecretsCommand {
     Delete(SecretsDeleteRequest),
 }
 
+#[cfg(feature = "secrets")]
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum ProjectsCommand {

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -17,6 +17,13 @@ use bitwarden::{
     auth::request::{ApiKeyLoginRequest, PasswordLoginRequest},
     platform::{FingerprintRequest, SecretVerificationRequest, SyncRequest},
 };
+
+#[cfg(feature = "mobile")]
+use bitwarden::mobile::{
+    crypto::{InitOrgCryptoRequest, InitUserCryptoRequest},
+    kdf::{KdfParamRequest, PasswordHashRequest},
+};
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -80,6 +87,9 @@ pub enum Command {
     Secrets(SecretsCommand),
     #[cfg(feature = "secrets")]
     Projects(ProjectsCommand),
+
+    #[cfg(feature = "mobile")]
+    Mobile(MobileCommand),
 }
 
 #[cfg(feature = "secrets")]
@@ -170,4 +180,41 @@ pub enum ProjectsCommand {
     /// Returns: [ProjectsDeleteResponse](bitwarden::secrets_manager::projects::ProjectsDeleteResponse)
     ///
     Delete(ProjectsDeleteRequest),
+}
+
+#[cfg(feature = "mobile")]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum MobileCommand {
+    Kdf(MobileKdfCommand),
+    Crypto(MobileCryptoCommand),
+}
+
+#[cfg(feature = "mobile")]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum MobileKdfCommand {
+    /// Sets the KDF parameters that are received in the prelogin request
+    ///
+    SetKdfParams(KdfParamRequest),
+    /// > Requires having previously set the KDF parameters
+    /// Calculates the user master password hash based on the provided password
+    ///
+    /// Returns: String
+    ///
+    GetUserPasswordHash(PasswordHashRequest),
+}
+
+#[cfg(feature = "mobile")]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum MobileCryptoCommand {
+    /// > Requires having previously set the KDF parameters
+    /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users items
+    ///
+    InitUserCrypto(InitUserCryptoRequest),
+    /// > Requires having previously initialized the user crypto
+    /// Decrypts the users organization keys, allowing for the encryption/decryption of the items in the users organizations
+    ///
+    InitOrgCrypto(InitOrgCryptoRequest),
 }

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -204,6 +204,7 @@ pub enum MobileKdfCommand {
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum MobileCryptoCommand {
+    #[cfg(feature = "internal")]
     /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users vault
     ///
     InitCrypto(InitCryptoRequest),

--- a/crates/bitwarden-napi/Cargo.toml
+++ b/crates/bitwarden-napi/Cargo.toml
@@ -21,7 +21,7 @@ napi-derive = "2"
 log = "0.4.18"
 env_logger="0.10.0"
 
-bitwarden-json = { path = "../bitwarden-json", version = "0.2.1" }
+bitwarden-json = { path = "../bitwarden-json", version = "0.2.1", features = ["secrets"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/crates/bitwarden-py/Cargo.toml
+++ b/crates/bitwarden-py/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18.3", features = ["extension-module"] }
 pyo3-log = "0.8.3"
 
-bitwarden-json = { path = "../bitwarden-json" }
+bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 
 [build-dependencies]
 pyo3-build-config = { version = "0.18.3" }

--- a/crates/bitwarden-wasm/Cargo.toml
+++ b/crates/bitwarden-wasm/Cargo.toml
@@ -17,7 +17,7 @@ console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.18"
 
-bitwarden-json = { path = "../bitwarden-json" }
+bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.36"

--- a/crates/bitwarden/CHANGELOG.md
+++ b/crates/bitwarden/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
--
+- The secrets manager SDK is now hidden behind a `secrets` feature flag. Make sure to enable
+  this flag in your `Cargo.toml` file. At the moment the flag is enabled by default for compatibility
+  reasons, but this is considered deprecated and the flag will be made opt-in eventually.
 
 ### Added
 

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -13,7 +13,11 @@ edition = "2021"
 rust-version = "1.57"
 
 [features]
+default = ["secrets"]
+
+secrets = []  # Secrets manager API
 internal = [] # Internal testing methods
+mobile = []   # Mobile-specific features
 
 [dependencies]
 base64 = ">=0.21.2, <0.22"

--- a/crates/bitwarden/README.md
+++ b/crates/bitwarden/README.md
@@ -7,7 +7,7 @@ be missing some functionality.
 
 ```toml
 [dependencies]
-bitwarden = "*"
+bitwarden = { "*", features = ["secrets"] }
 ```
 
 ## Minimum Supported Rust Version

--- a/crates/bitwarden/src/client/auth_settings.rs
+++ b/crates/bitwarden/src/client/auth_settings.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use base64::Engine;
+#[cfg(feature = "internal")]
 use bitwarden_api_identity::models::{KdfType, PreloginResponseModel};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -8,10 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     crypto::{PbkdfSha256Hmac, PBKDF_SHA256_HMAC_OUT_SIZE},
     error::Result,
-    util::{
-        default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,
-        default_pbkdf2_iterations, BASE64_ENGINE,
-    },
+    util::BASE64_ENGINE,
 };
 
 #[derive(Debug)]
@@ -34,7 +32,13 @@ pub enum Kdf {
 }
 
 impl AuthSettings {
+    #[cfg(feature = "internal")]
     pub fn new(response: PreloginResponseModel, email: String) -> Self {
+        use crate::util::{
+            default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,
+            default_pbkdf2_iterations,
+        };
+
         let kdf = match response.kdf.unwrap_or_default() {
             KdfType::Variant0 => Kdf::PBKDF2 {
                 iterations: response

--- a/crates/bitwarden/src/client/auth_settings.rs
+++ b/crates/bitwarden/src/client/auth_settings.rs
@@ -2,6 +2,8 @@ use std::num::NonZeroU32;
 
 use base64::Engine;
 use bitwarden_api_identity::models::{KdfType, PreloginResponseModel};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     crypto::{PbkdfSha256Hmac, PBKDF_SHA256_HMAC_OUT_SIZE},
@@ -18,7 +20,8 @@ pub(crate) struct AuthSettings {
     pub(crate) kdf: Kdf,
 }
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum Kdf {
     PBKDF2 {
         iterations: NonZeroU32,

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::{
     auth::{
         commands::{access_token_login, renew_token},
-        request::AccessTokenLoginRequest,
         response::ApiKeyLoginResponse,
     },
     client::{
@@ -15,6 +14,10 @@ use crate::{
     },
     error::Result,
 };
+
+#[cfg(feature = "secrets")]
+use crate::auth::request::AccessTokenLoginRequest;
+
 #[cfg(feature = "internal")]
 use {
     crate::{
@@ -145,6 +148,7 @@ impl Client {
         api_key_login(self, input).await
     }
 
+    #[cfg(feature = "secrets")]
     pub async fn access_token_login(
         &mut self,
         input: &AccessTokenLoginRequest,

--- a/crates/bitwarden/src/client/mod.rs
+++ b/crates/bitwarden/src/client/mod.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use client::*;
 pub(crate) mod access_token;
-#[cfg(feature = "internal")]
+#[cfg(any(feature = "internal", feature = "mobile"))]
 pub(crate) mod auth_settings;
 mod client;
 pub mod client_settings;

--- a/crates/bitwarden/src/crypto.rs
+++ b/crates/bitwarden/src/crypto.rs
@@ -16,12 +16,12 @@ use crate::{
 
 #[cfg(feature = "internal")]
 use {
-    crate::{client::auth_settings::Kdf, wordlist::EFF_LONG_WORD_LIST},
-    aes::cipher::typenum::U32,
-    num_bigint::BigUint,
+    crate::wordlist::EFF_LONG_WORD_LIST, aes::cipher::typenum::U32, num_bigint::BigUint,
     num_traits::cast::ToPrimitive,
-    sha2::{Digest, Sha256},
 };
+
+#[cfg(any(feature = "internal", feature = "mobile"))]
+use {crate::client::auth_settings::Kdf, sha2::Digest};
 
 #[allow(unused, non_camel_case_types)]
 pub enum CipherString {
@@ -238,7 +238,7 @@ pub(crate) type PbkdfSha256Hmac = hmac::Hmac<sha2::Sha256>;
 pub(crate) const PBKDF_SHA256_HMAC_OUT_SIZE: usize =
     <<PbkdfSha256Hmac as OutputSizeUser>::OutputSize as Unsigned>::USIZE;
 
-#[cfg(feature = "internal")]
+#[cfg(any(feature = "internal", feature = "mobile"))]
 pub(crate) fn hash_kdf(secret: &[u8], salt: &[u8], kdf: &Kdf) -> Result<[u8; 32]> {
     let hash = match kdf {
         Kdf::PBKDF2 { iterations } => pbkdf2::pbkdf2_array::<
@@ -324,7 +324,7 @@ pub(crate) fn stretch_key(secret: [u8; 16], name: &str, info: Option<&str>) -> S
 
 #[cfg(feature = "internal")]
 pub(crate) fn fingerprint(fingerprint_material: &str, public_key: &[u8]) -> Result<String> {
-    let mut h = Sha256::new();
+    let mut h = sha2::Sha256::new();
     h.update(public_key);
     h.finalize();
 

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -54,6 +54,7 @@ pub mod crypto;
 pub mod error;
 #[cfg(feature = "internal")]
 pub mod platform;
+#[cfg(feature = "secrets")]
 pub mod secrets_manager;
 mod util;
 pub mod wordlist;

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -52,6 +52,8 @@ pub mod auth;
 pub mod client;
 pub mod crypto;
 pub mod error;
+#[cfg(feature = "mobile")]
+pub mod mobile;
 #[cfg(feature = "internal")]
 pub mod platform;
 #[cfg(feature = "secrets")]

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```ini
 //! [dependencies]
-//! bitwarden = "*"
+//! bitwarden = { "*", features = ["secrets"] }
 //! ```
 //!
 //! # Basic setup

--- a/crates/bitwarden/src/mobile/client_crypto.rs
+++ b/crates/bitwarden/src/mobile/client_crypto.rs
@@ -1,5 +1,6 @@
 use crate::{error::Result, Client};
 
+#[cfg(feature = "internal")]
 use super::crypto::{initialize_crypto, InitCryptoRequest};
 
 pub struct ClientCrypto<'a> {
@@ -7,6 +8,7 @@ pub struct ClientCrypto<'a> {
 }
 
 impl<'a> ClientCrypto<'a> {
+    #[cfg(feature = "internal")]
     pub async fn initialize_crypto(&mut self, req: InitCryptoRequest) -> Result<()> {
         initialize_crypto(self.client, req).await
     }

--- a/crates/bitwarden/src/mobile/client_crypto.rs
+++ b/crates/bitwarden/src/mobile/client_crypto.rs
@@ -1,4 +1,6 @@
-use crate::{error::Result, Client};
+#[cfg(feature = "internal")]
+use crate::error::Result;
+use crate::Client;
 
 #[cfg(feature = "internal")]
 use super::crypto::{initialize_crypto, InitCryptoRequest};

--- a/crates/bitwarden/src/mobile/client_crypto.rs
+++ b/crates/bitwarden/src/mobile/client_crypto.rs
@@ -1,0 +1,25 @@
+use crate::{error::Result, Client};
+
+use super::crypto::{
+    initialize_org_crypto, initialize_user_crypto, InitOrgCryptoRequest, InitUserCryptoRequest,
+};
+
+pub struct ClientCrypto<'a> {
+    pub(crate) client: &'a mut crate::Client,
+}
+
+impl<'a> ClientCrypto<'a> {
+    pub async fn initialize_user_crypto(&mut self, req: InitUserCryptoRequest) -> Result<()> {
+        initialize_user_crypto(self.client, req).await
+    }
+
+    pub async fn initialize_org_crypto(&mut self, req: InitOrgCryptoRequest) -> Result<()> {
+        initialize_org_crypto(self.client, req).await
+    }
+}
+
+impl<'a> Client {
+    pub fn crypto(&'a mut self) -> ClientCrypto<'a> {
+        ClientCrypto { client: self }
+    }
+}

--- a/crates/bitwarden/src/mobile/client_crypto.rs
+++ b/crates/bitwarden/src/mobile/client_crypto.rs
@@ -1,20 +1,14 @@
 use crate::{error::Result, Client};
 
-use super::crypto::{
-    initialize_org_crypto, initialize_user_crypto, InitOrgCryptoRequest, InitUserCryptoRequest,
-};
+use super::crypto::{initialize_crypto, InitCryptoRequest};
 
 pub struct ClientCrypto<'a> {
     pub(crate) client: &'a mut crate::Client,
 }
 
 impl<'a> ClientCrypto<'a> {
-    pub async fn initialize_user_crypto(&mut self, req: InitUserCryptoRequest) -> Result<()> {
-        initialize_user_crypto(self.client, req).await
-    }
-
-    pub async fn initialize_org_crypto(&mut self, req: InitOrgCryptoRequest) -> Result<()> {
-        initialize_org_crypto(self.client, req).await
+    pub async fn initialize_crypto(&mut self, req: InitCryptoRequest) -> Result<()> {
+        initialize_crypto(self.client, req).await
     }
 }
 

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -1,6 +1,6 @@
 use crate::{error::Result, Client};
 
-use super::kdf::{get_user_password_hash, set_kdf_params, KdfParamRequest, PasswordHashRequest};
+use super::kdf::{hash_password, set_kdf_params, KdfParamRequest, PasswordHashRequest};
 
 pub struct ClientKdf<'a> {
     pub(crate) client: &'a mut crate::Client,
@@ -11,8 +11,8 @@ impl<'a> ClientKdf<'a> {
         set_kdf_params(self.client, req).await
     }
 
-    pub async fn get_user_password_hash(&mut self, req: PasswordHashRequest) -> Result<String> {
-        get_user_password_hash(self.client, req).await
+    pub async fn hash_password(&mut self, req: PasswordHashRequest) -> Result<String> {
+        hash_password(self.client, req).await
     }
 }
 

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -1,0 +1,23 @@
+use crate::{error::Result, Client};
+
+use super::kdf::{get_user_password_hash, set_kdf_params, KdfParamRequest, PasswordHashRequest};
+
+pub struct ClientKdf<'a> {
+    pub(crate) client: &'a mut crate::Client,
+}
+
+impl<'a> ClientKdf<'a> {
+    pub async fn set_kdf_params(&mut self, req: KdfParamRequest) -> Result<()> {
+        set_kdf_params(self.client, req).await
+    }
+
+    pub async fn get_user_password_hash(&mut self, req: PasswordHashRequest) -> Result<String> {
+        get_user_password_hash(self.client, req).await
+    }
+}
+
+impl<'a> Client {
+    pub fn kdf(&'a mut self) -> ClientKdf<'a> {
+        ClientKdf { client: self }
+    }
+}

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -1,16 +1,12 @@
 use crate::{error::Result, Client};
 
-use super::kdf::{hash_password, set_kdf_params, KdfParamRequest, PasswordHashRequest};
+use super::kdf::{hash_password, PasswordHashRequest};
 
 pub struct ClientKdf<'a> {
     pub(crate) client: &'a mut crate::Client,
 }
 
 impl<'a> ClientKdf<'a> {
-    pub async fn set_kdf_params(&mut self, req: KdfParamRequest) -> Result<()> {
-        set_kdf_params(self.client, req).await
-    }
-
     pub async fn hash_password(&mut self, req: PasswordHashRequest) -> Result<String> {
         hash_password(self.client, req).await
     }

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -7,32 +7,23 @@ use crate::{crypto::CipherString, error::Result, Client};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct InitUserCryptoRequest {
+pub struct InitCryptoRequest {
     /// The user's master password
     pub password: String,
     /// The user's encrypted symmetric crypto key
     pub user_key: String,
     /// The user's encryptred private key
     pub private_key: String,
+    /// The encryption keys for all the organizations the user is a part of
+    pub organization_keys: HashMap<uuid::Uuid, String>,
 }
 
-pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequest) -> Result<()> {
+pub async fn initialize_crypto(client: &mut Client, req: InitCryptoRequest) -> Result<()> {
     let user_key = req.user_key.parse::<CipherString>()?;
     let private_key = req.private_key.parse::<CipherString>()?;
 
     client.initialize_user_crypto(&req.password, user_key, private_key)?;
 
-    Ok(())
-}
-
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct InitOrgCryptoRequest {
-    /// The encryption keys for all the organizations the user is a part of
-    pub organization_keys: HashMap<uuid::Uuid, String>,
-}
-
-pub async fn initialize_org_crypto(client: &mut Client, req: InitOrgCryptoRequest) -> Result<()> {
     let organization_keys = req
         .organization_keys
         .into_iter()

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{crypto::CipherString, error::Result, Client};
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InitUserCryptoRequest {
+    /// The user's master password
+    pub password: String,
+    /// The user's encrypted symmetric crypto key
+    pub user_key: String,
+    /// The user's encryptred private key
+    pub private_key: String,
+}
+
+pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequest) -> Result<()> {
+    let user_key = req.user_key.parse::<CipherString>()?;
+    let private_key = req.private_key.parse::<CipherString>()?;
+
+    client.initialize_user_crypto(&req.password, user_key, private_key)?;
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InitOrgCryptoRequest {
+    /// The encryption keys for all the organizations the user is a part of
+    pub organization_keys: HashMap<uuid::Uuid, String>,
+}
+
+pub async fn initialize_org_crypto(client: &mut Client, req: InitOrgCryptoRequest) -> Result<()> {
+    let organization_keys = req
+        .organization_keys
+        .into_iter()
+        .map(|(k, v)| Ok((k, v.parse::<CipherString>()?)))
+        .collect::<Result<Vec<_>>>()?;
+
+    client.initialize_org_crypto(organization_keys)?;
+
+    Ok(())
+}

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -10,6 +10,7 @@ use crate::{
     Client,
 };
 
+#[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InitCryptoRequest {
@@ -27,6 +28,7 @@ pub struct InitCryptoRequest {
     pub organization_keys: HashMap<uuid::Uuid, String>,
 }
 
+#[cfg(feature = "internal")]
 pub async fn initialize_crypto(client: &mut Client, req: InitCryptoRequest) -> Result<()> {
     let auth_settings = AuthSettings {
         email: req.email,

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -33,10 +33,7 @@ pub struct PasswordHashRequest {
     pub password: String,
 }
 
-pub async fn get_user_password_hash(
-    client: &mut Client,
-    req: PasswordHashRequest,
-) -> Result<String> {
+pub async fn hash_password(client: &mut Client, req: PasswordHashRequest) -> Result<String> {
     let Some(auth_settings) = client.get_auth_settings() else { return Err(Error::NotAuthenticated); };
     let hash = auth_settings.make_user_password_hash(&req.password)?;
     Ok(hash)

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -3,38 +3,26 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     client::auth_settings::{AuthSettings, Kdf},
-    error::{Error, Result},
+    error::Result,
     Client,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct KdfParamRequest {
+pub struct PasswordHashRequest {
     /// The user's KDF parameters, as received from the prelogin request
     pub kdf_params: Kdf,
     /// The user's email address
     pub email: String,
-}
-
-pub async fn set_kdf_params(client: &mut Client, req: KdfParamRequest) -> Result<()> {
-    let auth_settings = AuthSettings {
-        email: req.email,
-        kdf: req.kdf_params,
-    };
-    client.set_auth_settings(auth_settings);
-
-    Ok(())
-}
-
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct PasswordHashRequest {
     /// The user's master password
     pub password: String,
 }
 
-pub async fn hash_password(client: &mut Client, req: PasswordHashRequest) -> Result<String> {
-    let Some(auth_settings) = client.get_auth_settings() else { return Err(Error::NotAuthenticated); };
+pub async fn hash_password(_client: &mut Client, req: PasswordHashRequest) -> Result<String> {
+    let auth_settings = AuthSettings {
+        email: req.email,
+        kdf: req.kdf_params,
+    };
     let hash = auth_settings.make_user_password_hash(&req.password)?;
     Ok(hash)
 }

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -1,0 +1,43 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    client::auth_settings::{AuthSettings, Kdf},
+    error::{Error, Result},
+    Client,
+};
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct KdfParamRequest {
+    /// The user's KDF parameters, as received from the prelogin request
+    pub kdf_params: Kdf,
+    /// The user's email address
+    pub email: String,
+}
+
+pub async fn set_kdf_params(client: &mut Client, req: KdfParamRequest) -> Result<()> {
+    let auth_settings = AuthSettings {
+        email: req.email,
+        kdf: req.kdf_params,
+    };
+    client.set_auth_settings(auth_settings);
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PasswordHashRequest {
+    /// The user's master password
+    pub password: String,
+}
+
+pub async fn get_user_password_hash(
+    client: &mut Client,
+    req: PasswordHashRequest,
+) -> Result<String> {
+    let Some(auth_settings) = client.get_auth_settings() else { return Err(Error::NotAuthenticated); };
+    let hash = auth_settings.make_user_password_hash(&req.password)?;
+    Ok(hash)
+}

--- a/crates/bitwarden/src/mobile/mod.rs
+++ b/crates/bitwarden/src/mobile/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "internal")]
 pub mod crypto;
 pub mod kdf;
 

--- a/crates/bitwarden/src/mobile/mod.rs
+++ b/crates/bitwarden/src/mobile/mod.rs
@@ -1,0 +1,5 @@
+pub mod crypto;
+pub mod kdf;
+
+pub(crate) mod client_crypto;
+pub(crate) mod client_kdf;

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bitwarden", "secrets-manager", "cli"]
 clap = { version = "4.3.0", features = ["derive", "env"] }
 tokio = { version = "1.28.2", features = ["rt-multi-thread", "macros"] }
 log = "0.4.18"
-bitwarden = { path = "../bitwarden", version = "0.2.1" }
+bitwarden = { path = "../bitwarden", version = "0.2.1", features = ["secrets"] }
 env_logger = "0.10.0"
 supports-color = "2.0.0"
 thiserror = "1.0.40"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "prettier --check .",
     "prettier": "prettier --write .",
-    "schemas": "rimraf ./support/schemas && cargo run --bin sdk-schemas --features internal,secrets,mobile && ts-node ./support/scripts/schemas.ts",
+    "schemas": "rimraf ./support/schemas && cargo run --bin sdk-schemas --all-features && ts-node ./support/scripts/schemas.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "prettier --check .",
     "prettier": "prettier --write .",
-    "schemas": "rimraf ./support/schemas && cargo run --bin sdk-schemas --features internal && ts-node ./support/scripts/schemas.ts",
+    "schemas": "rimraf ./support/schemas && cargo run --bin sdk-schemas --features internal,secrets,mobile && ts-node ./support/scripts/schemas.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Create a smaller client surface for the new mobile apps, by hiding all the secrets manager stuff under a `secrets` feature flag, and making a new encryption-focused API hidden under a `mobile` feature flag.

As an initial pass, I've implemented the KDF functions needed for login and the basics needed to initialise the cryptography parts of the client.

Sidenote: We really need to split the bitwarden_json::Command struct into multiple files 😨 
