### PR TITLE
Remove unnecessary mut from encryption/decryption clients

### DIFF
--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -22,7 +22,7 @@ use bitwarden::{
 #[cfg(feature = "mobile")]
 use bitwarden::mobile::{
     kdf::PasswordHashRequest,
-    vault::{FolderDecryptListRequest, FolderDecryptRequest},
+    vault::{FolderDecryptListRequest, FolderDecryptRequest, FolderEncryptRequest},
 };
 
 #[cfg(all(feature = "mobile", feature = "internal"))]

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -3,17 +3,17 @@ use crate::{error::Result, Client};
 use super::kdf::{hash_password, PasswordHashRequest};
 
 pub struct ClientKdf<'a> {
-    pub(crate) client: &'a mut crate::Client,
+    pub(crate) client: &'a crate::Client,
 }
 
 impl<'a> ClientKdf<'a> {
-    pub async fn hash_password(&mut self, req: PasswordHashRequest) -> Result<String> {
+    pub async fn hash_password(&self, req: PasswordHashRequest) -> Result<String> {
         hash_password(self.client, req).await
     }
 }
 
 impl<'a> Client {
-    pub fn kdf(&'a mut self) -> ClientKdf<'a> {
+    pub fn kdf(&'a self) -> ClientKdf<'a> {
         ClientKdf { client: self }
     }
 }

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -18,7 +18,7 @@ pub struct PasswordHashRequest {
     pub password: String,
 }
 
-pub async fn hash_password(_client: &mut Client, req: PasswordHashRequest) -> Result<String> {
+pub async fn hash_password(_client: &Client, req: PasswordHashRequest) -> Result<String> {
     let auth_settings = AuthSettings {
         email: req.email,
         kdf: req.kdf_params,

--- a/crates/bitwarden/src/mobile/vault/client_folders.rs
+++ b/crates/bitwarden/src/mobile/vault/client_folders.rs
@@ -10,11 +10,11 @@ use super::{
 };
 
 pub struct ClientFolders<'a> {
-    pub(crate) client: &'a mut Client,
+    pub(crate) client: &'a Client,
 }
 
 impl<'a> ClientFolders<'a> {
-    pub async fn encrypt(&mut self, req: FolderEncryptRequest) -> Result<FolderEncryptResponse> {
+    pub async fn encrypt(&self, req: FolderEncryptRequest) -> Result<FolderEncryptResponse> {
         let enc = self
             .client
             .get_encryption_settings()
@@ -26,7 +26,7 @@ impl<'a> ClientFolders<'a> {
         Ok(FolderEncryptResponse { folder })
     }
 
-    pub async fn decrypt(&mut self, req: FolderDecryptRequest) -> Result<FolderDecryptResponse> {
+    pub async fn decrypt(&self, req: FolderDecryptRequest) -> Result<FolderDecryptResponse> {
         let enc = self
             .client
             .get_encryption_settings()
@@ -39,7 +39,7 @@ impl<'a> ClientFolders<'a> {
     }
 
     pub async fn decrypt_list(
-        &mut self,
+        &self,
         req: FolderDecryptListRequest,
     ) -> Result<FolderDecryptListResponse> {
         let enc = self
@@ -55,7 +55,7 @@ impl<'a> ClientFolders<'a> {
 }
 
 impl<'a> ClientVault<'a> {
-    pub fn folders(&'a mut self) -> ClientFolders<'a> {
+    pub fn folders(&'a self) -> ClientFolders<'a> {
         ClientFolders {
             client: self.client,
         }

--- a/crates/bitwarden/src/mobile/vault/client_vault.rs
+++ b/crates/bitwarden/src/mobile/vault/client_vault.rs
@@ -1,11 +1,11 @@
 use crate::Client;
 
 pub struct ClientVault<'a> {
-    pub(crate) client: &'a mut crate::Client,
+    pub(crate) client: &'a crate::Client,
 }
 
 impl<'a> Client {
-    pub fn vault(&'a mut self) -> ClientVault<'a> {
+    pub fn vault(&'a self) -> ClientVault<'a> {
         ClientVault { client: self }
     }
 }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The mobile API encryption/decryption clients never modify anything internally in the client, so the `&mut` references are unnecessary. Removing them will also help make using `uniffi` or putting the API client behind a `RwLock` for synchronization between threads more efficient.