### PR TITLE
SM-1023: Remove Instant from Client in SDK

### DIFF
--- a/crates/bitwarden/src/auth/renew.rs
+++ b/crates/bitwarden/src/auth/renew.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use chrono::Utc;
 
 #[cfg(feature = "internal")]
 use crate::{auth::api::request::ApiTokenRequest, client::UserLoginMethod};
@@ -9,10 +9,10 @@ use crate::{
 };
 
 pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
-    const TOKEN_RENEW_MARGIN: Duration = Duration::from_secs(5 * 60);
+    const TOKEN_RENEW_MARGIN_SECONDS: i64 = 5 * 60;
 
     if let (Some(expires), Some(login_method)) = (&client.token_expires_in, &client.login_method) {
-        if expires > &(Instant::now() + TOKEN_RENEW_MARGIN) {
+        if Utc::now().timestamp() < expires - TOKEN_RENEW_MARGIN_SECONDS {
             return Ok(());
         }
 

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -1,5 +1,4 @@
-use std::time::{Duration, Instant};
-
+use chrono::Utc;
 use reqwest::header::{self};
 use uuid::Uuid;
 
@@ -69,7 +68,7 @@ pub(crate) enum ServiceAccountLoginMethod {
 pub struct Client {
     token: Option<String>,
     pub(crate) refresh_token: Option<String>,
-    pub(crate) token_expires_in: Option<Instant>,
+    pub(crate) token_expires_in: Option<i64>,
     pub(crate) login_method: Option<LoginMethod>,
 
     /// Use Client::get_api_configurations() to access this.
@@ -190,7 +189,7 @@ impl Client {
     ) {
         self.token = Some(token.clone());
         self.refresh_token = refresh_token;
-        self.token_expires_in = Some(Instant::now() + Duration::from_secs(expires_in));
+        self.token_expires_in = Some(Utc::now().timestamp() + expires_in as i64);
         self.login_method = Some(login_method);
         self.__api_configurations.identity.oauth_access_token = Some(token.clone());
         self.__api_configurations.api.oauth_access_token = Some(token);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Refactor out the `Instant` type in Client and use unix timestamps. This is to support this PR: https://github.com/bitwarden/sdk/pull/388 where we need to serialize token expiry times.

It also brings benefits to other areas like WASM, where `Instant` doesn't exist.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **crates/bitwarden/src/auth/renew.rs:** Update the `renew_token` function to use timestamps instead of the `Instant` type
- **crates/bitwarden/src/client/client.rs:** Update `Client` to store the unix timestamp for token expiration

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
