### PR TITLE
Fix iOS uniffi build by concatenating modulemaps correctly

### DIFF
--- a/languages/swift/build.sh
+++ b/languages/swift/build.sh
@@ -24,10 +24,8 @@ mv ./tmp/bindings/BitwardenCore.swift ./Sources/BitwardenSdk/
 # Massage the generated files to fit xcframework
 mkdir tmp/Headers
 mv ./tmp/bindings/BitwardenFFI.h ./tmp/Headers/
-mv ./tmp/bindings/BitwardenFFI.modulemap ./tmp/Headers/module.modulemap
 mv ./tmp/bindings/BitwardenCoreFFI.h ./tmp/Headers/
-mv ./tmp/bindings/BitwardenCoreFFI.modulemap ./tmp/Headers/module.modulemap
-
+cat ./tmp/bindings/BitwardenFFI.modulemap ./tmp/bindings/BitwardenCoreFFI.modulemap > ./tmp/Headers/module.modulemap
 
 # Build xcframework
 xcodebuild -create-xcframework \


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We need to combine both modules modulemap files instead of replacing them