### PR TITLE
AES tests

### DIFF
--- a/crates/bitwarden/src/crypto/enc_string.rs
+++ b/crates/bitwarden/src/crypto/enc_string.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
+use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::Engine;
 use serde::{de::Visitor, Deserialize};
 
@@ -331,6 +332,20 @@ impl serde::Serialize for EncString {
 }
 
 impl EncString {
+    pub(crate) fn encrypt_aes256_hmac(
+        data_dec: &[u8],
+        mac_key: GenericArray<u8, U32>,
+        key: GenericArray<u8, U32>,
+    ) -> Result<EncString> {
+        let enc = super::encrypt_aes256_hmac(data_dec, mac_key, key)?;
+
+        Ok(EncString::AesCbc256_HmacSha256_B64 {
+            iv: enc.0,
+            mac: enc.1,
+            data: enc.2,
+        })
+    }
+
     /// The numerical representation of the encryption type of the [EncString].
     const fn enc_type(&self) -> u8 {
         match self {
@@ -357,7 +372,7 @@ fn invalid_len_error(expected: usize) -> impl Fn(Vec<u8>) -> EncStringParseError
 impl LocateKey for EncString {}
 impl KeyEncryptable<EncString> for &[u8] {
     fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<EncString> {
-        super::encrypt_aes256_hmac(self, key.mac_key.ok_or(CryptoError::InvalidMac)?, key.key)
+        EncString::encrypt_aes256_hmac(self, key.mac_key.ok_or(CryptoError::InvalidMac)?, key.key)
     }
 }
 

--- a/crates/bitwarden/src/crypto/enc_string.rs
+++ b/crates/bitwarden/src/crypto/enc_string.rs
@@ -337,13 +337,8 @@ impl EncString {
         mac_key: GenericArray<u8, U32>,
         key: GenericArray<u8, U32>,
     ) -> Result<EncString> {
-        let enc = super::encrypt_aes256_hmac(data_dec, mac_key, key)?;
-
-        Ok(EncString::AesCbc256_HmacSha256_B64 {
-            iv: enc.0,
-            mac: enc.1,
-            data: enc.2,
-        })
+        let (iv, mac, data) = super::encrypt_aes256_hmac(data_dec, mac_key, key)?;
+        Ok(EncString::AesCbc256_HmacSha256_B64 { iv, mac, data })
     }
 
     /// The numerical representation of the encryption type of the [EncString].

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -4,8 +4,8 @@ use rand::Rng;
 use sha2::Digest;
 
 use super::{
-    encrypt_aes256_hmac, hkdf_expand, EncString, KeyDecryptable, PbkdfSha256Hmac,
-    SymmetricCryptoKey, UserKey, PBKDF_SHA256_HMAC_OUT_SIZE,
+    hkdf_expand, EncString, KeyDecryptable, PbkdfSha256Hmac, SymmetricCryptoKey, UserKey,
+    PBKDF_SHA256_HMAC_OUT_SIZE,
 };
 use crate::{client::kdf::Kdf, error::Result, util::BASE64_ENGINE};
 
@@ -61,8 +61,11 @@ fn make_user_key(
     rng.fill(&mut user_key);
 
     let stretched_key = stretch_master_key(master_key)?;
-    let protected =
-        encrypt_aes256_hmac(&user_key, stretched_key.mac_key.unwrap(), stretched_key.key)?;
+    let protected = EncString::encrypt_aes256_hmac(
+        &user_key,
+        stretched_key.mac_key.unwrap(),
+        stretched_key.key,
+    )?;
 
     let u: &[u8] = &user_key;
     Ok((UserKey::new(SymmetricCryptoKey::try_from(u)?), protected))

--- a/crates/bitwarden/src/crypto/rsa.rs
+++ b/crates/bitwarden/src/crypto/rsa.rs
@@ -5,7 +5,7 @@ use rsa::{
 };
 
 use crate::{
-    crypto::{encrypt_aes256_hmac, EncString, SymmetricCryptoKey},
+    crypto::{EncString, SymmetricCryptoKey},
     error::{Error, Result},
     util::BASE64_ENGINE,
 };
@@ -33,7 +33,7 @@ pub(super) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
         .to_pkcs8_der()
         .map_err(|_| Error::Internal("unable to create private key"))?;
 
-    let protected = encrypt_aes256_hmac(pkcs.as_bytes(), key.mac_key.unwrap(), key.key)?;
+    let protected = EncString::encrypt_aes256_hmac(pkcs.as_bytes(), key.mac_key.unwrap(), key.key)?;
 
     Ok(RsaKeyPair {
         public: b64,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

An effort in making the AES operations lower level by removing the `EncString` concept from them. This makes them more easily testable and reusable.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **crates/bitwarden/src/crypto/aes_ops.rs:** Removed `EncString` and made the low level interfaces return slices and vectors directly. Mocked `rand` and wrote unit tests.
- **crates/bitwarden/src/crypto/enc_string.rs**: Added `EncString::encrypt_aes256_hmac` which behaves similar to `aes_ops::encrypt_aes256_hmac` except it returns an `EncString` instead of the primitives.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
