### PR TITLE
Exclude snapshots from the GH artifact cleanup job

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -22,4 +22,4 @@ jobs:
           min-versions-to-keep: 25
 
           # Ignore versions only containing version numbers
-          ignore-versions: '^\\d*\\.\\d*\\.\\d*$'
+          ignore-versions: '^\\d*\\.\\d*\\.\\d*(-SNAPSHOT)?$'


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

GitHub packages doesn't update the date on snapshots, this caused our cleanup script to cleanup a snapshot version in use.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
