### PR TITLE
[BEEEP] SM-1005 - Add env output option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "env_logger",
  "log",
  "openssl",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["rt-multi-thread", "macros"] }
 toml = "0.8.0"
 uuid = { version = "^1.3.3", features = ["serde"] }
+regex = { version = "1.10.2", features=["std", "perf"], default-features=false }
 
 bitwarden = { path = "../bitwarden", version = "0.3.1", features = ["secrets"] }
 

--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -62,7 +62,7 @@ pub(crate) fn serialize_response<T: Serialize + TableSerialize<N>, const N: usiz
                         format!("{}=\"{}\"", row[1], row[2])
                     } else {
                         commented_out = true;
-                        format!("# {}=\"{}\"", row[1], row[2].replace("\n", "\n# "))
+                        format!("# {}=\"{}\"", row[1], row[2].replace('\n', "\n# "))
                     }
                 })
                 .collect();

--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -51,16 +51,14 @@ pub(crate) fn serialize_response<T: Serialize + TableSerialize<N>, const N: usiz
             pretty_print("yaml", &text, color);
         }
         Output::Env => {
+            let valid_key_regex = regex::Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
+
             let mut commented_out = false;
             let mut text: Vec<String> = data
                 .get_values()
                 .into_iter()
                 .map(|row| {
-                    if row[1]
-                        .chars()
-                        .all(|c| c.is_ascii_alphanumeric() || c == '_')
-                        && !row[1].chars().next().unwrap().is_digit(10)
-                    {
+                    if valid_key_regex.is_match(&row[1]) {
                         format!("{}=\"{}\"", row[1], row[2])
                     } else {
                         commented_out = true;

--- a/crates/bws/src/render.rs
+++ b/crates/bws/src/render.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 pub(crate) enum Output {
     JSON,
     YAML,
+    Env,
     Table,
     TSV,
     None,
@@ -48,6 +49,14 @@ pub(crate) fn serialize_response<T: Serialize + TableSerialize<N>, const N: usiz
         Output::YAML => {
             let text = serde_yaml::to_string(&data).unwrap();
             pretty_print("yaml", &text, color);
+        }
+        Output::Env => {
+            let text: Vec<String> = data
+                .get_values()
+                .into_iter()
+                .map(|row| format!("{}=\"{}\"", row[1], row[2]))
+                .collect();
+            println!("{}", text.join("\n"));
         }
         Output::Table => {
             let mut table = Table::new();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add an env output option to `bws`. This allows for easier command-line usage in scripts, particularly where a JSON or YAML parser is not desirable or available.

Basic usage examples in Bash:

- `source <(bws secret get ec9e0489-244e-4b3f-8782-b0a800fe562f -o env)`
- `bws secret list -o env > .env`

## Code changes

- **`crates/bws/src/render.rs`:** Output secrets in `key="value"` format

## Screenshots

![image](https://github.com/bitwarden/sdk/assets/5676771/72201357-dc4c-471e-b1f0-011297dbb978)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
