### PR TITLE
Update serde_repr to fix some warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
+checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = ">=0.11, <0.12", features = ["json"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 serde_qs = ">=0.12.0, <0.13"
-serde_repr = ">=0.1.12, <0.2"
+serde_repr = ">=0.1.16, <0.2"
 schemars = { version = ">=0.8, <0.9", features = ["uuid1", "chrono"] }
 log = ">=0.4.18, <0.5"
 assert_matches = ">=1.5.0, <2.0"

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = ">=0.11, <0.12", features = ["json"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 serde_qs = ">=0.12.0, <0.13"
-serde_repr = ">=0.1.16, <0.2"
+serde_repr = ">=0.1.12, <0.2"
 schemars = { version = ">=0.8, <0.9", features = ["uuid1", "chrono"] }
 log = ">=0.4.18, <0.5"
 assert_matches = ">=1.5.0, <2.0"


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The macro-generated code of `serde_repr` serialization implementation contains a lowercase struct, which generates a warning in rust-analyzer, seems like it doesn't show in CI, and it's not important, but I think it's a good idea to update the dependency to make the warning go away. 

https://github.com/dtolnay/serde-repr/releases/tag/0.1.16
![image](https://github.com/bitwarden/sdk/assets/725423/c06ad325-8e05-43e2-a3d7-b15d13287959)