### PR TITLE
Fix make_user_key which previously didn't stretch the users key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "num-traits",
  "pbkdf2",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "reqwest",
  "rsa",
  "schemars",

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -59,5 +59,6 @@ bitwarden-api-identity = { path = "../bitwarden-api-identity", version = "=0.2.2
 bitwarden-api-api = { path = "../bitwarden-api-api", version = "=0.2.2" }
 
 [dev-dependencies]
+rand_chacha = "0.3.1"
 tokio = { version = "1.28.2", features = ["rt", "macros"] }
 wiremock = "0.5.18"

--- a/crates/bitwarden/src/auth/register.rs
+++ b/crates/bitwarden/src/auth/register.rs
@@ -79,7 +79,7 @@ pub(super) fn make_register_keys(
 
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct RegisterKeyResponse {
-    master_password_hash: String,
-    encrypted_user_key: String,
-    keys: RsaKeyPair,
+    pub master_password_hash: String,
+    pub encrypted_user_key: String,
+    pub keys: RsaKeyPair,
 }

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -288,9 +288,14 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use wiremock::{matchers, Mock, ResponseTemplate};
 
-    use crate::{auth::login::AccessTokenLoginRequest, secrets_manager::secrets::*};
+    use crate::{
+        auth::login::AccessTokenLoginRequest, client::kdf::Kdf, mobile::crypto::InitCryptoRequest,
+        secrets_manager::secrets::*, Client,
+    };
 
     #[tokio::test]
     async fn test_access_token_login() {
@@ -378,5 +383,35 @@ mod tests {
         assert_eq!(res.key, "TEST");
         assert_eq!(res.note, "TEST");
         assert_eq!(res.value, "TEST");
+    }
+
+    #[cfg(feature = "internal")]
+    #[tokio::test]
+    async fn test_register_initialize_crypto() {
+        let mut client = Client::new(None);
+
+        let email = "test@bitwarden.com";
+        let password = "test123";
+        let kdf = Kdf::PBKDF2 {
+            iterations: NonZeroU32::new(600_000).unwrap(),
+        };
+
+        let register_response = client
+            .auth()
+            .make_register_keys(email.to_owned(), password.to_owned(), kdf.clone())
+            .unwrap();
+
+        client
+            .crypto()
+            .initialize_crypto(InitCryptoRequest {
+                kdf_params: kdf,
+                email: email.to_owned(),
+                password: password.to_owned(),
+                user_key: register_response.encrypted_user_key,
+                private_key: register_response.keys.private.to_string(),
+                organization_keys: Default::default(),
+            })
+            .await
+            .unwrap();
     }
 }

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -4,8 +4,8 @@ use rand::Rng;
 use sha2::Digest;
 
 use super::{
-    encrypt_aes256, hkdf_expand, EncString, KeyDecryptable, PbkdfSha256Hmac, SymmetricCryptoKey,
-    UserKey, PBKDF_SHA256_HMAC_OUT_SIZE,
+    encrypt_aes256_hmac, hkdf_expand, EncString, KeyDecryptable, PbkdfSha256Hmac,
+    SymmetricCryptoKey, UserKey, PBKDF_SHA256_HMAC_OUT_SIZE,
 };
 use crate::{client::kdf::Kdf, error::Result, util::BASE64_ENGINE};
 
@@ -44,7 +44,9 @@ impl MasterKey {
         let mut user_key = [0u8; 64];
         rand::thread_rng().fill(&mut user_key);
 
-        let protected = encrypt_aes256(&user_key, self.0.key)?;
+        let stretched_key = stretch_master_key(self)?;
+        let protected =
+            encrypt_aes256_hmac(&user_key, stretched_key.mac_key.unwrap(), stretched_key.key)?;
 
         let u: &[u8] = &user_key;
         Ok((UserKey::new(SymmetricCryptoKey::try_from(u)?), protected))

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -122,7 +122,7 @@ fn stretch_master_key(master_key: &MasterKey) -> Result<SymmetricCryptoKey> {
 mod tests {
     use std::num::NonZeroU32;
 
-    use rand::rngs::mock::StepRng;
+    use rand::SeedableRng;
 
     use super::{make_user_key, stretch_master_key, HashPurpose, MasterKey};
     use crate::{client::kdf::Kdf, crypto::SymmetricCryptoKey};
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_make_user_key() {
-        let mut rng = StepRng::new(2, 1);
+        let mut rng = rand_chacha::ChaCha8Rng::from_seed([0u8; 32]);
 
         let master_key = MasterKey(SymmetricCryptoKey {
             key: [
@@ -256,15 +256,15 @@ mod tests {
         assert_eq!(
             user_key.0.key.as_slice(),
             [
-                2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0,
-                0, 0, 0, 0
+                62, 0, 239, 47, 137, 95, 64, 214, 127, 91, 184, 232, 31, 9, 165, 161, 44, 132, 14,
+                195, 206, 154, 127, 59, 24, 27, 225, 136, 239, 113, 26, 30
             ]
         );
         assert_eq!(
             user_key.0.mac_key.unwrap().as_slice(),
             [
-                6, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0,
-                0, 0, 0, 0
+                152, 76, 225, 114, 185, 33, 111, 65, 159, 68, 83, 103, 69, 109, 86, 25, 49, 74, 66,
+                163, 218, 134, 176, 1, 56, 123, 253, 184, 14, 12, 254, 66
             ]
         );
 

--- a/crates/bitwarden/src/crypto/user_key.rs
+++ b/crates/bitwarden/src/crypto/user_key.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Result,
 };
 
-pub(crate) struct UserKey(SymmetricCryptoKey);
+pub(crate) struct UserKey(pub(super) SymmetricCryptoKey);
 
 impl UserKey {
     pub(crate) fn new(key: SymmetricCryptoKey) -> Self {

--- a/crates/bitwarden/tests/register.rs
+++ b/crates/bitwarden/tests/register.rs
@@ -1,0 +1,35 @@
+/// Integration test for registering a new user and unlocking the vault
+#[cfg(feature = "mobile")]
+#[tokio::test]
+async fn test_register_initialize_crypto() {
+    use std::num::NonZeroU32;
+
+    use bitwarden::{client::kdf::Kdf, mobile::crypto::InitCryptoRequest, Client};
+
+    let mut client = Client::new(None);
+
+    let email = "test@bitwarden.com";
+    let password = "test123";
+    let kdf = Kdf::PBKDF2 {
+        iterations: NonZeroU32::new(600_000).unwrap(),
+    };
+
+    let register_response = client
+        .auth()
+        .make_register_keys(email.to_owned(), password.to_owned(), kdf.clone())
+        .unwrap();
+
+    // Ensure we can initialize the crypto with the new keys
+    client
+        .crypto()
+        .initialize_crypto(InitCryptoRequest {
+            kdf_params: kdf,
+            email: email.to_owned(),
+            password: password.to_owned(),
+            user_key: register_response.encrypted_user_key,
+            private_key: register_response.keys.private.to_string(),
+            organization_keys: Default::default(),
+        })
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The `make_user_key` needs to use the same key as `decrypt_user_key`, which should be the stretched users key.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
