### PR TITLE
Use static libs for the iOS Swift framework

### DIFF
--- a/languages/swift/build.sh
+++ b/languages/swift/build.sh
@@ -15,9 +15,9 @@ cargo build --package bitwarden-uniffi --target aarch64-apple-ios --release
 cargo build --package bitwarden-uniffi --target x86_64-apple-ios --release
 
 # Create universal libraries
-lipo -create ../../target/aarch64-apple-ios-sim/release/libbitwarden_uniffi.dylib \
-  ../../target/x86_64-apple-ios/release/libbitwarden_uniffi.dylib  \
-  -output ./tmp/target/universal-ios-sim/release/libbitwarden_uniffi.dylib
+lipo -create ../../target/aarch64-apple-ios-sim/release/libbitwarden_uniffi.a \
+  ../../target/x86_64-apple-ios/release/libbitwarden_uniffi.a \
+  -output ./tmp/target/universal-ios-sim/release/libbitwarden_uniffi.a
 
 # Generate swift bindings
 cargo run -p uniffi-bindgen generate \
@@ -39,9 +39,9 @@ cat ./tmp/bindings/BitwardenFFI.modulemap ./tmp/bindings/BitwardenCoreFFI.module
 
 # Build xcframework
 xcodebuild -create-xcframework \
-  -library ../../target/aarch64-apple-ios/release/libbitwarden_uniffi.dylib \
+  -library ../../target/aarch64-apple-ios/release/libbitwarden_uniffi.a \
   -headers ./tmp/Headers \
-  -library ./tmp/target/universal-ios-sim/release/libbitwarden_uniffi.dylib \
+  -library ./tmp/target/universal-ios-sim/release/libbitwarden_uniffi.a \
   -headers ./tmp/Headers \
   -output ./BitwardenFFI.xcframework
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Running an iOS app linked against the SDK on a device results in a crash because the dynamic library can't be found.

> dyld[11647]: Library not loaded: libbitwarden_uniffi.dylib

In looking through the Apple docs, I found the following:

> Avoid using dynamic library files (.dylib files) for dynamic linking. An XCFramework can include dynamic library files, but only macOS supports these libraries for dynamic linking. Dynamic linking on iOS, watchOS, and tvOS requires the XCFramework to contain .framework bundles.

> For each library and each platform, build a binary static libary file (.a file) that includes slices for all the possible architectures the platform uses.

https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle#Avoid-issues-when-using-alternate-build-systems

This updates the build script to build the framework with static libraries instead. I've tested on a device and it seems to be working.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **build.sh:** Updates the script to use static libraries when building the XCFramework.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
