### PR TITLE
Change login_method to have the access token directly

### DIFF
--- a/crates/bitwarden/src/auth/login/access_token.rs
+++ b/crates/bitwarden/src/auth/login/access_token.rs
@@ -61,8 +61,7 @@ pub(crate) async fn login_access_token(
         );
         client.set_login_method(LoginMethod::ServiceAccount(
             ServiceAccountLoginMethod::AccessToken {
-                access_token_id: access_token.access_token_id,
-                client_secret: access_token.client_secret,
+                access_token,
                 organization_id,
             },
         ));

--- a/crates/bitwarden/src/auth/renew.rs
+++ b/crates/bitwarden/src/auth/renew.rs
@@ -43,14 +43,13 @@ pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
                 }
             },
             LoginMethod::ServiceAccount(s) => match s {
-                ServiceAccountLoginMethod::AccessToken {
-                    access_token_id,
-                    client_secret,
-                    ..
-                } => {
-                    AccessTokenRequest::new(*access_token_id, client_secret)
-                        .send(&client.__api_configurations)
-                        .await?
+                ServiceAccountLoginMethod::AccessToken { access_token, .. } => {
+                    AccessTokenRequest::new(
+                        access_token.access_token_id,
+                        &access_token.client_secret,
+                    )
+                    .send(&client.__api_configurations)
+                    .await?
                 }
             },
         };

--- a/crates/bitwarden/src/client/access_token.rs
+++ b/crates/bitwarden/src/client/access_token.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt::Debug, str::FromStr};
 
 use base64::Engine;
 use uuid::Uuid;
@@ -13,6 +13,15 @@ pub struct AccessToken {
     pub access_token_id: Uuid,
     pub client_secret: String,
     pub encryption_key: SymmetricCryptoKey,
+}
+
+// We don't want to log the more sensitive fields from an AccessToken
+impl Debug for AccessToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccessToken")
+            .field("access_token_id", &self.access_token_id)
+            .finish()
+    }
 }
 
 impl FromStr for AccessToken {

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -22,6 +22,8 @@ use crate::{
     error::{Error, Result},
 };
 
+use super::AccessToken;
+
 #[derive(Debug)]
 pub(crate) struct ApiConfigurations {
     pub identity: bitwarden_api_identity::apis::configuration::Configuration,
@@ -58,8 +60,7 @@ pub(crate) enum UserLoginMethod {
 #[derive(Debug)]
 pub(crate) enum ServiceAccountLoginMethod {
     AccessToken {
-        access_token_id: Uuid,
-        client_secret: String,
+        access_token: AccessToken,
         organization_id: Uuid,
     },
 }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Now that set_login_method is split from set_tokens, we can just change this to directly contain the token without adding the Clone bound to it. This way we avoid duplicating 2/3rds of the AccessToken.

This should help with #388 