### PR TITLE
chore: stop printing input string before C commands

### DIFF
--- a/crates/bitwarden-c/src/c.rs
+++ b/crates/bitwarden-c/src/c.rs
@@ -12,7 +12,6 @@ pub async extern "C" fn run_command(
 ) -> *mut c_char {
     let client = unsafe { ffi_ref!(client_ptr) };
     let input_str = str::from_utf8(unsafe { CStr::from_ptr(c_str_ptr).to_bytes() }).unwrap();
-    println!("{}", input_str);
 
     let result = client.run_command(input_str).await;
     match std::ffi::CString::new(result) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Stop printing input string before each C API Call - it was leaking the accessTokenLogin

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **crates/bitwarden-c/src/c.rs:** Remove `println`

## Before you submit

Before, GOLANG App using the "master" version of a built `libbitwarden_c.so`:

```
root@3109875c9808:/tmp# ./example 
{"accessTokenLogin":{"accessToken":"0.7a7e976d-dd5a-4915-8bbd-b0d50118903b.hmXzh9efndJxePmCgWs2neZq3lVFb1:87U3EjhGZq3ufZv+Mso5PA=="}}
{"projects":{"list":{"organizationId":"d2f88df6-b07b-4acb-9a0f-b09600cf89e5"}}}
{"secrets":{"list":{"organizationId":"d2f88df6-b07b-4acb-9a0f-b09600cf89e5"}}}
{"secrets":{"get":{"id":"697720c2-50f6-4dd9-8859-b0d501191ee5"}}}
{"secrets":{"get":{"id":"b6820a10-d6e3-490e-9476-b0d5012222d6"}}}
world2
```

After, same GOLANG App using my version of `libbitwarden_c.so` compiled without the `println`:
```
root@3109875c9808:/tmp# ./example 
world2
```