### PR TITLE
Change gh action android combine rust toolchain to stable

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@f361669954a8ecfc00a3443f35f9ac8e610ffc06 # stable
         with:
-          toolchain: 1.67.0 # https://github.com/cross-rs/cross/issues/1222
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@e207df5d269b42b69c8bc5101da26f7d31feddb4 # v2.6.2


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

An updated dependency results in errors in #194 . Bumping the rust version for the combine task in the android workflow which should resolve this.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
