### PR TITLE
Make MAC validation optional when decrypting

### DIFF
--- a/crates/bitwarden/src/client/encryption_settings.rs
+++ b/crates/bitwarden/src/client/encryption_settings.rs
@@ -49,7 +49,7 @@ impl EncryptionSettings {
                 _ => return Err(CryptoError::InvalidKey.into()),
             };
 
-            let dec = decrypt_aes256(&iv, &mac, data, Some(mac_key), key)?;
+            let dec = decrypt_aes256(&iv, Some(&mac), data, Some(mac_key), key)?;
             SymmetricCryptoKey::try_from(dec.as_slice())?
         };
 

--- a/crates/bitwarden/src/crypto/aes_ops.rs
+++ b/crates/bitwarden/src/crypto/aes_ops.rs
@@ -12,21 +12,22 @@ use crate::{
 
 pub fn decrypt_aes256(
     iv: &[u8; 16],
-    mac: &[u8; 32],
+    mac: Option<&[u8; 32]>,
     data: Vec<u8>,
     mac_key: Option<GenericArray<u8, U32>>,
     key: GenericArray<u8, U32>,
 ) -> Result<Vec<u8>> {
-    let mac_key = match mac_key {
-        Some(k) => k,
-        None => return Err(CryptoError::InvalidMac.into()),
+    match (mac_key, mac) {
+        (Some(mac_key), Some(mac)) => {
+            // Validate HMAC
+            let res = validate_mac(&mac_key, iv, &data)?;
+            if res != *mac {
+                return Err(CryptoError::InvalidMac.into());
+            }
+        }
+        (None, None) => { /* No mac provided, so we don't do MAC checking */ }
+        _ => return Err(CryptoError::InvalidMac.into()),
     };
-
-    // Validate HMAC
-    let res = validate_mac(&mac_key, iv, &data)?;
-    if res != *mac {
-        return Err(CryptoError::InvalidMac.into());
-    }
 
     // Decrypt data
     let iv = GenericArray::from_slice(iv);

--- a/crates/bitwarden/src/crypto/enc_string.rs
+++ b/crates/bitwarden/src/crypto/enc_string.rs
@@ -281,7 +281,7 @@ impl EncString {
     pub fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<Vec<u8>> {
         match self {
             EncString::AesCbc256_HmacSha256_B64 { iv, mac, data } => {
-                let dec = decrypt_aes256(iv, mac, data.clone(), key.mac_key, key.key)?;
+                let dec = decrypt_aes256(iv, Some(mac), data.clone(), key.mac_key, key.key)?;
                 Ok(dec)
             }
             _ => Err(CryptoError::InvalidKey.into()),


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Change the parameters of `decrypt_aes256` to make the MAC optional and not validate it, needed for implementing AES encryption without HMAC