### PR TITLE
Add Sends API in bitwarden-uniffi

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 target
-languages
+languages/*
+!/languages/kotlin
+languages/kotlin/*
+!/languages/kotlin/doc.md
 schemas
 /crates/bitwarden-napi/src-ts/bitwarden_client/schemas.ts
 about.hbs

--- a/crates/bitwarden-uniffi/src/docs.rs
+++ b/crates/bitwarden-uniffi/src/docs.rs
@@ -3,7 +3,7 @@ use bitwarden::{
     client::auth_settings::Kdf,
     mobile::crypto::InitCryptoRequest,
     tool::{ExportFormat, PassphraseGeneratorRequest, PasswordGeneratorRequest},
-    vault::{Cipher, CipherView, Collection, Folder, FolderView},
+    vault::{Cipher, CipherView, Collection, Folder, FolderView, Send, SendListView, SendView},
 };
 use schemars::JsonSchema;
 
@@ -16,6 +16,9 @@ pub enum DocRef {
     Collection(Collection),
     Folder(Folder),
     FolderView(FolderView),
+    Send(Send),
+    SendView(SendView),
+    SendListView(SendListView),
 
     // Crypto
     InitCryptoRequest(InitCryptoRequest),

--- a/crates/bitwarden-uniffi/src/vault/mod.rs
+++ b/crates/bitwarden-uniffi/src/vault/mod.rs
@@ -6,6 +6,7 @@ pub mod ciphers;
 pub mod collections;
 pub mod folders;
 pub mod password_history;
+pub mod sends;
 
 #[derive(uniffi::Object)]
 pub struct ClientVault(pub(crate) Arc<Client>);
@@ -27,8 +28,13 @@ impl ClientVault {
         Arc::new(ciphers::ClientCiphers(self.0.clone()))
     }
 
-    /// Ciphers operations
+    /// Password history operations
     pub fn password_history(self: Arc<Self>) -> Arc<password_history::ClientPasswordHistory> {
         Arc::new(password_history::ClientPasswordHistory(self.0.clone()))
+    }
+
+    /// Sends operations
+    pub fn sends(self: Arc<Self>) -> Arc<sends::ClientSends> {
+        Arc::new(sends::ClientSends(self.0.clone()))
     }
 }

--- a/crates/bitwarden-uniffi/src/vault/sends.rs
+++ b/crates/bitwarden-uniffi/src/vault/sends.rs
@@ -1,0 +1,104 @@
+use std::{path::Path, sync::Arc};
+
+use bitwarden::vault::{Send, SendListView, SendView};
+
+use crate::{Client, Result};
+
+#[derive(uniffi::Object)]
+pub struct ClientSends(pub Arc<Client>);
+
+#[uniffi::export]
+impl ClientSends {
+    /// Encrypt send
+    pub async fn encrypt(&self, send: SendView) -> Result<Send> {
+        Ok(self.0 .0.read().await.vault().sends().encrypt(send).await?)
+    }
+
+    /// Encrypt a send file in memory
+    pub async fn encrypt_buffer(&self, send: Send, buffer: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .sends()
+            .encrypt_buffer(send, &buffer)
+            .await?)
+    }
+
+    /// Encrypt a send file located in the file system
+    pub async fn encrypt_file(
+        &self,
+        send: Send,
+        decrypted_file_path: String,
+        encrypted_file_path: String,
+    ) -> Result<()> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .sends()
+            .encrypt_file(
+                send,
+                Path::new(&decrypted_file_path),
+                Path::new(&encrypted_file_path),
+            )
+            .await?)
+    }
+
+    /// Decrypt send
+    pub async fn decrypt(&self, send: Send) -> Result<SendView> {
+        Ok(self.0 .0.read().await.vault().sends().decrypt(send).await?)
+    }
+
+    /// Decrypt send list
+    pub async fn decrypt_list(&self, sends: Vec<Send>) -> Result<Vec<SendListView>> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .sends()
+            .decrypt_list(sends)
+            .await?)
+    }
+
+    /// Decrypt a send file in memory
+    pub async fn decrypt_buffer(&self, send: Send, buffer: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .sends()
+            .decrypt_buffer(send, &buffer)
+            .await?)
+    }
+
+    /// Decrypt a send file located in the file system
+    pub async fn decrypt_file(
+        &self,
+        send: Send,
+        encrypted_file_path: String,
+        decrypted_file_path: String,
+    ) -> Result<()> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .sends()
+            .decrypt_file(
+                send,
+                Path::new(&encrypted_file_path),
+                Path::new(&decrypted_file_path),
+            )
+            .await?)
+    }
+}

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -291,6 +291,91 @@ Decrypt password history
 
 **Output**: std::result::Result<Vec,BitwardenError>
 
+## ClientSends
+
+### `encrypt`
+
+Encrypt send
+
+**Arguments**:
+
+- self:
+- send: SendView
+
+**Output**: std::result::Result<Send,BitwardenError>
+
+### `encrypt_buffer`
+
+Encrypt a send file in memory
+
+**Arguments**:
+
+- self:
+- send: Send
+- buffer: Vec<>
+
+**Output**: std::result::Result<Vec,BitwardenError>
+
+### `encrypt_file`
+
+Encrypt a send file located in the file system
+
+**Arguments**:
+
+- self:
+- send: Send
+- decrypted_file_path: String
+- encrypted_file_path: String
+
+**Output**: std::result::Result<,BitwardenError>
+
+### `decrypt`
+
+Decrypt send
+
+**Arguments**:
+
+- self:
+- send: Send
+
+**Output**: std::result::Result<SendView,BitwardenError>
+
+### `decrypt_list`
+
+Decrypt send list
+
+**Arguments**:
+
+- self:
+- sends: Vec<Send>
+
+**Output**: std::result::Result<Vec,BitwardenError>
+
+### `decrypt_buffer`
+
+Decrypt a send file in memory
+
+**Arguments**:
+
+- self:
+- send: Send
+- buffer: Vec<>
+
+**Output**: std::result::Result<Vec,BitwardenError>
+
+### `decrypt_file`
+
+Decrypt a send file located in the file system
+
+**Arguments**:
+
+- self:
+- send: Send
+- encrypted_file_path: String
+- decrypted_file_path: String
+
+**Output**: std::result::Result<,BitwardenError>
+
 ## ClientVault
 
 ### `folders`
@@ -325,13 +410,23 @@ Ciphers operations
 
 ### `password_history`
 
-Ciphers operations
+Password history operations
 
 **Arguments**:
 
 - self: Arc<Self>
 
 **Output**: Arc<password_history::ClientPasswordHistory>
+
+### `sends`
+
+Sends operations
+
+**Arguments**:
+
+- self: Arc<Self>
+
+**Output**: Arc<sends::ClientSends>
 
 # References
 

--- a/support/docs/docs.ts
+++ b/support/docs/docs.ts
@@ -28,6 +28,7 @@ const rootElements = [
   "ClientFolders",
   "ClientGenerators",
   "ClientPasswordHistory",
+  "ClientSends",
   "ClientVault",
 ];
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add missing Sends API to the bitwarden-uniffi crate.

Also fixed copy-pasted comment in the password history function