### PR TITLE
Lock SDK to 6.0.100 and ignore with Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,10 +44,7 @@
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "matchPackageNames": ["dotnet-sdk"],
-      "enabled": false
     }
-  ]
+  ],
+  "ignoreDeps": ["dotnet-sdk"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,6 +44,10 @@
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchPackageNames": ["dotnet-sdk"],
+      "enabled": false
     }
   ]
 }

--- a/languages/csharp/global.json
+++ b/languages/csharp/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.413",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Disable renovate from bumping the dotnet-sdk. We have prefer latest which should be sufficient.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
