### PR TITLE
[SM-938] Change secrets manager to use proper dates

### DIFF
--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Chrono(#[from] chrono::ParseError),
 
     #[error("Received error message from server: [{}] {}", .status, .message)]
     ResponseContent { status: StatusCode, message: String },
@@ -92,16 +94,6 @@ pub enum EncStringParseError {
     InvalidBase64(#[from] base64::DecodeError),
     #[error("Invalid length: expected {expected}, got {got}")]
     InvalidLength { expected: usize, got: usize },
-}
-
-impl From<chrono::ParseError> for Error {
-    fn from(e: chrono::ParseError) -> Self {
-        Self::Internal(string_to_static_str(e.to_string()))
-    }
-}
-
-fn string_to_static_str(s: String) -> &'static str {
-    Box::leak(s.into_boxed_str())
 }
 
 // Ensure that the error messages implement Send and Sync

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -94,6 +94,16 @@ pub enum EncStringParseError {
     InvalidLength { expected: usize, got: usize },
 }
 
+impl From<chrono::ParseError> for Error {
+    fn from(e: chrono::ParseError) -> Self {
+        Self::Internal(string_to_static_str(e.to_string()))
+    }
+}
+
+fn string_to_static_str(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
 // Ensure that the error messages implement Send and Sync
 #[cfg(test)]
 const _: () = {

--- a/crates/bitwarden/src/secrets_manager/projects/project_response.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/project_response.rs
@@ -1,4 +1,5 @@
 use bitwarden_api_api::models::ProjectResponseModel;
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -7,17 +8,17 @@ use crate::{
     client::encryption_settings::EncryptionSettings,
     crypto::{Decryptable, EncString},
     error::{Error, Result},
+    util::parse_date,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectResponse {
-    pub object: String,
     pub id: Uuid,
     pub organization_id: Uuid,
     pub name: String,
-    pub creation_date: String,
-    pub revision_date: String,
+    pub creation_date: DateTime<Utc>,
+    pub revision_date: DateTime<Utc>,
 }
 
 impl ProjectResponse {
@@ -34,14 +35,12 @@ impl ProjectResponse {
             .decrypt(enc, &Some(organization_id))?;
 
         Ok(ProjectResponse {
-            object: "project".to_owned(),
-
             id: response.id.ok_or(Error::MissingFields)?,
             organization_id,
             name,
 
-            creation_date: response.creation_date.ok_or(Error::MissingFields)?,
-            revision_date: response.revision_date.ok_or(Error::MissingFields)?,
+            creation_date: parse_date(&response.creation_date.ok_or(Error::MissingFields)?)?,
+            revision_date: parse_date(&response.revision_date.ok_or(Error::MissingFields)?)?,
         })
     }
 }

--- a/crates/bitwarden/src/secrets_manager/projects/project_response.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/project_response.rs
@@ -8,7 +8,6 @@ use crate::{
     client::encryption_settings::EncryptionSettings,
     crypto::{Decryptable, EncString},
     error::{Error, Result},
-    util::parse_date,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -39,8 +38,14 @@ impl ProjectResponse {
             organization_id,
             name,
 
-            creation_date: parse_date(&response.creation_date.ok_or(Error::MissingFields)?)?,
-            revision_date: parse_date(&response.revision_date.ok_or(Error::MissingFields)?)?,
+            creation_date: response
+                .creation_date
+                .ok_or(Error::MissingFields)?
+                .parse()?,
+            revision_date: response
+                .revision_date
+                .ok_or(Error::MissingFields)?
+                .parse()?,
         })
     }
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/secret_response.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/secret_response.rs
@@ -10,7 +10,6 @@ use crate::{
     client::encryption_settings::EncryptionSettings,
     crypto::{Decryptable, EncString},
     error::{Error, Result},
-    util::parse_date,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -81,8 +80,14 @@ impl SecretResponse {
             value,
             note,
 
-            creation_date: parse_date(&response.creation_date.ok_or(Error::MissingFields)?)?,
-            revision_date: parse_date(&response.revision_date.ok_or(Error::MissingFields)?)?,
+            creation_date: response
+                .creation_date
+                .ok_or(Error::MissingFields)?
+                .parse()?,
+            revision_date: response
+                .revision_date
+                .ok_or(Error::MissingFields)?
+                .parse()?,
         })
     }
 }

--- a/crates/bitwarden/src/secrets_manager/secrets/secret_response.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/secret_response.rs
@@ -1,6 +1,7 @@
 use bitwarden_api_api::models::{
     BaseSecretResponseModel, BaseSecretResponseModelListResponseModel, SecretResponseModel,
 };
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -9,12 +10,12 @@ use crate::{
     client::encryption_settings::EncryptionSettings,
     crypto::{Decryptable, EncString},
     error::{Error, Result},
+    util::parse_date,
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretResponse {
-    pub object: String,
     pub id: Uuid,
     pub organization_id: Uuid,
     pub project_id: Option<Uuid>,
@@ -23,8 +24,8 @@ pub struct SecretResponse {
     pub value: String,
     pub note: String,
 
-    pub creation_date: String,
-    pub revision_date: String,
+    pub creation_date: DateTime<Utc>,
+    pub revision_date: DateTime<Utc>,
 }
 
 impl SecretResponse {
@@ -73,7 +74,6 @@ impl SecretResponse {
             .and_then(|p| p.id);
 
         Ok(SecretResponse {
-            object: "secret".to_owned(),
             id: response.id.ok_or(Error::MissingFields)?,
             organization_id: org_id.ok_or(Error::MissingFields)?,
             project_id: project,
@@ -81,8 +81,8 @@ impl SecretResponse {
             value,
             note,
 
-            creation_date: response.creation_date.ok_or(Error::MissingFields)?,
-            revision_date: response.revision_date.ok_or(Error::MissingFields)?,
+            creation_date: parse_date(&response.creation_date.ok_or(Error::MissingFields)?)?,
+            revision_date: parse_date(&response.revision_date.ok_or(Error::MissingFields)?)?,
         })
     }
 }

--- a/crates/bitwarden/src/util.rs
+++ b/crates/bitwarden/src/util.rs
@@ -5,6 +5,7 @@ use base64::{
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
+use chrono::{DateTime, Utc};
 
 use crate::error::Result;
 
@@ -48,6 +49,11 @@ pub fn decode_token(token: &str) -> Result<JWTToken> {
     }
     let decoded = BASE64_ENGINE.decode(split[1])?;
     Ok(serde_json::from_slice(&decoded)?)
+}
+
+/// Parse a date in RFC3339 format
+pub(crate) fn parse_date(date: &str) -> Result<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(date)?.with_timezone(&Utc))
 }
 
 #[cfg(test)]

--- a/crates/bitwarden/src/util.rs
+++ b/crates/bitwarden/src/util.rs
@@ -5,7 +5,6 @@ use base64::{
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
-use chrono::{DateTime, Utc};
 
 use crate::error::Result;
 
@@ -49,11 +48,6 @@ pub fn decode_token(token: &str) -> Result<JWTToken> {
     }
     let decoded = BASE64_ENGINE.decode(split[1])?;
     Ok(serde_json::from_slice(&decoded)?)
-}
-
-/// Parse a date in RFC3339 format
-pub(crate) fn parse_date(date: &str) -> Result<DateTime<Utc>> {
-    Ok(DateTime::parse_from_rfc3339(date)?.with_timezone(&Utc))
 }
 
 #[cfg(test)]

--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -1,5 +1,5 @@
 use bitwarden::secrets_manager::{projects::ProjectResponse, secrets::SecretResponse};
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use comfy_table::Table;
 use serde::Serialize;
@@ -105,11 +105,8 @@ impl<T: TableSerialize<N>, const N: usize> TableSerialize<N> for Vec<T> {
     }
 }
 
-fn format_date(date: &str) -> String {
-    DateTime::parse_from_rfc3339(date)
-        .unwrap()
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string()
+fn format_date(date: &DateTime<Utc>) -> String {
+    date.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
 impl TableSerialize<3> for ProjectResponse {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Secrets Manager objects are still using strings for date objects. Change to proper dates.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
