### PR TITLE
Explicitly define internal feature for sdk-schemas crate

### DIFF
--- a/crates/sdk-schemas/Cargo.toml
+++ b/crates/sdk-schemas/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.57"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+internal = ["bitwarden/internal", "bitwarden-json/internal"]
 
 [dependencies]
 schemars = { version = "0.8.12",  features = ["preserve_order"] }


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On the `sdk-schemas` crate we have some types behind an `internal` feature flag, which is not defined in `Cargo.toml`, this means that building with `--features internal` would enable those types behind the `internal` flag, but `--all-features` would not. This causes the `npm run schemas` command to not generate those types, because we're using `--all-features` in the `package.json` file.

By defining the features in the manifest file, we remove that inconsistency with `--all-features` and make sure that `npm run schemas` generates all the schemas correctly.