### PR TITLE
Add missing client vault function

### DIFF
--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -12,6 +12,7 @@ mod error;
 pub mod vault;
 
 use error::Result;
+use vault::ClientVault;
 
 #[derive(uniffi::Object)]
 pub struct Client(RwLock<bitwarden::Client>);
@@ -38,6 +39,11 @@ impl Client {
     /// Crypto operations
     pub fn crypto(self: Arc<Self>) -> Arc<ClientCrypto> {
         Arc::new(ClientCrypto(self))
+    }
+
+    /// Vault item operations
+    pub fn vault(self: Arc<Self>) -> Arc<ClientVault> {
+        Arc::new(ClientVault(self))
     }
 
     /// Test method, echoes back the input

--- a/crates/bitwarden-uniffi/src/vault/mod.rs
+++ b/crates/bitwarden-uniffi/src/vault/mod.rs
@@ -8,7 +8,7 @@ pub mod folders;
 pub mod password_history;
 
 #[derive(uniffi::Object)]
-pub struct ClientVault(Arc<Client>);
+pub struct ClientVault(pub(crate) Arc<Client>);
 
 #[uniffi::export]
 impl ClientVault {


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We missed adding this function to access the ClientVault from the uniffi API