### PR TITLE
Lock generated API crates to the specified version

### DIFF
--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -55,8 +55,8 @@ uniffi = { version = "=0.24.1", optional = true }
 # We don't use this directly (it's used by rand), but we need it here to enable WASM support
 getrandom = { version = ">=0.2.9", features = ["js"] }
 
-bitwarden-api-identity = { path = "../bitwarden-api-identity", version = "0.2.1" }
-bitwarden-api-api = { path = "../bitwarden-api-api", version = "0.2.1" }
+bitwarden-api-identity = { path = "../bitwarden-api-identity", version = "=0.2.1" }
+bitwarden-api-api = { path = "../bitwarden-api-api", version = "=0.2.1" }
 
 [dev-dependencies]
 tokio = { version = "1.28.2", features = ["rt", "macros"] }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Lock the generated `bitwarden-api-api` and `bitwarden-api-identity` to specific versions in `bitwarden` to avoid possible conflicts when new versions of these two are released.

CI is running cargo set-version to update the version numbers, and that seems to respect the `=` bound in my tests, so this seems safe to do.