### PR TITLE
Fix Swift build warnings

### DIFF
--- a/languages/swift/Package.swift
+++ b/languages/swift/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "BitwardenSdk",
-            dependencies: ["BitwardenFFI"]),
+            dependencies: ["BitwardenFFI"],
+            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]),
         .testTarget(
             name: "BitwardenSdkTests",
             dependencies: ["BitwardenSdk"]),

--- a/languages/swift/build.sh
+++ b/languages/swift/build.sh
@@ -8,6 +8,8 @@ mkdir tmp
 mkdir -p tmp/target/universal-ios-sim/release
 
 # Build native library
+export IPHONEOS_DEPLOYMENT_TARGET="13.0"
+export RUSTFLAGS="-C link-arg=-Wl,-application_extension"
 cargo build --package bitwarden-uniffi --target aarch64-apple-ios-sim --release
 cargo build --package bitwarden-uniffi --target aarch64-apple-ios --release
 cargo build --package bitwarden-uniffi --target x86_64-apple-ios --release


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

This fixes a few build warnings when integrating the Swift SDK package within an app:

> ld: warning: dylib (libbitwarden_uniffi.dylib) was built for newer iOS Simulator version (16.2) than being linked (15.0)

It looks like Rust probably uses the latest iOS deployment target/min iOS version if not specified. I added `IPHONEOS_DEPLOYMENT_TARGET="13.0"` to set this to iOS 13, which matches the version in Package.swift.
https://github.com/bitwarden/sdk/blob/c707fc9ff9a241b73ef7471f90a3d0b0e68c6e33/languages/swift/Package.swift#L9

> ld: warning: linking against a dylib which is not safe for use in application extensions: libbitwarden_uniffi.dylib

We need to link the SDK within an iOS app extension to use for auto fill. `RUSTFLAGS="-C link-arg=-Wl,-application_extension"` enables a linker flag which specifies that this code is being linked for use in an extension. This prevents using some UIKit APIs that don't exist in extensions but shouldn't have any negative effects on the SDK.

<img width="499" alt="Screenshot 2023-09-13 at 8 51 46 AM" src="https://github.com/bitwarden/sdk/assets/126492398/ef971fa6-745b-43de-91a6-8620af0c823b">

There's a bunch of build warnings from the SDK. These all appear to be around how Rust escapes argument parameters in the generated code, so it seems safe enough to ignore these and add the `-suppress-warnings` Swift flag. Xcode does a pretty good job of hiding warnings from SPM packages, but they still show up in build logs so it would be nice to hide these.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **Package.swift:** Adds a flag to suppress warnings from the SDK package.
- **build.sh:** Adds two environment variables to fix build warnings.