### PR TITLE
[PM-4930] Implement password validation

### DIFF
--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bitwarden::{
     auth::{password::MasterPasswordPolicyOptions, RegisterKeyResponse},
     client::kdf::Kdf,
+    crypto::HashPurpose,
 };
 
 use crate::{error::Result, Client};
@@ -50,6 +51,7 @@ impl ClientAuth {
         email: String,
         password: String,
         kdf_params: Kdf,
+        purpose: HashPurpose,
     ) -> Result<String> {
         Ok(self
             .0
@@ -57,7 +59,7 @@ impl ClientAuth {
             .read()
             .await
             .kdf()
-            .hash_password(email, password, kdf_params)
+            .hash_password(email, password, kdf_params, purpose)
             .await?)
     }
 
@@ -75,5 +77,17 @@ impl ClientAuth {
             .await
             .auth()
             .make_register_keys(email, password, kdf)?)
+    }
+
+    /// Validate the user password
+    pub async fn validate_password(&self, password: String) -> Result<bool> {
+        Ok(self
+            .0
+             .0
+            .write()
+            .await
+            .auth()
+            .validate_password(password, "".to_string())
+            .await?)
     }
 }

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -80,14 +80,18 @@ impl ClientAuth {
     }
 
     /// Validate the user password
-    pub async fn validate_password(&self, password: String) -> Result<bool> {
+    ///
+    /// To retrieve the user's password hash, use [`ClientAuth::hash_password`] with
+    /// `HashPurpose::LocalAuthentication` during login and persist it. If the login method has no
+    /// password, use the email OTP.
+    pub async fn validate_password(&self, password: String, password_hash: String) -> Result<bool> {
         Ok(self
             .0
              .0
             .write()
             .await
             .auth()
-            .validate_password(password, "".to_string())
+            .validate_password(password, password_hash.to_string())
             .await?)
     }
 }

--- a/crates/bitwarden-uniffi/src/docs.rs
+++ b/crates/bitwarden-uniffi/src/docs.rs
@@ -1,6 +1,7 @@
 use bitwarden::{
     auth::password::MasterPasswordPolicyOptions,
     client::kdf::Kdf,
+    crypto::HashPurpose,
     mobile::crypto::{InitOrgCryptoRequest, InitUserCryptoRequest},
     platform::FingerprintRequest,
     tool::{ExportFormat, PassphraseGeneratorRequest, PasswordGeneratorRequest},
@@ -27,6 +28,7 @@ pub enum DocRef {
     // Crypto
     InitUserCryptoRequest(InitUserCryptoRequest),
     InitOrgCryptoRequest(InitOrgCryptoRequest),
+    HashPurpose(HashPurpose),
 
     // Generators
     PasswordGeneratorRequest(PasswordGeneratorRequest),

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -93,8 +93,8 @@ impl<'a> ClientAuth<'a> {
         send_two_factor_email(self.client, tf).await
     }
 
-    pub async fn validate_password(&self, password: String, user_key: String) -> Result<bool> {
-        validate_password(self.client, password, user_key).await
+    pub async fn validate_password(&self, password: String, password_hash: String) -> Result<bool> {
+        validate_password(self.client, password, password_hash).await
     }
 }
 

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -9,7 +9,9 @@ use crate::{
             ApiKeyLoginResponse, PasswordLoginRequest, PasswordLoginResponse,
             TwoFactorEmailRequest,
         },
-        password::{password_strength, satisfies_policy, MasterPasswordPolicyOptions},
+        password::{
+            password_strength, satisfies_policy, validate_password, MasterPasswordPolicyOptions,
+        },
         register::{make_register_keys, register},
         RegisterKeyResponse, RegisterRequest,
     },
@@ -89,6 +91,10 @@ impl<'a> ClientAuth<'a> {
 
     pub async fn send_two_factor_email(&mut self, tf: &TwoFactorEmailRequest) -> Result<()> {
         send_two_factor_email(self.client, tf).await
+    }
+
+    pub async fn validate_password(&self, password: String, user_key: String) -> Result<bool> {
+        validate_password(self.client, password, user_key).await
     }
 }
 

--- a/crates/bitwarden/src/auth/login/mod.rs
+++ b/crates/bitwarden/src/auth/login/mod.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "internal")]
 use {
-    crate::{
-        client::{kdf::Kdf, Client},
-        error::Result,
-    },
+    crate::{client::Client, error::Result},
     bitwarden_api_identity::{
         apis::accounts_api::accounts_prelogin_post,
         models::{PreloginRequestModel, PreloginResponseModel},
@@ -38,14 +35,6 @@ mod access_token;
 pub(super) use access_token::login_access_token;
 #[cfg(feature = "secrets")]
 pub use access_token::{AccessTokenLoginRequest, AccessTokenLoginResponse};
-
-#[cfg(feature = "internal")]
-async fn determine_password_hash(email: &str, kdf: &Kdf, password: &str) -> Result<String> {
-    use crate::crypto::{HashPurpose, MasterKey};
-
-    let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), kdf)?;
-    master_key.derive_master_key_hash(password.as_bytes(), HashPurpose::ServerAuthorization)
-}
 
 #[cfg(feature = "internal")]
 pub(crate) async fn request_prelogin(

--- a/crates/bitwarden/src/auth/login/password.rs
+++ b/crates/bitwarden/src/auth/login/password.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "internal")]
 use crate::{
-    auth::{
-        api::request::PasswordTokenRequest,
-        login::{determine_password_hash, TwoFactorRequest},
-    },
+    auth::{api::request::PasswordTokenRequest, login::TwoFactorRequest},
     client::{kdf::Kdf, LoginMethod},
     crypto::EncString,
     Client,
@@ -26,12 +23,18 @@ pub(crate) async fn login_password(
     client: &mut Client,
     input: &PasswordLoginRequest,
 ) -> Result<PasswordLoginResponse> {
-    use crate::client::UserLoginMethod;
+    use crate::{auth::determine_password_hash, client::UserLoginMethod, crypto::HashPurpose};
 
     info!("password logging in");
     debug!("{:#?}, {:#?}", client, input);
 
-    let password_hash = determine_password_hash(&input.email, &input.kdf, &input.password).await?;
+    let password_hash = determine_password_hash(
+        &input.email,
+        &input.kdf,
+        &input.password,
+        HashPurpose::ServerAuthorization,
+    )
+    .await?;
     let response = request_identity_tokens(client, input, &password_hash).await?;
 
     if let IdentityTokenResponse::Authenticated(r) = &response {

--- a/crates/bitwarden/src/auth/login/two_factor.rs
+++ b/crates/bitwarden/src/auth/login/two_factor.rs
@@ -3,8 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use super::determine_password_hash;
-use crate::{error::Result, Client};
+use crate::{auth::determine_password_hash, crypto::HashPurpose, error::Result, Client};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -22,7 +21,13 @@ pub(crate) async fn send_two_factor_email(
     // TODO: This should be resolved from the client
     let kdf = client.auth().prelogin(input.email.clone()).await?;
 
-    let password_hash = determine_password_hash(&input.email, &kdf, &input.password).await?;
+    let password_hash = determine_password_hash(
+        &input.email,
+        &kdf,
+        &input.password,
+        HashPurpose::ServerAuthorization,
+    )
+    .await?;
 
     let config = client.get_api_configurations().await;
     bitwarden_api_api::apis::two_factor_api::two_factor_send_email_login_post(

--- a/crates/bitwarden/src/auth/mod.rs
+++ b/crates/bitwarden/src/auth/mod.rs
@@ -11,3 +11,21 @@ pub use jwt_token::JWTToken;
 mod register;
 #[cfg(feature = "internal")]
 pub use register::{RegisterKeyResponse, RegisterRequest};
+
+#[cfg(feature = "internal")]
+use crate::{
+    client::kdf::Kdf,
+    crypto::{HashPurpose, MasterKey},
+    error::Result,
+};
+
+#[cfg(feature = "internal")]
+async fn determine_password_hash(
+    email: &str,
+    kdf: &Kdf,
+    password: &str,
+    purpose: HashPurpose,
+) -> Result<String> {
+    let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), kdf)?;
+    master_key.derive_master_key_hash(password.as_bytes(), purpose)
+}

--- a/crates/bitwarden/src/auth/mod.rs
+++ b/crates/bitwarden/src/auth/mod.rs
@@ -29,3 +29,29 @@ async fn determine_password_hash(
     let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), kdf)?;
     master_key.derive_master_key_hash(password.as_bytes(), purpose)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+
+    #[cfg(feature = "internal")]
+    #[tokio::test]
+    async fn test_determine_password_hash() {
+        use super::determine_password_hash;
+
+        let password = "password123";
+        let email = "test@bitwarden.com";
+        let kdf = Kdf::PBKDF2 {
+            iterations: NonZeroU32::new(100_000).unwrap(),
+        };
+        let purpose = HashPurpose::LocalAuthorization;
+
+        let result = determine_password_hash(email, &kdf, password, purpose)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU=");
+    }
+}

--- a/crates/bitwarden/src/auth/password.rs
+++ b/crates/bitwarden/src/auth/password.rs
@@ -67,3 +67,34 @@ pub struct MasterPasswordPolicyOptions {
     /// the user will be forced to update their password.
     enforce_on_login: bool,
 }
+
+#[cfg(test)]
+
+mod tests {
+
+    #[cfg(feature = "mobile")]
+    #[tokio::test]
+    async fn test_validate_password() {
+        use std::num::NonZeroU32;
+
+        use crate::client::{kdf::Kdf, Client, LoginMethod, UserLoginMethod};
+
+        use super::validate_password;
+
+        let mut client = Client::new(None);
+        client.set_login_method(LoginMethod::User(UserLoginMethod::Username {
+            email: "test@bitwarden.com".to_string(),
+            kdf: Kdf::PBKDF2 {
+                iterations: NonZeroU32::new(100_000).unwrap(),
+            },
+            client_id: "1".to_string(),
+        }));
+
+        let password = "password123".to_string();
+        let password_hash = "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU=".to_string();
+
+        let result = validate_password(&client, password, password_hash).await;
+
+        assert!(result.unwrap());
+    }
+}

--- a/crates/bitwarden/src/auth/password.rs
+++ b/crates/bitwarden/src/auth/password.rs
@@ -1,12 +1,12 @@
+use schemars::JsonSchema;
+
+use super::determine_password_hash;
 use crate::{
     client::{LoginMethod, UserLoginMethod},
     crypto::HashPurpose,
     error::{Error, Result},
     Client,
 };
-use schemars::JsonSchema;
-
-use super::determine_password_hash;
 
 pub(super) fn password_strength(
     _password: String,
@@ -77,9 +77,8 @@ mod tests {
     async fn test_validate_password() {
         use std::num::NonZeroU32;
 
-        use crate::client::{kdf::Kdf, Client, LoginMethod, UserLoginMethod};
-
         use super::validate_password;
+        use crate::client::{kdf::Kdf, Client, LoginMethod, UserLoginMethod};
 
         let mut client = Client::new(None);
         client.set_login_method(LoginMethod::User(UserLoginMethod::Username {

--- a/crates/bitwarden/src/auth/password.rs
+++ b/crates/bitwarden/src/auth/password.rs
@@ -47,7 +47,7 @@ pub(super) async fn validate_password(
             }
         }
     } else {
-        Ok(false)
+        Err(Error::NotAuthenticated)
     }
 }
 

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -10,9 +10,10 @@ use super::{
 use crate::{client::kdf::Kdf, error::Result, util::BASE64_ENGINE};
 
 #[derive(Copy, Clone)]
-pub(crate) enum HashPurpose {
+#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+pub enum HashPurpose {
     ServerAuthorization = 1,
-    // LocalAuthorization = 2,
+    LocalAuthorization = 2,
 }
 
 /// A Master Key.

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -1,6 +1,7 @@
 use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::Engine;
 use rand::Rng;
+use schemars::JsonSchema;
 use sha2::Digest;
 
 use super::{
@@ -9,7 +10,7 @@ use super::{
 };
 use crate::{client::kdf::Kdf, error::Result, util::BASE64_ENGINE};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, JsonSchema)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
 pub enum HashPurpose {
     ServerAuthorization = 1,

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -42,7 +42,9 @@ pub(crate) use shareable_key::derive_shareable_key;
 #[cfg(feature = "internal")]
 mod master_key;
 #[cfg(feature = "internal")]
-pub(crate) use master_key::{HashPurpose, MasterKey};
+pub use master_key::HashPurpose;
+#[cfg(feature = "internal")]
+pub(crate) use master_key::MasterKey;
 #[cfg(feature = "internal")]
 mod user_key;
 #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -1,4 +1,6 @@
-use crate::{client::kdf::Kdf, error::Result, mobile::kdf::hash_password, Client};
+use crate::{
+    client::kdf::Kdf, crypto::HashPurpose, error::Result, mobile::kdf::hash_password, Client,
+};
 
 pub struct ClientKdf<'a> {
     pub(crate) client: &'a crate::Client,
@@ -10,8 +12,9 @@ impl<'a> ClientKdf<'a> {
         email: String,
         password: String,
         kdf_params: Kdf,
+        purpose: HashPurpose,
     ) -> Result<String> {
-        hash_password(self.client, email, password, kdf_params).await
+        hash_password(self.client, email, password, kdf_params, purpose).await
     }
 }
 

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -10,8 +10,9 @@ pub async fn hash_password(
     email: String,
     password: String,
     kdf_params: Kdf,
+    purpose: HashPurpose,
 ) -> Result<String> {
     let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), &kdf_params)?;
 
-    master_key.derive_master_key_hash(password.as_bytes(), HashPurpose::ServerAuthorization)
+    master_key.derive_master_key_hash(password.as_bytes(), purpose)
 }

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -121,6 +121,17 @@ Generate keys needed for registration process
 
 **Output**: std::result::Result<RegisterKeyResponse,BitwardenError>
 
+### `validate_password`
+
+Validate the user password
+
+**Arguments**:
+
+- self:
+- password: String
+
+**Output**: std::result::Result<,BitwardenError>
+
 ## ClientCiphers
 
 ### `encrypt`
@@ -493,7 +504,7 @@ The key can be either:
 - key: String
 - time: Option<DateTime>
 
-**Output**: [TotpResponse](#totpresponse)
+**Output**: std::result::Result<TotpResponse,BitwardenError>
 
 # References
 
@@ -1126,7 +1137,7 @@ implementations.
 <tr>
     <th>wordSeparator</th>
     <th>string</th>
-    <th>Character separator between words in the generated passphrase. If the value is set, it cannot be empty.</th>
+    <th>Character separator between words in the generated passphrase. The value cannot be empty.</th>
 </tr>
 <tr>
     <th>capitalize</th>
@@ -1397,25 +1408,5 @@ implementations.
     <th>expirationDate</th>
     <th>string,null</th>
     <th></th>
-</tr>
-</table>
-
-## `TotpResponse`
-
-<table>
-<tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-</tr>
-<tr>
-    <th>code</th>
-    <th>string</th>
-    <th>Generated TOTP code</th>
-</tr>
-<tr>
-    <th>period</th>
-    <th>integer</th>
-    <th>Time period</th>
 </tr>
 </table>

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -105,6 +105,7 @@ Hash the user password
 - email: String
 - password: String
 - kdf_params: [Kdf](#kdf)
+- purpose: [HashPurpose](#hashpurpose)
 
 **Output**: std::result::Result<String,BitwardenError>
 
@@ -912,6 +913,16 @@ implementations.
 </tr>
 </table>
 
+## `HashPurpose`
+
+<table>
+<tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+</tr>
+</table>
+
 ## `InitOrgCryptoRequest`
 
 <table>
@@ -1162,52 +1173,52 @@ implementations.
 <tr>
     <th>lowercase</th>
     <th>boolean</th>
-    <th></th>
+    <th>Include lowercase characters (a-z).</th>
 </tr>
 <tr>
     <th>uppercase</th>
     <th>boolean</th>
-    <th></th>
+    <th>Include uppercase characters (A-Z).</th>
 </tr>
 <tr>
     <th>numbers</th>
     <th>boolean</th>
-    <th></th>
+    <th>Include numbers (0-9).</th>
 </tr>
 <tr>
     <th>special</th>
     <th>boolean</th>
-    <th></th>
+    <th>Include special characters: ! @ # $ % ^ &amp; *</th>
 </tr>
 <tr>
     <th>length</th>
-    <th>integer,null</th>
-    <th></th>
+    <th>integer</th>
+    <th>The length of the generated password. Note that the password length must be greater than the sum of all the minimums.</th>
 </tr>
 <tr>
     <th>avoidAmbiguous</th>
-    <th>boolean,null</th>
-    <th></th>
+    <th>boolean</th>
+    <th>When set to true, the generated password will not contain ambiguous characters. The ambiguous characters are: I, O, l, 0, 1</th>
 </tr>
 <tr>
     <th>minLowercase</th>
-    <th>boolean,null</th>
-    <th></th>
+    <th>integer,null</th>
+    <th>The minimum number of lowercase characters in the generated password. When set, the value must be between 1 and 9. This value is ignored is lowercase is false</th>
 </tr>
 <tr>
     <th>minUppercase</th>
-    <th>boolean,null</th>
-    <th></th>
+    <th>integer,null</th>
+    <th>The minimum number of uppercase characters in the generated password. When set, the value must be between 1 and 9. This value is ignored is uppercase is false</th>
 </tr>
 <tr>
     <th>minNumber</th>
-    <th>boolean,null</th>
-    <th></th>
+    <th>integer,null</th>
+    <th>The minimum number of numbers in the generated password. When set, the value must be between 1 and 9. This value is ignored is numbers is false</th>
 </tr>
 <tr>
     <th>minSpecial</th>
-    <th>boolean,null</th>
-    <th></th>
+    <th>integer,null</th>
+    <th>The minimum number of special characters in the generated password. When set, the value must be between 1 and 9. This value is ignored is special is false</th>
 </tr>
 </table>
 

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -126,10 +126,15 @@ Generate keys needed for registration process
 
 Validate the user password
 
+To retrieve the user&#x27;s password hash, use [&#x60;ClientAuth::hash_password&#x60;] with
+&#x60;HashPurpose::LocalAuthentication&#x60; during login and persist it. If the login method has no
+password, use the email OTP.
+
 **Arguments**:
 
 - self:
 - password: String
+- password_hash: String
 
 **Output**: std::result::Result<,BitwardenError>
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Client will call `hash_password` with `Purpose::Local`, persist it and revalidate by using `validate_password(password, persisted_hash)`.

Long term the SDK will persist the hash itself and not require it as input.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
