### PR TITLE
Fix encryption model optionals

### DIFF
--- a/crates/bitwarden/src/vault/cipher/cipher.rs
+++ b/crates/bitwarden/src/vault/cipher/cipher.rs
@@ -59,9 +59,9 @@ pub struct Cipher {
     pub view_password: bool,
     pub local_data: Option<LocalData>,
 
-    pub attachments: Vec<attachment::Attachment>,
-    pub fields: Vec<field::Field>,
-    pub password_history: Vec<password_history::PasswordHistory>,
+    pub attachments: Option<Vec<attachment::Attachment>>,
+    pub fields: Option<Vec<field::Field>>,
+    pub password_history: Option<Vec<password_history::PasswordHistory>>,
 
     pub creation_date: DateTime<Utc>,
     pub deleted_date: Option<DateTime<Utc>>,
@@ -93,9 +93,9 @@ pub struct CipherView {
     pub view_password: bool,
     pub local_data: Option<LocalDataView>,
 
-    pub attachments: Vec<attachment::AttachmentView>,
-    pub fields: Vec<field::FieldView>,
-    pub password_history: Vec<password_history::PasswordHistoryView>,
+    pub attachments: Option<Vec<attachment::AttachmentView>>,
+    pub fields: Option<Vec<field::FieldView>>,
+    pub password_history: Option<Vec<password_history::PasswordHistoryView>>,
 
     pub creation_date: DateTime<Utc>,
     pub deleted_date: Option<DateTime<Utc>>,
@@ -202,7 +202,7 @@ impl Cipher {
                 let Some(login) = &self.login else {
                     return Ok(String::new());
                 };
-                login.username.decrypt(enc, org_id).unwrap_or_default()
+                login.username.decrypt(enc, org_id)?.unwrap_or_default()
             }
             CipherType::SecureNote => String::new(),
             CipherType::Card => {
@@ -273,7 +273,11 @@ impl Decryptable<CipherListView> for Cipher {
             reprompt: self.reprompt,
             edit: self.edit,
             view_password: self.view_password,
-            attachments: self.attachments.len() as u32,
+            attachments: self
+                .attachments
+                .as_ref()
+                .map(|a| a.len() as u32)
+                .unwrap_or(0),
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,

--- a/crates/bitwarden/src/vault/cipher/field.rs
+++ b/crates/bitwarden/src/vault/cipher/field.rs
@@ -24,8 +24,8 @@ pub enum FieldType {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct Field {
-    name: EncString,
-    value: EncString,
+    name: Option<EncString>,
+    value: Option<EncString>,
     r#type: FieldType,
 
     linked_id: Option<LinkedIdType>,
@@ -35,8 +35,8 @@ pub struct Field {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct FieldView {
-    name: String,
-    value: String,
+    name: Option<String>,
+    value: Option<String>,
     r#type: FieldType,
 
     linked_id: Option<LinkedIdType>,

--- a/crates/bitwarden/src/vault/cipher/login.rs
+++ b/crates/bitwarden/src/vault/cipher/login.rs
@@ -27,7 +27,7 @@ pub enum UriMatchType {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct LoginUri {
-    pub uri: EncString,
+    pub uri: Option<EncString>,
     pub r#match: Option<UriMatchType>,
 }
 
@@ -35,7 +35,7 @@ pub struct LoginUri {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct LoginUriView {
-    pub uri: String,
+    pub uri: Option<String>,
     pub r#match: Option<UriMatchType>,
 }
 
@@ -43,11 +43,11 @@ pub struct LoginUriView {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct Login {
-    pub username: EncString,
-    pub password: EncString,
+    pub username: Option<EncString>,
+    pub password: Option<EncString>,
     pub password_revision_date: Option<DateTime<Utc>>,
 
-    pub uris: Vec<LoginUri>,
+    pub uris: Option<Vec<LoginUri>>,
     pub totp: Option<EncString>,
     pub autofill_on_page_load: Option<bool>,
 }
@@ -56,11 +56,11 @@ pub struct Login {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct LoginView {
-    pub username: String,
-    pub password: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
     pub password_revision_date: Option<DateTime<Utc>>,
 
-    pub uris: Vec<LoginUriView>,
+    pub uris: Option<Vec<LoginUriView>>,
     pub totp: Option<String>,
     pub autofill_on_page_load: Option<bool>,
 }

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -36,7 +36,7 @@ pub struct SendFileView {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct SendText {
-    pub text: EncString,
+    pub text: Option<EncString>,
     pub hidden: bool,
 }
 
@@ -44,7 +44,7 @@ pub struct SendText {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct SendTextView {
-    pub text: String,
+    pub text: Option<String>,
     pub hidden: bool,
 }
 


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Some of the fields in the encryption models were incorrectly marked as non-optional, when in reality null values can be valid. I've marked these as Optional instead