### PR TITLE
Fix invalid target_arch

### DIFF
--- a/crates/bitwarden-napi/src/lib.rs
+++ b/crates/bitwarden-napi/src/lib.rs
@@ -1,2 +1,2 @@
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod client;

--- a/crates/bitwarden-py/src/lib.rs
+++ b/crates/bitwarden-py/src/lib.rs
@@ -1,5 +1,5 @@
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod client;
 
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod python_module;


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Some `cfg`s were checking for a `target_arch` of `wasm`, this value is not valid, the only valid values are `wasm32` and `wasm64`.

You can check the possible values with this command:
```sh
rustc +nightly -Z unstable-options --print all-target-specs-json | jq '[ to_entries[] | { "target": .key, "arch": .value.arch, "target-family": .value."target-family" } | select(.arch | startswith("wasm")) ]'
```