### PR TITLE
Reduce the number of CI jobs that are run on PRs

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -1,7 +1,7 @@
 name: Build .NET SDK
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -1,7 +1,7 @@
 name: Build Java SDK
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -1,7 +1,7 @@
 name: Publish PHP SDK
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -1,7 +1,7 @@
 name: Publish Ruby SDK
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
With the recent addition of all the SDK language bindings, we've added a lot of CI jobs on PRs that are unnecessary and slow down builds. By switching them to run only on merge we should save some CI time.

Ultimately, we'd want some way to make it so that the `Build Rust Cross Platform` get only called once and reused for every language SDK, but for now this should help.