### PR TITLE
Use tokio executor for uniffi async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3569,7 @@ version = "0.25.2"
 source = "git+https://github.com/mozilla/uniffi-rs?rev=23711c8151bbb794369aa1f9d383db386792dff9#23711c8151bbb794369aa1f9d383db386792dff9"
 dependencies = [
  "anyhow",
+ "async-compat",
  "bytes",
  "camino",
  "log",

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -11,7 +11,7 @@ use crate::{error::Result, Client};
 #[derive(uniffi::Object)]
 pub struct ClientAuth(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientAuth {
     /// **API Draft:** Calculate Password Strength
     pub async fn password_strength(

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -7,7 +7,7 @@ use crate::{error::Result, Client};
 #[derive(uniffi::Object)]
 pub struct ClientCrypto(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientCrypto {
     /// Initialization method for the user crypto. Needs to be called before any other crypto operations.
     pub async fn initialize_user_crypto(&self, req: InitUserCryptoRequest) -> Result<()> {

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -7,7 +7,7 @@ use crate::{error::Result, Client};
 #[derive(uniffi::Object)]
 pub struct ClientPlatform(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientPlatform {
     /// Fingerprint
     pub async fn fingerprint(&self, req: FingerprintRequest) -> Result<String> {

--- a/crates/bitwarden-uniffi/src/tool/mod.rs
+++ b/crates/bitwarden-uniffi/src/tool/mod.rs
@@ -10,7 +10,7 @@ use crate::{error::Result, Client};
 #[derive(uniffi::Object)]
 pub struct ClientGenerators(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientGenerators {
     /// **API Draft:** Generate Password
     pub async fn password(&self, settings: PasswordGeneratorRequest) -> Result<String> {
@@ -40,7 +40,7 @@ impl ClientGenerators {
 #[derive(uniffi::Object)]
 pub struct ClientExporters(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientExporters {
     /// **API Draft:** Export user vault
     pub async fn export_vault(

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 #[derive(uniffi::Object)]
 pub struct ClientCiphers(pub Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientCiphers {
     /// Encrypt cipher
     pub async fn encrypt(&self, cipher_view: CipherView) -> Result<Cipher> {

--- a/crates/bitwarden-uniffi/src/vault/collections.rs
+++ b/crates/bitwarden-uniffi/src/vault/collections.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 #[derive(uniffi::Object)]
 pub struct ClientCollections(pub Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientCollections {
     /// Decrypt collection
     pub async fn decrypt(&self, collection: Collection) -> Result<CollectionView> {

--- a/crates/bitwarden-uniffi/src/vault/folders.rs
+++ b/crates/bitwarden-uniffi/src/vault/folders.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 #[derive(uniffi::Object)]
 pub struct ClientFolders(pub Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientFolders {
     /// Encrypt folder
     pub async fn encrypt(&self, folder: FolderView) -> Result<Folder> {

--- a/crates/bitwarden-uniffi/src/vault/mod.rs
+++ b/crates/bitwarden-uniffi/src/vault/mod.rs
@@ -14,7 +14,7 @@ pub mod sends;
 #[derive(uniffi::Object)]
 pub struct ClientVault(pub(crate) Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientVault {
     /// Folder operations
     pub fn folders(self: Arc<Self>) -> Arc<folders::ClientFolders> {

--- a/crates/bitwarden-uniffi/src/vault/password_history.rs
+++ b/crates/bitwarden-uniffi/src/vault/password_history.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 #[derive(uniffi::Object)]
 pub struct ClientPasswordHistory(pub Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientPasswordHistory {
     /// Encrypt password history
     pub async fn encrypt(&self, password_history: PasswordHistoryView) -> Result<PasswordHistory> {

--- a/crates/bitwarden-uniffi/src/vault/sends.rs
+++ b/crates/bitwarden-uniffi/src/vault/sends.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 #[derive(uniffi::Object)]
 pub struct ClientSends(pub Arc<Client>);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientSends {
     /// Encrypt send
     pub async fn encrypt(&self, send: SendView) -> Result<Send> {

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -56,7 +56,7 @@ sha1 = ">=0.10.5, <0.11"
 sha2 = ">=0.10.6, <0.11"
 subtle = ">=2.5.0, <3.0"
 thiserror = ">=1.0.40, <2.0"
-uniffi = { version = "=0.25.2", optional = true }
+uniffi = { version = "=0.25.2", optional = true, features = ["tokio"] }
 uuid = { version = ">=1.3.3, <2.0", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When testing the username generator using uniffi, I noticed that uniffi was using it's own async executor by default, while reqwest was expecting tokio, which caused errors. 

I've changed all uniffi exported async functions to use tokio by default, to avoid these issues.