### PR TITLE
Remove token from client

### DIFF
--- a/crates/bitwarden/src/auth/login/access_token.rs
+++ b/crates/bitwarden/src/auth/login/access_token.rs
@@ -54,11 +54,7 @@ pub(crate) async fn login_access_token(
             .parse()
             .map_err(|_| Error::InvalidResponse)?;
 
-        client.set_tokens(
-            r.access_token.clone(),
-            r.refresh_token.clone(),
-            r.expires_in,
-        );
+        client.set_tokens(r.access_token.clone(), r.expires_in);
         client.set_login_method(LoginMethod::ServiceAccount(
             ServiceAccountLoginMethod::AccessToken {
                 access_token,

--- a/crates/bitwarden/src/auth/login/api_key.rs
+++ b/crates/bitwarden/src/auth/login/api_key.rs
@@ -32,11 +32,7 @@ pub(crate) async fn login_api_key(
 
         let kdf = client.auth().prelogin(email.clone()).await?;
 
-        client.set_tokens(
-            r.access_token.clone(),
-            r.refresh_token.clone(),
-            r.expires_in,
-        );
+        client.set_tokens(r.access_token.clone(), r.expires_in);
         client.set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
             client_id: input.client_id.to_owned(),
             client_secret: input.client_secret.to_owned(),

--- a/crates/bitwarden/src/auth/login/password.rs
+++ b/crates/bitwarden/src/auth/login/password.rs
@@ -38,15 +38,12 @@ pub(crate) async fn login_password(
     let response = request_identity_tokens(client, input, &password_hash).await?;
 
     if let IdentityTokenResponse::Authenticated(r) = &response {
-        client.set_tokens(
-            r.access_token.clone(),
-            r.refresh_token.clone(),
-            r.expires_in,
-        );
+        client.set_tokens(r.access_token.clone(), r.expires_in);
         client.set_login_method(LoginMethod::User(UserLoginMethod::Username {
             client_id: "web".to_owned(),
             email: input.email.to_owned(),
             kdf: input.kdf.to_owned(),
+            refresh_token: r.refresh_token.clone(),
         }));
 
         let user_key: EncString = r.key.as_deref().unwrap().parse().unwrap();

--- a/crates/bitwarden/src/auth/password.rs
+++ b/crates/bitwarden/src/auth/password.rs
@@ -87,6 +87,7 @@ mod tests {
                 iterations: NonZeroU32::new(100_000).unwrap(),
             },
             client_id: "1".to_string(),
+            refresh_token: None,
         }));
 
         let password = "password123".to_string();

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -47,6 +47,7 @@ pub(crate) enum UserLoginMethod {
         client_id: String,
         email: String,
         kdf: Kdf,
+        refresh_token: Option<String>,
     },
     ApiKey {
         client_id: String,
@@ -67,8 +68,6 @@ pub(crate) enum ServiceAccountLoginMethod {
 
 #[derive(Debug)]
 pub struct Client {
-    token: Option<String>,
-    pub(crate) refresh_token: Option<String>,
     pub(crate) token_expires_in: Option<i64>,
     pub(crate) login_method: Option<LoginMethod>,
 
@@ -112,8 +111,6 @@ impl Client {
         };
 
         Self {
-            token: None,
-            refresh_token: None,
             token_expires_in: None,
             login_method: None,
             __api_configurations: ApiConfigurations {
@@ -180,14 +177,7 @@ impl Client {
         self.login_method = Some(login_method);
     }
 
-    pub(crate) fn set_tokens(
-        &mut self,
-        token: String,
-        refresh_token: Option<String>,
-        expires_in: u64,
-    ) {
-        self.token = Some(token.clone());
-        self.refresh_token = refresh_token;
+    pub(crate) fn set_tokens(&mut self, token: String, expires_in: u64) {
         self.token_expires_in = Some(Utc::now().timestamp() + expires_in as i64);
         self.__api_configurations.identity.oauth_access_token = Some(token.clone());
         self.__api_configurations.api.oauth_access_token = Some(token);
@@ -195,7 +185,7 @@ impl Client {
 
     #[cfg(feature = "internal")]
     pub fn is_authed(&self) -> bool {
-        self.token.is_some() || self.login_method.is_some()
+        self.login_method.is_some()
     }
 
     #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -56,6 +56,7 @@ pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequ
         client_id: "".to_string(),
         email: req.email,
         kdf: req.kdf_params,
+        refresh_token: None,
     });
     client.set_login_method(login_method);
 

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -338,6 +338,7 @@ mod tests {
                 kdf: Kdf::PBKDF2 {
                     iterations: 345123.try_into().unwrap(),
                 },
+                refresh_token: None,
             },
             "asdfasdfasdf",
             "2.majkL1/hNz9yptLqNAUSnw==|RiOzMTTJMG948qu8O3Zm1EQUO2E8BuTwFKnO9LWQjMzxMWJM5GbyOq2/A+tumPbTERt4JWur/FKfgHb+gXuYiEYlXPMuVBvT7nv4LPytJuM=|IVqMxHJeR1ZXY0sGngTC0x+WqbG8p6V+BTrdgBbQXjM=".parse().unwrap(),


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
As mentioned in #388, the `token` and `refresh_token` fields in `Client` are never really required directly by `Client`. The `token` is already directly set within the API clients, and the `refresh_token` is only used for the renew function with the user login method.

Knowing this, we can remove `token` entirely and move `refresh_token` into `UserLoginMethod::Username`.