### PR TITLE
[PM-3131] Implement Folder decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,11 +505,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -2000,7 +1997,7 @@ dependencies = [
  "line-wrap",
  "quick-xml",
  "serde",
- "time 0.3.23",
+ "time",
 ]
 
 [[package]]
@@ -2860,17 +2857,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
@@ -3187,12 +3173,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "bitwarden-api-api",
  "bitwarden-api-identity",
  "cbc",
+ "chrono",
  "getrandom 0.2.10",
  "hkdf",
  "hmac",
@@ -504,7 +505,11 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -1995,7 +2000,7 @@ dependencies = [
  "line-wrap",
  "quick-xml",
  "serde",
- "time",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -2398,6 +2403,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "indexmap 1.9.3",
  "schemars_derive",
@@ -2854,6 +2860,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
@@ -3170,6 +3187,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -11,7 +11,7 @@ use crate::command::{ProjectsCommand, SecretsCommand};
 #[cfg(all(feature = "internal", feature = "mobile"))]
 use crate::command::MobileCryptoCommand;
 #[cfg(feature = "mobile")]
-use crate::command::{MobileCommand, MobileKdfCommand};
+use crate::command::{MobileCommand, MobileFoldersCommand, MobileKdfCommand, MobileVaultCommand};
 
 pub struct Client(bitwarden::Client);
 
@@ -94,6 +94,20 @@ impl Client {
                     MobileCryptoCommand::InitCrypto(req) => {
                         self.0.crypto().initialize_crypto(req).await.into_string()
                     }
+                },
+                MobileCommand::Vault(cmd) => match cmd {
+                    MobileVaultCommand::Folders(cmd) => match cmd {
+                        MobileFoldersCommand::Decrypt(cmd) => {
+                            self.0.vault().folders().decrypt(cmd).await.into_string()
+                        }
+                        MobileFoldersCommand::DecryptList(cmd) => self
+                            .0
+                            .vault()
+                            .folders()
+                            .decrypt_list(cmd)
+                            .await
+                            .into_string(),
+                    },
                 },
             },
         }

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -20,7 +20,10 @@ use bitwarden::{
 };
 
 #[cfg(feature = "mobile")]
-use bitwarden::mobile::kdf::PasswordHashRequest;
+use bitwarden::mobile::{
+    kdf::PasswordHashRequest,
+    vault::{FolderDecryptListRequest, FolderDecryptRequest},
+};
 
 #[cfg(all(feature = "mobile", feature = "internal"))]
 use bitwarden::mobile::crypto::InitCryptoRequest;
@@ -190,6 +193,8 @@ pub enum ProjectsCommand {
 pub enum MobileCommand {
     Kdf(MobileKdfCommand),
     Crypto(MobileCryptoCommand),
+
+    Vault(MobileVaultCommand),
 }
 
 #[cfg(feature = "mobile")]
@@ -211,4 +216,29 @@ pub enum MobileCryptoCommand {
     /// Decrypts the users keys and initializes the user crypto, allowing for the encryption/decryption of the users vault
     ///
     InitCrypto(InitCryptoRequest),
+}
+
+#[cfg(feature = "mobile")]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum MobileVaultCommand {
+    Folders(MobileFoldersCommand),
+}
+
+#[cfg(feature = "mobile")]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub enum MobileFoldersCommand {
+    /// > Requires having previously initialized the cryptography parameters
+    /// Decrypts the provided folder
+    ///
+    /// Returns: [FolderDecryptResponse](bitwarden::mobile::vault::FolderDecryptResponse)
+    ///  
+    Decrypt(FolderDecryptRequest),
+    /// > Requires having previously initialized the cryptography parameters
+    /// Decrypts the provided folders
+    ///
+    /// Returns: [FolderDecryptListResponse](bitwarden::mobile::vault::FolderDecryptListResponse)   
+    ///
+    DecryptList(FolderDecryptListRequest),
 }

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 serde_qs = ">=0.12.0, <0.13"
 serde_repr = ">=0.1.12, <0.2"
-schemars = { version = ">=0.8, <0.9", features = ["uuid1"] }
+schemars = { version = ">=0.8, <0.9", features = ["uuid1", "chrono"] }
 log = ">=0.4.18, <0.5"
 assert_matches = ">=1.5.0, <2.0"
 thiserror = ">=1.0.40, <2.0"
@@ -52,6 +52,7 @@ getrandom = { version = ">=0.2.9", features = ["js"] }
 
 bitwarden-api-identity = { path = "../bitwarden-api-identity", version = "0.2.0" }
 bitwarden-api-api = { path = "../bitwarden-api-api", version = "0.2.0" }
+chrono = { version = "0.4.26", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.28.2", features = ["rt", "macros"] }

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -46,13 +46,13 @@ rand = ">=0.8.5, <0.9"
 num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
 uuid = { version = ">=1.3.3, <2.0", features = ["serde"] }
+chrono = { version = ">=0.4.26, <0.5", features = ["serde"], default-features = false }
 
 # We don't use this directly (it's used by rand), but we need it here to enable WASM support
 getrandom = { version = ">=0.2.9", features = ["js"] }
 
 bitwarden-api-identity = { path = "../bitwarden-api-identity", version = "0.2.0" }
 bitwarden-api-api = { path = "../bitwarden-api-api", version = "0.2.0" }
-chrono = { version = "0.4.26", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.28.2", features = ["rt", "macros"] }

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -59,6 +59,7 @@ pub mod platform;
 #[cfg(feature = "secrets")]
 pub mod secrets_manager;
 mod util;
+pub mod vault;
 pub mod wordlist;
 
 pub use client::Client;

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -59,6 +59,7 @@ pub mod platform;
 #[cfg(feature = "secrets")]
 pub mod secrets_manager;
 mod util;
+#[cfg(feature = "mobile")]
 pub mod vault;
 pub mod wordlist;
 

--- a/crates/bitwarden/src/mobile/mod.rs
+++ b/crates/bitwarden/src/mobile/mod.rs
@@ -1,6 +1,19 @@
 #[cfg(feature = "internal")]
 pub mod crypto;
 pub mod kdf;
+pub mod vault;
 
 pub(crate) mod client_crypto;
 pub(crate) mod client_kdf;
+
+// Usually we wouldn't want to expose CipherStrings in the API or the schemas,
+// but we need them in the mobile API, so define it here to limit the scope
+impl schemars::JsonSchema for crate::crypto::CipherString {
+    fn schema_name() -> String {
+        "CipherString".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        gen.subschema_for::<String>()
+    }
+}

--- a/crates/bitwarden/src/mobile/vault/client_folders.rs
+++ b/crates/bitwarden/src/mobile/vault/client_folders.rs
@@ -1,0 +1,51 @@
+use crate::{
+    crypto::Decryptable,
+    error::{Error, Result},
+    Client,
+};
+
+use super::{
+    client_vault::ClientVault, FolderDecryptListRequest, FolderDecryptListResponse,
+    FolderDecryptRequest, FolderDecryptResponse,
+};
+
+pub struct ClientFolders<'a> {
+    pub(crate) client: &'a mut Client,
+}
+
+impl<'a> ClientFolders<'a> {
+    pub async fn decrypt(&mut self, req: FolderDecryptRequest) -> Result<FolderDecryptResponse> {
+        let enc = self
+            .client
+            .get_encryption_settings()
+            .as_ref()
+            .ok_or(Error::VaultLocked)?;
+
+        let folder = req.folder.decrypt(enc, &None)?;
+
+        Ok(FolderDecryptResponse { folder })
+    }
+
+    pub async fn decrypt_list(
+        &mut self,
+        req: FolderDecryptListRequest,
+    ) -> Result<FolderDecryptListResponse> {
+        let enc = self
+            .client
+            .get_encryption_settings()
+            .as_ref()
+            .ok_or(Error::VaultLocked)?;
+
+        let folders = req.folders.decrypt(enc, &None)?;
+
+        Ok(FolderDecryptListResponse { folders })
+    }
+}
+
+impl<'a> ClientVault<'a> {
+    pub fn folders(&'a mut self) -> ClientFolders<'a> {
+        ClientFolders {
+            client: self.client,
+        }
+    }
+}

--- a/crates/bitwarden/src/mobile/vault/client_vault.rs
+++ b/crates/bitwarden/src/mobile/vault/client_vault.rs
@@ -1,0 +1,11 @@
+use crate::Client;
+
+pub struct ClientVault<'a> {
+    pub(crate) client: &'a mut crate::Client,
+}
+
+impl<'a> Client {
+    pub fn vault(&'a mut self) -> ClientVault<'a> {
+        ClientVault { client: self }
+    }
+}

--- a/crates/bitwarden/src/mobile/vault/folders/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/mod.rs
@@ -1,5 +1,5 @@
 mod request;
 mod response;
 
-pub use request::*;
-pub use response::*;
+pub use request::{FolderDecryptListRequest, FolderDecryptRequest};
+pub use response::{FolderDecryptListResponse, FolderDecryptResponse};

--- a/crates/bitwarden/src/mobile/vault/folders/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/mod.rs
@@ -1,42 +1,5 @@
-use chrono::{DateTime, Utc};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
-use crate::{
-    client::encryption_settings::EncryptionSettings,
-    crypto::{CipherString, Decryptable},
-    error::Result,
-};
-
 mod request;
 mod response;
 
 pub use request::*;
 pub use response::*;
-
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Folder {
-    id: Uuid,
-    name: CipherString,
-    revision_date: DateTime<Utc>,
-}
-
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct FolderView {
-    id: Uuid,
-    name: String,
-    revision_date: DateTime<Utc>,
-}
-
-impl Decryptable<FolderView> for Folder {
-    fn decrypt(&self, enc: &EncryptionSettings, _org: &Option<Uuid>) -> Result<FolderView> {
-        Ok(FolderView {
-            id: self.id,
-            name: self.name.decrypt(enc, &None)?,
-            revision_date: self.revision_date,
-        })
-    }
-}

--- a/crates/bitwarden/src/mobile/vault/folders/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/mod.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    client::encryption_settings::EncryptionSettings,
+    crypto::{CipherString, Decryptable},
+    error::Result,
+};
+
+mod request;
+mod response;
+
+pub use request::*;
+pub use response::*;
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Folder {
+    id: Uuid,
+    name: CipherString,
+    revision_date: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderView {
+    id: Uuid,
+    name: String,
+    revision_date: DateTime<Utc>,
+}
+
+impl Decryptable<FolderView> for Folder {
+    fn decrypt(&self, enc: &EncryptionSettings, _org: &Option<Uuid>) -> Result<FolderView> {
+        Ok(FolderView {
+            id: self.id,
+            name: self.name.decrypt(enc, &None)?,
+            revision_date: self.revision_date,
+        })
+    }
+}

--- a/crates/bitwarden/src/mobile/vault/folders/request.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/request.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::Folder;
+use crate::vault::Folder;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/bitwarden/src/mobile/vault/folders/request.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/request.rs
@@ -1,0 +1,16 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::Folder;
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FolderDecryptRequest {
+    pub folder: Folder,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FolderDecryptListRequest {
+    pub folders: Vec<Folder>,
+}

--- a/crates/bitwarden/src/mobile/vault/folders/response.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/response.rs
@@ -1,0 +1,16 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::FolderView;
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FolderDecryptResponse {
+    pub folder: FolderView,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FolderDecryptListResponse {
+    pub folders: Vec<FolderView>,
+}

--- a/crates/bitwarden/src/mobile/vault/folders/response.rs
+++ b/crates/bitwarden/src/mobile/vault/folders/response.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::FolderView;
+use crate::vault::FolderView;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/bitwarden/src/mobile/vault/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/mod.rs
@@ -1,0 +1,5 @@
+mod client_folders;
+mod client_vault;
+mod folders;
+
+pub use folders::*;

--- a/crates/bitwarden/src/mobile/vault/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/mod.rs
@@ -2,4 +2,7 @@ mod client_folders;
 mod client_vault;
 mod folders;
 
-pub use folders::*;
+pub use folders::{
+    FolderDecryptListRequest, FolderDecryptListResponse, FolderDecryptRequest,
+    FolderDecryptResponse,
+};

--- a/crates/bitwarden/src/vault/folder.rs
+++ b/crates/bitwarden/src/vault/folder.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    client::encryption_settings::EncryptionSettings,
+    crypto::{CipherString, Decryptable},
+    error::Result,
+};
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Folder {
+    id: Uuid,
+    name: CipherString,
+    revision_date: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderView {
+    id: Uuid,
+    name: String,
+    revision_date: DateTime<Utc>,
+}
+
+impl Decryptable<FolderView> for Folder {
+    fn decrypt(&self, enc: &EncryptionSettings, _org: &Option<Uuid>) -> Result<FolderView> {
+        Ok(FolderView {
+            id: self.id,
+            name: self.name.decrypt(enc, &None)?,
+            revision_date: self.revision_date,
+        })
+    }
+}

--- a/crates/bitwarden/src/vault/mod.rs
+++ b/crates/bitwarden/src/vault/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "mobile")]
+mod folder;
+
+#[cfg(feature = "mobile")]
+pub use folder::*;

--- a/crates/bitwarden/src/vault/mod.rs
+++ b/crates/bitwarden/src/vault/mod.rs
@@ -1,3 +1,3 @@
 mod folder;
 
-pub use folder::*;
+pub use folder::{Folder, FolderView};

--- a/crates/bitwarden/src/vault/mod.rs
+++ b/crates/bitwarden/src/vault/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "mobile")]
 mod folder;
 
-#[cfg(feature = "mobile")]
 pub use folder::*;


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Implement folder models and folder decryption for the mobile SDK.

I've exposed the CipherString type directly in the schemas to avoid doing a lot of `.parse::<CipherString>()?` all over the place. It's defined inside the `mobile` module to limit the scope, as it's not something we want exposed in the normal SDK.
