### PR TITLE
Fix panic when re-registering a logger

### DIFF
--- a/crates/bitwarden-c/src/c.rs
+++ b/crates/bitwarden-c/src/c.rs
@@ -24,7 +24,8 @@ pub async extern "C" fn run_command(
 // Init client, potential leak! You need to call free_mem after this!
 #[no_mangle]
 pub extern "C" fn init(c_str_ptr: *const c_char) -> *mut Client {
-    env_logger::init();
+    // This will only fail if another logger was already initialized, so we can ignore the result
+    let _ = env_logger::try_init();
     if c_str_ptr.is_null() {
         box_ptr!(Client::new(None))
     } else {

--- a/crates/bitwarden-napi/src/client.rs
+++ b/crates/bitwarden-napi/src/client.rs
@@ -30,9 +30,10 @@ pub struct BitwardenClient(JsonClient);
 impl BitwardenClient {
     #[napi(constructor)]
     pub fn new(settings_input: Option<String>, log_level: Option<LogLevel>) -> Self {
-        env_logger::Builder::from_default_env()
+        // This will only fail if another logger was already initialized, so we can ignore the result
+        let _ = env_logger::Builder::from_default_env()
             .filter_level(convert_level(log_level.unwrap_or(LogLevel::Info)))
-            .init();
+            .try_init();
         Self(bitwarden_json::client::Client::new(settings_input))
     }
 


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix panic when re-registering a logger. This should only happen if our logger got registered on a previous call, so there's no need to register it again.

Fixes #134, but it's also applicable to `bitwarden-c`