### PR TITLE
Rename EncString parse error

### DIFF
--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     Crypto(#[from] CryptoError),
 
     #[error("Error parsing EncString: {0}")]
-    InvalidEncString(#[from] CSParseError),
+    InvalidEncString(#[from] EncStringParseError),
 
     #[error("Error parsing Identity response: {0}")]
     IdentityFail(crate::auth::api::response::IdentityTokenFailResponse),
@@ -83,7 +83,7 @@ pub enum CryptoError {
 }
 
 #[derive(Debug, Error)]
-pub enum CSParseError {
+pub enum EncStringParseError {
     #[error("No type detected, missing '.' separator")]
     NoType,
     #[error("Invalid type, got {enc_type} with {parts} parts")]


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Rename CSParseError to EncStringParseError, to better match the new naming. No need to abbreviate, the name is short enough.
