### PR TITLE
Asymmetric encryption support for EncString

### DIFF
--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -11,7 +11,7 @@ use {
             TwoFactorEmailRequest,
         },
         client::auth_settings::AuthSettings,
-        crypto::EncString,
+        crypto::{AsymmetricEncString, EncString},
         platform::{
             generate_fingerprint, get_user_api_key, sync, FingerprintRequest, FingerprintResponse,
             SecretVerificationRequest, SyncRequest, SyncResponse, UserApiKeyResponse,
@@ -244,7 +244,7 @@ impl Client {
     #[cfg(feature = "internal")]
     pub(crate) fn initialize_org_crypto(
         &mut self,
-        org_keys: Vec<(Uuid, EncString)>,
+        org_keys: Vec<(Uuid, AsymmetricEncString)>,
     ) -> Result<&EncryptionSettings> {
         let enc = self
             .encryption_settings

--- a/crates/bitwarden/src/crypto/aes_ops.rs
+++ b/crates/bitwarden/src/crypto/aes_ops.rs
@@ -10,6 +10,8 @@ use crate::{
     error::{CryptoError, Result},
 };
 
+use super::EncStringVariants;
+
 pub fn decrypt_aes256(iv: &[u8; 16], data: Vec<u8>, key: GenericArray<u8, U32>) -> Result<Vec<u8>> {
     // Decrypt data
     let iv = GenericArray::from_slice(iv);
@@ -42,7 +44,7 @@ pub fn decrypt_aes256_hmac(
 pub fn encrypt_aes256(data_dec: &[u8], key: GenericArray<u8, U32>) -> Result<EncString> {
     let (iv, data) = encrypt_aes256_internal(data_dec, key);
 
-    Ok(EncString::AesCbc256_B64 { iv, data })
+    Ok(EncStringVariants::AesCbc256_B64 { iv, data }.into())
 }
 
 pub fn encrypt_aes256_hmac(
@@ -53,7 +55,7 @@ pub fn encrypt_aes256_hmac(
     let (iv, data) = encrypt_aes256_internal(data_dec, key);
     let mac = validate_mac(&mac_key, &iv, &data)?;
 
-    Ok(EncString::AesCbc256_HmacSha256_B64 { iv, mac, data })
+    Ok(EncStringVariants::AesCbc256_HmacSha256_B64 { iv, mac, data }.into())
 }
 
 fn encrypt_aes256_internal(data_dec: &[u8], key: GenericArray<u8, U32>) -> ([u8; 16], Vec<u8>) {

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -27,7 +27,8 @@ use hmac::digest::OutputSizeUser;
 use crate::error::{Error, Result};
 
 mod enc_string;
-pub use enc_string::EncString;
+pub(super) use enc_string::EncStringVariants;
+pub use enc_string::{AsymmetricEncString, EncString};
 mod encryptable;
 pub use encryptable::{Decryptable, Encryptable};
 mod aes_ops;

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -5,10 +5,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     client::auth_settings::{AuthSettings, Kdf},
-    crypto::EncString,
     error::Result,
     Client,
 };
+
+#[cfg(feature = "internal")]
+use crate::crypto::{AsymmetricEncString, EncString};
 
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -45,7 +47,7 @@ pub async fn initialize_crypto(client: &mut Client, req: InitCryptoRequest) -> R
     let organization_keys = req
         .organization_keys
         .into_iter()
-        .map(|(k, v)| Ok((k, v.parse::<EncString>()?)))
+        .map(|(k, v)| Ok((k, v.parse::<AsymmetricEncString>()?)))
         .collect::<Result<Vec<_>>>()?;
 
     client.initialize_org_crypto(organization_keys)?;


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
EncString now has a generic type param to indicate whether it's using Symm/Asymm encryption. `EncString` is now the equivalent of `BaseEncString<SymmetricKey>` and `AsymmetricEncString` is `BaseEncString<AsymmetricKey>`. 

Note that both `EncString` and `AsymmetricEncString` are specific versions of the `BaseEncString`, which mean they both contain all the 7 variants we support, this is just to avoid code duplication while implementing parsing, but some of that might be able to be moved to the generic type.