### PR TITLE
Make get_encryption_settings return Result

### DIFF
--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -183,8 +183,8 @@ impl Client {
         }
     }
 
-    pub(crate) fn get_encryption_settings(&self) -> &Option<EncryptionSettings> {
-        &self.encryption_settings
+    pub(crate) fn get_encryption_settings(&self) -> Result<&EncryptionSettings> {
+        self.encryption_settings.as_ref().ok_or(Error::VaultLocked)
     }
 
     #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -12,7 +12,7 @@ use crate::{
         client_settings::{ClientSettings, DeviceType},
         encryption_settings::{EncryptionSettings, SymmetricCryptoKey},
     },
-    error::Result,
+    error::{Error, Result},
 };
 
 #[cfg(feature = "secrets")]
@@ -28,7 +28,6 @@ use {
         },
         client::auth_settings::AuthSettings,
         crypto::CipherString,
-        error::Error,
         platform::{
             generate_fingerprint, get_user_api_key, sync, FingerprintRequest,
             SecretVerificationRequest, SyncRequest, SyncResponse, UserApiKeyResponse,

--- a/crates/bitwarden/src/mobile/vault/client_folders.rs
+++ b/crates/bitwarden/src/mobile/vault/client_folders.rs
@@ -1,6 +1,6 @@
 use crate::{
     crypto::{Decryptable, Encryptable},
-    error::{Error, Result},
+    error::Result,
     Client,
 };
 
@@ -15,11 +15,7 @@ pub struct ClientFolders<'a> {
 
 impl<'a> ClientFolders<'a> {
     pub async fn encrypt(&self, req: FolderEncryptRequest) -> Result<FolderEncryptResponse> {
-        let enc = self
-            .client
-            .get_encryption_settings()
-            .as_ref()
-            .ok_or(Error::VaultLocked)?;
+        let enc = self.client.get_encryption_settings()?;
 
         let folder = req.folder.encrypt(enc, &None)?;
 
@@ -27,11 +23,7 @@ impl<'a> ClientFolders<'a> {
     }
 
     pub async fn decrypt(&self, req: FolderDecryptRequest) -> Result<FolderDecryptResponse> {
-        let enc = self
-            .client
-            .get_encryption_settings()
-            .as_ref()
-            .ok_or(Error::VaultLocked)?;
+        let enc = self.client.get_encryption_settings()?;
 
         let folder = req.folder.decrypt(enc, &None)?;
 
@@ -42,11 +34,7 @@ impl<'a> ClientFolders<'a> {
         &self,
         req: FolderDecryptListRequest,
     ) -> Result<FolderDecryptListResponse> {
-        let enc = self
-            .client
-            .get_encryption_settings()
-            .as_ref()
-            .ok_or(Error::VaultLocked)?;
+        let enc = self.client.get_encryption_settings()?;
 
         let folders = req.folders.decrypt(enc, &None)?;
 

--- a/crates/bitwarden/src/secrets_manager/projects/create.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/create.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::ProjectResponse;
-use crate::{
-    client::Client,
-    error::{Error, Result},
-};
+use crate::{client::Client, error::Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -22,10 +19,7 @@ pub(crate) async fn create_project(
     client: &mut Client,
     input: &ProjectCreateRequest,
 ) -> Result<ProjectResponse> {
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     let org_id = Some(input.organization_id);
 
@@ -41,10 +35,7 @@ pub(crate) async fn create_project(
     )
     .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     ProjectResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/projects/get.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/get.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::ProjectResponse;
-use crate::{
-    client::Client,
-    error::{Error, Result},
-};
+use crate::{client::Client, error::Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -23,10 +20,7 @@ pub(crate) async fn get_project(
 
     let res = bitwarden_api_api::apis::projects_api::projects_id_get(&config.api, input.id).await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     ProjectResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/projects/list.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/list.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::ProjectResponse;
 use crate::{
     client::{encryption_settings::EncryptionSettings, Client},
-    error::{Error, Result},
+    error::Result,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -27,10 +27,7 @@ pub(crate) async fn list_projects(
     )
     .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     ProjectsResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/projects/update.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/update.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::ProjectResponse;
-use crate::{
-    client::Client,
-    error::{Error, Result},
-};
+use crate::{client::Client, error::Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -24,10 +21,7 @@ pub(crate) async fn update_project(
     client: &mut Client,
     input: &ProjectPutRequest,
 ) -> Result<ProjectResponse> {
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     let org_id = Some(input.organization_id);
 
@@ -40,10 +34,7 @@ pub(crate) async fn update_project(
         bitwarden_api_api::apis::projects_api::projects_id_put(&config.api, input.id, project)
             .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     ProjectResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/create.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/create.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::SecretResponse;
-use crate::{
-    error::{Error, Result},
-    Client,
-};
+use crate::{error::Result, Client};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -27,10 +24,7 @@ pub(crate) async fn create_secret(
     client: &mut Client,
     input: &SecretCreateRequest,
 ) -> Result<SecretResponse> {
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     let org_id = Some(input.organization_id);
 
@@ -49,10 +43,7 @@ pub(crate) async fn create_secret(
     )
     .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     SecretResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/get.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/get.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::SecretResponse;
-use crate::{
-    error::{Error, Result},
-    Client,
-};
+use crate::{error::Result, Client};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -22,10 +19,7 @@ pub(crate) async fn get_secret(
     let config = client.get_api_configurations().await;
     let res = bitwarden_api_api::apis::secrets_api::secrets_id_get(&config.api, input.id).await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     SecretResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/list.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/list.rs
@@ -29,10 +29,7 @@ pub(crate) async fn list_secrets(
     )
     .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     SecretIdentifiersResponse::process_response(res, enc)
 }
@@ -55,10 +52,7 @@ pub(crate) async fn list_secrets_by_project(
     )
     .await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     SecretIdentifiersResponse::process_response(res, enc)
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/update.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/update.rs
@@ -4,10 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::SecretResponse;
-use crate::{
-    client::Client,
-    error::{Error, Result},
-};
+use crate::{client::Client, error::Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -27,10 +24,7 @@ pub(crate) async fn update_secret(
     client: &mut Client,
     input: &SecretPutRequest,
 ) -> Result<SecretResponse> {
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     let org_id = Some(input.organization_id);
 
@@ -45,10 +39,7 @@ pub(crate) async fn update_secret(
     let res =
         bitwarden_api_api::apis::secrets_api::secrets_id_put(&config.api, input.id, secret).await?;
 
-    let enc = client
-        .get_encryption_settings()
-        .as_ref()
-        .ok_or(Error::VaultLocked)?;
+    let enc = client.get_encryption_settings()?;
 
     SecretResponse::process_response(res, enc)
 }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Every single use of it would immediately do `.as_ref().ok_or(Error::VaultLocked)?`, so make it just return the Result directly. This change originated in #70, but I'm opening a separate PR for it because it's been annoying me each time I implement something handling encryption or decryption lol