### PR TITLE
Split set_login_method from set_tokens

### DIFF
--- a/crates/bitwarden/src/auth/login/access_token.rs
+++ b/crates/bitwarden/src/auth/login/access_token.rs
@@ -58,12 +58,14 @@ pub(crate) async fn login_access_token(
             r.access_token.clone(),
             r.refresh_token.clone(),
             r.expires_in,
-            LoginMethod::ServiceAccount(ServiceAccountLoginMethod::AccessToken {
+        );
+        client.set_login_method(LoginMethod::ServiceAccount(
+            ServiceAccountLoginMethod::AccessToken {
                 access_token_id: access_token.access_token_id,
                 client_secret: access_token.client_secret,
                 organization_id,
-            }),
-        );
+            },
+        ));
 
         client.initialize_crypto_single_key(encryption_key);
     }

--- a/crates/bitwarden/src/auth/login/api_key.rs
+++ b/crates/bitwarden/src/auth/login/api_key.rs
@@ -36,13 +36,13 @@ pub(crate) async fn login_api_key(
             r.access_token.clone(),
             r.refresh_token.clone(),
             r.expires_in,
-            LoginMethod::User(UserLoginMethod::ApiKey {
-                client_id: input.client_id.to_owned(),
-                client_secret: input.client_secret.to_owned(),
-                email,
-                kdf,
-            }),
         );
+        client.set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
+            client_id: input.client_id.to_owned(),
+            client_secret: input.client_secret.to_owned(),
+            email,
+            kdf,
+        }));
 
         let user_key: EncString = r.key.as_deref().unwrap().parse().unwrap();
         let private_key: EncString = r.private_key.as_deref().unwrap().parse().unwrap();

--- a/crates/bitwarden/src/auth/login/password.rs
+++ b/crates/bitwarden/src/auth/login/password.rs
@@ -42,12 +42,12 @@ pub(crate) async fn login_password(
             r.access_token.clone(),
             r.refresh_token.clone(),
             r.expires_in,
-            LoginMethod::User(UserLoginMethod::Username {
-                client_id: "web".to_owned(),
-                email: input.email.to_owned(),
-                kdf: input.kdf.to_owned(),
-            }),
         );
+        client.set_login_method(LoginMethod::User(UserLoginMethod::Username {
+            client_id: "web".to_owned(),
+            email: input.email.to_owned(),
+            kdf: input.kdf.to_owned(),
+        }));
 
         let user_key: EncString = r.key.as_deref().unwrap().parse().unwrap();
         let private_key: EncString = r.private_key.as_deref().unwrap().parse().unwrap();

--- a/crates/bitwarden/src/auth/renew.rs
+++ b/crates/bitwarden/src/auth/renew.rs
@@ -57,13 +57,11 @@ pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
 
         match res {
             IdentityTokenResponse::Refreshed(r) => {
-                let login_method = login_method.to_owned();
-                client.set_tokens(r.access_token, r.refresh_token, r.expires_in, login_method);
+                client.set_tokens(r.access_token, r.refresh_token, r.expires_in);
                 return Ok(());
             }
             IdentityTokenResponse::Authenticated(r) => {
-                let login_method = login_method.to_owned();
-                client.set_tokens(r.access_token, r.refresh_token, r.expires_in, login_method);
+                client.set_tokens(r.access_token, r.refresh_token, r.expires_in);
                 return Ok(());
             }
             _ => {

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -29,7 +29,7 @@ pub(crate) struct ApiConfigurations {
     pub device_type: DeviceType,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum LoginMethod {
     #[cfg(feature = "internal")]
     User(UserLoginMethod),
@@ -38,7 +38,7 @@ pub(crate) enum LoginMethod {
     ServiceAccount(ServiceAccountLoginMethod),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg(feature = "internal")]
 pub(crate) enum UserLoginMethod {
     Username {
@@ -55,7 +55,7 @@ pub(crate) enum UserLoginMethod {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum ServiceAccountLoginMethod {
     AccessToken {
         access_token_id: Uuid,
@@ -185,12 +185,10 @@ impl Client {
         token: String,
         refresh_token: Option<String>,
         expires_in: u64,
-        login_method: LoginMethod,
     ) {
         self.token = Some(token.clone());
         self.refresh_token = refresh_token;
         self.token_expires_in = Some(Utc::now().timestamp() + expires_in as i64);
-        self.login_method = Some(login_method);
         self.__api_configurations.identity.oauth_access_token = Some(token.clone());
         self.__api_configurations.api.oauth_access_token = Some(token);
     }

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -172,7 +172,6 @@ impl Client {
         self.encryption_settings.as_ref().ok_or(Error::VaultLocked)
     }
 
-    #[cfg(feature = "mobile")]
     pub(crate) fn set_login_method(&mut self, login_method: LoginMethod) {
         use log::debug;
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
There's no reason for these two to be combined, and it forces `renew_tokens` to clone login_method every time