### PR TITLE
Fix typo in added schemas, ProjectsResponse was missing

### DIFF
--- a/crates/sdk-schemas/src/main.rs
+++ b/crates/sdk-schemas/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
         bitwarden::secrets_manager::secrets::SecretResponse,
         bitwarden::secrets_manager::secrets::SecretsDeleteResponse,
         bitwarden::secrets_manager::projects::ProjectResponse,
-        bitwarden::secrets_manager::projects::ProjectResponse,
+        bitwarden::secrets_manager::projects::ProjectsResponse,
         bitwarden::secrets_manager::projects::ProjectsDeleteResponse,
     };
 


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
#180 accidentally added ProjectResponse twice when it should have added ProjectResponse and Project**s**Response