### PR TITLE
Fix new doc warning

### DIFF
--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! # Basic setup
 //!
-//! All operations in this crate are done via a [Client](crate::client::Client):
+//! All operations in this crate are done via a [Client]:
 //!
 //! ```rust
 //! use bitwarden::{


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix new doc warning that started appearing, I assume because the new Rust update

https://github.com/bitwarden/sdk/actions/runs/6433340114/job/17470205155?pr=203
![image](https://github.com/bitwarden/sdk/assets/725423/8357def8-20ec-41ff-95b5-297765981398)
