### PR TITLE
Tweak ruby to not emit null in settings

### DIFF
--- a/languages/ruby/bitwarden_sdk/lib/bitwarden-sdk.rb
+++ b/languages/ruby/bitwarden_sdk/lib/bitwarden-sdk.rb
@@ -37,7 +37,7 @@ module BitwardenSDK
       )
 
       @bitwarden = BitwardenLib
-      @handle = @bitwarden.init(client_settings.to_json)
+      @handle = @bitwarden.init(client_settings.to_dynamic.compact.to_json)
       @command_runner = CommandRunner.new(@bitwarden, @handle)
       @project_client = ProjectsClient.new(@command_runner)
       @secrets_client = SecretsClient.new(@command_runner)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Ruby emitted `null` in client settings which prevented rust from using the default implementation.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
