### PR TITLE
Generate better schema types

### DIFF
--- a/support/scripts/schemas.ts
+++ b/support/scripts/schemas.ts
@@ -22,22 +22,16 @@ async function* walk(dir: string): AsyncIterable<string> {
 
 async function main() {
   const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
-
-  const filenames: string[] = [];
-  for await (const p of walk("./support/schemas")) {
-    filenames.push(p);
-  }
-
-  filenames.sort();
-
-  for (const f of filenames) {
-    const buffer = fs.readFileSync(f);
-    const relative = path.relative(path.join(process.cwd(), "support/schemas"), f);
-    await schemaInput.addSource({ name: relative, schema: buffer.toString() });
-  }
-
   const inputData = new InputData();
   inputData.addInput(schemaInput);
+  inputData.addSource(
+    "schema",
+    {
+      name: "SchemaTypes",
+      uris: ["support/schemas/schema_types/SchemaTypes.json#/definitions/"],
+    },
+    () => new JSONSchemaInput(new FetchingJSONSchemaStore()),
+  );
 
   const ts = await quicktype({
     inputData,


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The `quicktype` schema generation seems to have trouble with types in schema files being referenced from other types in separate schema files, which created duplicate classes, with a lot of strange names.

Instead of generating one individual file for each response, we create a big struct with all the options. This seems to solve the issue of references between schema files, and so no duplicate classes are created.

Note that the way that the file is loaded in `quicktype` is different. By default, `quicktype` generates JSON conversion helper functions only for the root type, which would be the big struct `SchemaTypes`. By importing the file with `#/definitions/` appended, we only bring the sub schemas as root types, and ignore `SchemaTypes`, which we don't care about.

Examples of the schema changes, using C# as an example:
- `ProjectsResponse` previously contained an array of `DatumElement`, which were identical to `ProjectResponse`. Now it properly contains an array of `ProjectResponse`. This is also applicable to `SecretsResponse` which contained an array of `DatumClass`
- Previously it would generate multiple variants for `Argon2ID`, named: `FluffyArgon2Id` and `PurpleArgon2Id`, now there is only one `Argon2Id`. This is applicable to the two factor response types, which change in the same way

This is working correctly with the Java, Go, C++, PHP and Ruby bindings.