### PR TITLE
Improve internal error

### DIFF
--- a/crates/bitwarden/src/auth/jwt_token.rs
+++ b/crates/bitwarden/src/auth/jwt_token.rs
@@ -29,9 +29,7 @@ impl FromStr for JWTToken {
     fn from_str(s: &str) -> Result<Self> {
         let split = s.split('.').collect::<Vec<_>>();
         if split.len() != 3 {
-            return Err(crate::error::Error::Internal(
-                "JWT token has an invalid number of parts",
-            ));
+            return Err("JWT token has an invalid number of parts".into());
         }
         let decoded = BASE64_ENGINE.decode(split[1])?;
         Ok(serde_json::from_slice(&decoded)?)

--- a/crates/bitwarden/src/auth/login/api_key.rs
+++ b/crates/bitwarden/src/auth/login/api_key.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     client::{LoginMethod, UserLoginMethod},
     crypto::EncString,
-    error::{Error, Result},
+    error::Result,
     Client,
 };
 
@@ -28,7 +28,7 @@ pub(crate) async fn login_api_key(
         // This should always be Some() when logging in with an api key
         let email = access_token_obj
             .email
-            .ok_or(Error::Internal("Access token doesn't contain email"))?;
+            .ok_or("Access token doesn't contain email")?;
 
         let kdf = client.auth().prelogin(email.clone()).await?;
 

--- a/crates/bitwarden/src/client/kdf.rs
+++ b/crates/bitwarden/src/client/kdf.rs
@@ -32,7 +32,7 @@ impl TryFrom<PreloginResponseModel> for Kdf {
             default_pbkdf2_iterations,
         };
 
-        let kdf = response.kdf.ok_or(Error::Internal("KDF not found"))?;
+        let kdf = response.kdf.ok_or("KDF not found")?;
 
         Ok(match kdf {
             KdfType::Variant0 => Kdf::PBKDF2 {

--- a/crates/bitwarden/src/crypto/fingerprint.rs
+++ b/crates/bitwarden/src/crypto/fingerprint.rs
@@ -2,10 +2,7 @@ use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 use sha2::Digest;
 
-use crate::{
-    error::{Error, Result},
-    wordlist::EFF_LONG_WORD_LIST,
-};
+use crate::{error::Result, wordlist::EFF_LONG_WORD_LIST};
 
 /// Computes a fingerprint of the given `fingerprint_material` using the given `public_key`.
 ///
@@ -17,12 +14,12 @@ pub(crate) fn fingerprint(fingerprint_material: &str, public_key: &[u8]) -> Resu
     h.update(public_key);
     h.finalize();
 
-    let hkdf = hkdf::Hkdf::<sha2::Sha256>::from_prk(public_key)
-        .map_err(|_| Error::Internal("hkdf::InvalidLength"))?;
+    let hkdf =
+        hkdf::Hkdf::<sha2::Sha256>::from_prk(public_key).map_err(|_| "hkdf::InvalidLength")?;
 
     let mut user_fingerprint = [0u8; 32];
     hkdf.expand(fingerprint_material.as_bytes(), &mut user_fingerprint)
-        .map_err(|_| Error::Internal("hkdf::expand"))?;
+        .map_err(|_| "hkdf::expand")?;
 
     Ok(hash_word(user_fingerprint).unwrap())
 }
@@ -37,9 +34,7 @@ fn hash_word(hash: [u8; 32]) -> Result<String> {
     let hash_arr: Vec<u8> = hash.to_vec();
     let entropy_available = hash_arr.len() * 4;
     if num_words as f64 * entropy_per_word > entropy_available as f64 {
-        return Err(Error::Internal(
-            "Output entropy of hash function is too small",
-        ));
+        return Err("Output entropy of hash function is too small".into());
     }
 
     let mut phrase = Vec::new();

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -24,7 +24,7 @@
 use aes::cipher::{generic_array::GenericArray, ArrayLength, Unsigned};
 use hmac::digest::OutputSizeUser;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 mod enc_string;
 pub use enc_string::EncString;
@@ -65,13 +65,11 @@ pub(crate) const PBKDF_SHA256_HMAC_OUT_SIZE: usize =
 
 /// RFC5869 HKDF-Expand operation
 fn hkdf_expand<T: ArrayLength<u8>>(prk: &[u8], info: Option<&str>) -> Result<GenericArray<u8, T>> {
-    let hkdf = hkdf::Hkdf::<sha2::Sha256>::from_prk(prk)
-        .map_err(|_| Error::Internal("invalid prk length"))?;
+    let hkdf = hkdf::Hkdf::<sha2::Sha256>::from_prk(prk).map_err(|_| "invalid prk length")?;
     let mut key = GenericArray::<u8, T>::default();
 
     let i = info.map(|i| i.as_bytes()).unwrap_or(&[]);
-    hkdf.expand(i, &mut key)
-        .map_err(|_| Error::Internal("invalid length"))?;
+    hkdf.expand(i, &mut key).map_err(|_| "invalid length")?;
 
     Ok(key)
 }

--- a/crates/bitwarden/src/crypto/rsa.rs
+++ b/crates/bitwarden/src/crypto/rsa.rs
@@ -6,7 +6,7 @@ use rsa::{
 
 use crate::{
     crypto::{EncString, SymmetricCryptoKey},
-    error::{Error, Result},
+    error::Result,
     util::BASE64_ENGINE,
 };
 
@@ -26,12 +26,12 @@ pub(super) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
 
     let spki = pub_key
         .to_public_key_der()
-        .map_err(|_| Error::Internal("unable to create public key"))?;
+        .map_err(|_| "unable to create public key")?;
 
     let b64 = BASE64_ENGINE.encode(spki.as_bytes());
     let pkcs = priv_key
         .to_pkcs8_der()
-        .map_err(|_| Error::Internal("unable to create private key"))?;
+        .map_err(|_| "unable to create private key")?;
 
     let protected = EncString::encrypt_aes256_hmac(pkcs.as_bytes(), key.mac_key.unwrap(), key.key)?;
 

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -1,6 +1,6 @@
 //! Errors that can occur when using this SDK
 
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
 use bitwarden_api_api::apis::Error as ApiError;
 use bitwarden_api_identity::apis::Error as IdentityError;
@@ -47,7 +47,19 @@ pub enum Error {
     ResponseContent { status: StatusCode, message: String },
 
     #[error("Internal error: {0}")]
-    Internal(&'static str),
+    Internal(Cow<'static, str>),
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Self::Internal(s.into())
+    }
+}
+
+impl From<&'static str> for Error {
+    fn from(s: &'static str) -> Self {
+        Self::Internal(s.into())
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/bitwarden/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden/src/platform/get_user_api_key.rs
@@ -62,7 +62,7 @@ fn get_secret_verification_request(
             auth_request_access_code: None,
         })
     } else {
-        Err(Error::Internal("Unsupported login method"))
+        Err("Unsupported login method".into())
     }
 }
 

--- a/crates/bitwarden/src/tool/generators/passphrase.rs
+++ b/crates/bitwarden/src/tool/generators/passphrase.rs
@@ -49,7 +49,7 @@ impl PassphraseGeneratorRequest {
 
         if !(MINIMUM_PASSPHRASE_NUM_WORDS..=MAXIMUM_PASSPHRASE_NUM_WORDS).contains(&self.num_words)
         {
-            return Err("'num_words' must be between 3 and 20".into());
+            return Err(format!("'num_words' must be between {MINIMUM_PASSPHRASE_NUM_WORDS} and {MAXIMUM_PASSPHRASE_NUM_WORDS}").into());
         }
 
         if self.word_separator.chars().next().is_none() {

--- a/crates/bitwarden/src/tool/generators/passphrase.rs
+++ b/crates/bitwarden/src/tool/generators/passphrase.rs
@@ -1,7 +1,4 @@
-use crate::{
-    error::{Error, Result},
-    wordlist::EFF_LONG_WORD_LIST,
-};
+use crate::{error::Result, wordlist::EFF_LONG_WORD_LIST};
 use rand::{seq::SliceRandom, Rng, RngCore};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -52,11 +49,11 @@ impl PassphraseGeneratorRequest {
 
         if !(MINIMUM_PASSPHRASE_NUM_WORDS..=MAXIMUM_PASSPHRASE_NUM_WORDS).contains(&self.num_words)
         {
-            return Err(Error::Internal("'num_words' must be between 3 and 20"));
+            return Err("'num_words' must be between 3 and 20".into());
         }
 
         if self.word_separator.chars().next().is_none() {
-            return Err(Error::Internal("'word_separator' cannot be empty"));
+            return Err("'word_separator' cannot be empty".into());
         };
 
         Ok(ValidPassphraseGeneratorOptions {

--- a/crates/bitwarden/src/tool/generators/password.rs
+++ b/crates/bitwarden/src/tool/generators/password.rs
@@ -4,7 +4,7 @@ use rand::{distributions::Distribution, seq::SliceRandom, RngCore};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 /// Password generator request options.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -133,15 +133,11 @@ impl PasswordGeneratorRequest {
 
         // We always have to have at least one character set enabled
         if !self.lowercase && !self.uppercase && !self.numbers && !self.special {
-            return Err(Error::Internal(
-                "At least one character set must be enabled",
-            ));
+            return Err("At least one character set must be enabled".into());
         }
 
         if self.length < 4 {
-            return Err(Error::Internal(
-                "A password must be at least 4 characters long",
-            ));
+            return Err("A password must be at least 4 characters long".into());
         }
 
         // Make sure the minimum values are zero when the character
@@ -163,9 +159,7 @@ impl PasswordGeneratorRequest {
         // Check that the minimum lengths aren't larger than the password length
         let minimum_length = min_lowercase + min_uppercase + min_number + min_special;
         if minimum_length > length {
-            return Err(Error::Internal(
-                "Password length can't be less than the sum of the minimums",
-            ));
+            return Err("Password length can't be less than the sum of the minimums".into());
         }
 
         let lower = (

--- a/crates/bitwarden/src/uniffi_support.rs
+++ b/crates/bitwarden/src/uniffi_support.rs
@@ -10,7 +10,7 @@ impl UniffiCustomTypeConverter for NonZeroU32 {
     type Builtin = u32;
 
     fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        Self::new(val).ok_or(Error::Internal("Number is zero").into())
+        Self::new(val).ok_or(Error::from("Number is zero").into())
     }
 
     fn from_custom(obj: Self) -> Self::Builtin {

--- a/crates/bitwarden/src/vault/totp.rs
+++ b/crates/bitwarden/src/vault/totp.rs
@@ -130,11 +130,11 @@ impl FromStr for Totp {
         fn decode_secret(secret: &str) -> Result<Vec<u8>> {
             BASE32
                 .decode(secret.as_bytes())
-                .map_err(|_| Error::Internal("Unable to decode secret"))
+                .map_err(|_| "Unable to decode secret".into())
         }
 
         let params = if key.starts_with("otpauth://") {
-            let url = Url::parse(key).map_err(|_| Error::Internal("Unable to parse URL"))?;
+            let url = Url::parse(key).map_err(|_| "Unable to parse URL")?;
             let parts: HashMap<_, _> = url.query_pairs().collect();
 
             Totp {
@@ -161,7 +161,7 @@ impl FromStr for Totp {
                     &parts
                         .get("secret")
                         .map(|v| v.to_string())
-                        .ok_or(Error::Internal("Missing secret in otpauth URI"))?,
+                        .ok_or("Missing secret in otpauth URI")?,
                 )?,
             }
         } else if let Some(secret) = key.strip_prefix("steam://") {


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Allow using dynamic strings on the Internal error variant, tested on the passphrase length error.

The Internal variant is using a `Cow<'static, str>`, to avoid unnecessary allocations on all the cases where a `&'static str` would suffice.

I've implemented `From<&'static str>` and `From<String>` for Error. It feels a bit magic, but it avoids repeating `Error::Internal` all over the place. 