### PR TITLE
Update public modules to get correct documentation

### DIFF
--- a/crates/bitwarden/src/crypto/aes_ops.rs
+++ b/crates/bitwarden/src/crypto/aes_ops.rs
@@ -62,6 +62,7 @@ pub fn decrypt_aes256_hmac(
 /// ## Returns
 ///
 /// A AesCbc256_B64 EncString
+#[allow(unused)]
 pub fn encrypt_aes256(data_dec: &[u8], key: GenericArray<u8, U32>) -> Result<EncString> {
     let (iv, data) = encrypt_aes256_internal(data_dec, key);
 

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -33,7 +33,7 @@ pub use encryptable::{Decryptable, Encryptable, LocateKey};
 mod key_encryptable;
 pub use key_encryptable::{KeyDecryptable, KeyEncryptable};
 mod aes_ops;
-pub use aes_ops::{decrypt_aes256, decrypt_aes256_hmac, encrypt_aes256, encrypt_aes256_hmac};
+use aes_ops::{decrypt_aes256_hmac, encrypt_aes256_hmac};
 mod symmetric_crypto_key;
 pub use symmetric_crypto_key::SymmetricCryptoKey;
 mod shareable_key;

--- a/crates/bitwarden/src/mobile/mod.rs
+++ b/crates/bitwarden/src/mobile/mod.rs
@@ -3,8 +3,11 @@ pub mod crypto;
 pub mod kdf;
 pub mod vault;
 
-pub(crate) mod client_crypto;
-pub(crate) mod client_kdf;
+mod client_crypto;
+mod client_kdf;
+
+pub use client_crypto::ClientCrypto;
+pub use client_kdf::ClientKdf;
 
 // Usually we wouldn't want to expose EncStrings in the API or the schemas,
 // but we need them in the mobile API, so define it here to limit the scope

--- a/crates/bitwarden/src/mobile/vault/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/mod.rs
@@ -5,3 +5,10 @@ mod client_password_history;
 mod client_sends;
 mod client_totp;
 mod client_vault;
+
+pub use client_ciphers::ClientCiphers;
+pub use client_collection::ClientCollections;
+pub use client_folders::ClientFolders;
+pub use client_password_history::ClientPasswordHistory;
+pub use client_sends::ClientSends;
+pub use client_vault::ClientVault;

--- a/crates/bitwarden/src/secrets_manager/mod.rs
+++ b/crates/bitwarden/src/secrets_manager/mod.rs
@@ -3,3 +3,6 @@ pub mod secrets;
 
 mod client_projects;
 mod client_secrets;
+
+pub use client_projects::ClientProjects;
+pub use client_secrets::ClientSecrets;

--- a/crates/bitwarden/src/tool/exporters/mod.rs
+++ b/crates/bitwarden/src/tool/exporters/mod.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 mod client_exporter;
+pub use client_exporter::ClientExporters;
 
 #[derive(JsonSchema)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Enum))]

--- a/crates/bitwarden/src/tool/generators/mod.rs
+++ b/crates/bitwarden/src/tool/generators/mod.rs
@@ -1,4 +1,5 @@
 mod client_generator;
 mod password;
 
+pub use client_generator::ClientGenerator;
 pub use password::{PassphraseGeneratorRequest, PasswordGeneratorRequest};

--- a/crates/bitwarden/src/tool/mod.rs
+++ b/crates/bitwarden/src/tool/mod.rs
@@ -1,5 +1,5 @@
 mod exporters;
 mod generators;
 
-pub use exporters::ExportFormat;
-pub use generators::{PassphraseGeneratorRequest, PasswordGeneratorRequest};
+pub use exporters::{ClientExporters, ExportFormat};
+pub use generators::{ClientGenerator, PassphraseGeneratorRequest, PasswordGeneratorRequest};


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
All the functions in `Client` that return `Client*` were inside private modules, which make them accessible for use, but `cargo doc` will not document them. By making them public, the cargo docs generate the correct documentation.

Also made `aes_ops` private as it's not used outside the crypto module anymore.
