### PR TITLE
Support Rustls through cargo features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,7 +1693,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2558,6 +2572,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2568,17 +2583,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2595,6 +2614,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2634,6 +2667,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.5",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2729,6 +2793,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3010,6 +3084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -3624,6 +3714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,6 +3902,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "weedle2"

--- a/crates/bitwarden-api-api/Cargo.toml
+++ b/crates/bitwarden-api-api/Cargo.toml
@@ -22,5 +22,6 @@ uuid = { version = ">=1.3.3, <2", features = ["serde"] }
 [dependencies.reqwest]
 version = ">=0.11.18, <0.12"
 features = ["json", "multipart"]
+default-features = false
 
 [dev-dependencies]

--- a/crates/bitwarden-api-identity/Cargo.toml
+++ b/crates/bitwarden-api-identity/Cargo.toml
@@ -22,5 +22,6 @@ uuid = { version = ">=1.3.3, <2", features = ["serde"] }
 [dependencies.reqwest]
 version = ">=0.11.18, <0.12"
 features = ["json", "multipart"]
+default-features = false
 
 [dev-dependencies]

--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -14,8 +14,14 @@ edition = "2021"
 rust-version = "1.57"
 
 [features]
+default = ["use_native_tls"]
+
 internal = ["bitwarden/internal"] # Internal testing methods
 secrets = ["bitwarden/secrets"]   # Secrets manager API
+
+# TLS backend selection
+use_native_tls = ["bitwarden/use_native_tls"]
+use_rustls = ["bitwarden/use_rustls"]
 
 [dependencies]
 log = ">=0.4.18, <0.5"
@@ -23,4 +29,4 @@ schemars = ">=0.8.12, <0.9"
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 
-bitwarden = { path = "../bitwarden" }
+bitwarden = { path = "../bitwarden", default-features = false }

--- a/crates/bitwarden-py/Cargo.toml
+++ b/crates/bitwarden-py/Cargo.toml
@@ -12,7 +12,10 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.20.0", features = ["extension-module"] }
 pyo3-log = "0.9.0"
 
-bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
+bitwarden-json = { path = "../bitwarden-json", features = [
+    "secrets",
+    "use_rustls",
+], default-features = false }
 
 [build-dependencies]
 pyo3-build-config = { version = "0.20.0" }

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -13,11 +13,15 @@ edition = "2021"
 rust-version = "1.57"
 
 [features]
-default = ["secrets"]
+default = ["secrets", "use_native_tls"]
 
 secrets = []                    # Secrets manager API
 internal = []                   # Internal testing methods
 mobile = ["uniffi", "internal"] # Mobile-specific features
+
+# TLS backend selection
+use_native_tls = ["reqwest/native-tls"]
+use_rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 aes = ">=0.8.2, <0.9"
@@ -43,7 +47,9 @@ num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
 pbkdf2 = { version = ">=0.12.1, <0.13", default-features = false }
 rand = ">=0.8.5, <0.9"
-reqwest = { version = ">=0.11, <0.12", features = ["json"] }
+reqwest = { version = ">=0.11, <0.12", features = [
+    "json",
+], default-features = false }
 rsa = ">=0.9.2, <0.10"
 schemars = { version = ">=0.8, <0.9", features = ["uuid1", "chrono"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Created two cargo features: `use_native_tls` and `use_rustls` in bitwarden and bitwarden-json to allow TLS backend selection in all the crates. By default we use native-tls to keep the same backend we are using now, with the exception of bitwarden-py, which is using rustls to avoid issues with manylinux compatibility.

Another alternative can also be to remove these features, and just force downstream users (and our internal crates) to specifically declare the reqwest dependency with their preferred backend, though this might be a problem if we ever need to change to a different HTTP crate:
```toml
reqwest = {version = "*", features = ["rustls-tls"], default-features = false }
```

<br/>

It would be good to think which backend we're going to use for all the internal crates, too. I'm going to do some testing also on the mobile apps to see how both options fare.