### PR TITLE
Fix Python package case

### DIFF
--- a/languages/python/setup.py
+++ b/languages/python/setup.py
@@ -9,4 +9,10 @@ setup(
         "bitwarden_py", path="../../crates/bitwarden-py/Cargo.toml", binding=Binding.PyO3)],
     packages=['BitwardenClient'],
     zip_safe=False,
+    install_requires=[
+        'setuptools',
+        'setuptools_rust',
+        'dateutils',
+        'wheel',
+    ],
 )

--- a/languages/python/setup.py
+++ b/languages/python/setup.py
@@ -7,6 +7,6 @@ setup(
     version="0.1",
     rust_extensions=[RustExtension(
         "bitwarden_py", path="../../crates/bitwarden-py/Cargo.toml", binding=Binding.PyO3)],
-    packages=['bitwardenclient'],
+    packages=['BitwardenClient'],
     zip_safe=False,
 )


### PR DESCRIPTION
Resolves issue with running `python ./setup.py develop` on Linux, where the package name is case-sensitive.

```bash
(.venv) [fedora@fedora python]$ python ./setup.py develop
running develop
/home/fedora/Documents/sdk/languages/python/.venv/lib64/python3.11/site-packages/setuptools/command/easy_install.py:144: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/home/fedora/Documents/sdk/languages/python/.venv/lib64/python3.11/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running egg_info
creating BitwardenClient.egg-info
writing BitwardenClient.egg-info/PKG-INFO
writing dependency_links to BitwardenClient.egg-info/dependency_links.txt
writing top-level names to BitwardenClient.egg-info/top_level.txt
writing manifest file 'BitwardenClient.egg-info/SOURCES.txt'
error: package directory 'bitwardenclient' does not exist
```

The package spec looks for a `bitwardenclient` directory, which does not exist.

## Type of change

<!-- (mark with an `X`) -->

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

- **`languages/python/setup.py`:** Use case-sensitive and correct name for the BitwardenClient Python package

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
