### PR TITLE
Enable AES optimization in ARMv8

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_arch="aarch64")']
+rustflags = ["--cfg", "aes_armv8"]


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
Enable the ARMv8 Cryptographic Extensions, for a performance increase in our encryption operations (https://docs.rs/aes/latest/aes/#armv8-intrinsics-rust-161)

Enabling this requires using Rust 1.61, but I just realized that the changes in the `config.toml` would only apply to anyone building the SDK from source and not to anyone using it from crates.io. Seeing as we're using the latest stable when building ourselves, this seems okay.
