### PR TITLE
Split EncString for asymmetric support

### DIFF
--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -9,7 +9,7 @@ use crate::auth::login::{AccessTokenLoginRequest, AccessTokenLoginResponse};
 #[cfg(feature = "internal")]
 use crate::{
     client::kdf::Kdf,
-    crypto::EncString,
+    crypto::{AsymmEncString, EncString},
     platform::{
         generate_fingerprint, get_user_api_key, sync, FingerprintRequest, FingerprintResponse,
         SecretVerificationRequest, SyncRequest, SyncResponse, UserApiKeyResponse,
@@ -275,7 +275,7 @@ impl Client {
     #[cfg(feature = "internal")]
     pub(crate) fn initialize_org_crypto(
         &mut self,
-        org_keys: Vec<(Uuid, EncString)>,
+        org_keys: Vec<(Uuid, AsymmEncString)>,
     ) -> Result<&EncryptionSettings> {
         let enc = self
             .encryption_settings

--- a/crates/bitwarden/src/client/encryption_settings.rs
+++ b/crates/bitwarden/src/client/encryption_settings.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use {
     crate::{
         client::UserLoginMethod,
-        crypto::{EncString, KeyDecryptable},
+        crypto::{AsymmEncString, EncString, KeyDecryptable},
         error::{CryptoError, Result},
     },
     rsa::pkcs8::DecodePrivateKey,
@@ -84,7 +84,7 @@ impl EncryptionSettings {
     #[cfg(feature = "internal")]
     pub(crate) fn set_org_keys(
         &mut self,
-        org_enc_keys: Vec<(Uuid, EncString)>,
+        org_enc_keys: Vec<(Uuid, AsymmEncString)>,
     ) -> Result<&mut Self> {
         use crate::error::Error;
 

--- a/crates/bitwarden/src/client/encryption_settings.rs
+++ b/crates/bitwarden/src/client/encryption_settings.rs
@@ -96,7 +96,7 @@ impl EncryptionSettings {
 
         // Decrypt the org keys with the private key
         for (org_id, org_enc_key) in org_enc_keys {
-            let dec = org_enc_key.decrypt_with_private_key(private_key)?;
+            let dec = org_enc_key.decrypt(private_key)?;
 
             let org_key = SymmetricCryptoKey::try_from(dec.as_slice())?;
 

--- a/crates/bitwarden/src/crypto/enc_string/asymmetric.rs
+++ b/crates/bitwarden/src/crypto/enc_string/asymmetric.rs
@@ -1,0 +1,272 @@
+use std::{fmt::Display, str::FromStr};
+
+use base64::Engine;
+#[cfg(feature = "internal")]
+use rsa::{Oaep, RsaPrivateKey};
+use serde::{de::Visitor, Deserialize};
+
+use crate::{
+    error::{EncStringParseError, Error, Result},
+    util::BASE64_ENGINE,
+};
+
+#[cfg(feature = "internal")]
+use crate::error::CryptoError;
+
+use super::{from_b64_vec, split_enc_string};
+
+/// # Encrypted string primitive
+///
+/// [AsymmEncString] is a Bitwarden specific primitive that represents an asymmetrically encrypted string. They are
+/// are used together with the KeyDecryptable and KeyEncryptable traits to encrypt and decrypt
+/// data using AsymmetricCryptoKeys.
+///
+/// The flexibility of the [AsymmEncString] type allows for different encryption algorithms to be used
+/// which is represented by the different variants of the enum.
+///
+/// ## Note
+///
+/// For backwards compatibility we will rarely if ever be able to remove support for decrypting old
+/// variants, but we should be opinionated in which variants are used for encrypting.
+///
+/// ## Variants
+/// - [Rsa2048_OaepSha256_B64](AsymmEncString::Rsa2048_OaepSha256_B64)
+/// - [Rsa2048_OaepSha1_B64](AsymmEncString::Rsa2048_OaepSha1_B64)
+///
+/// ## Serialization
+///
+/// [AsymmEncString] implements [Display] and [FromStr] to allow for easy serialization and uses a
+/// custom scheme to represent the different variants.
+///
+/// The scheme is one of the following schemes:
+/// - `[type].[data]`
+///
+/// Where:
+/// - `[type]`: is a digit number representing the variant.
+/// - `[data]`: is the encrypted data.
+#[derive(Clone)]
+#[allow(unused, non_camel_case_types)]
+pub enum AsymmEncString {
+    /// 3
+    Rsa2048_OaepSha256_B64 { data: Vec<u8> },
+    /// 4
+    Rsa2048_OaepSha1_B64 { data: Vec<u8> },
+    /// 5
+    #[deprecated]
+    Rsa2048_OaepSha256_HmacSha256_B64 { data: Vec<u8>, mac: Vec<u8> },
+    /// 6
+    #[deprecated]
+    Rsa2048_OaepSha1_HmacSha256_B64 { data: Vec<u8>, mac: Vec<u8> },
+}
+
+/// To avoid printing sensitive information, [AsymmEncString] debug prints to `AsymmEncString`.
+impl std::fmt::Debug for AsymmEncString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsymmEncString").finish()
+    }
+}
+
+/// Deserializes an [AsymmEncString] from a string.
+impl FromStr for AsymmEncString {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (enc_type, parts) = split_enc_string(s);
+        match (enc_type, parts.len()) {
+            ("3", 1) => {
+                let data = from_b64_vec(parts[0])?;
+                Ok(AsymmEncString::Rsa2048_OaepSha256_B64 { data })
+            }
+            ("4", 1) => {
+                let data = from_b64_vec(parts[0])?;
+                Ok(AsymmEncString::Rsa2048_OaepSha1_B64 { data })
+            }
+            #[allow(deprecated)]
+            ("5", 2) => {
+                let data = from_b64_vec(parts[0])?;
+                let mac: Vec<u8> = from_b64_vec(parts[1])?;
+                Ok(AsymmEncString::Rsa2048_OaepSha256_HmacSha256_B64 { data, mac })
+            }
+            #[allow(deprecated)]
+            ("6", 2) => {
+                let data = from_b64_vec(parts[0])?;
+                let mac: Vec<u8> = from_b64_vec(parts[1])?;
+                Ok(AsymmEncString::Rsa2048_OaepSha1_HmacSha256_B64 { data, mac })
+            }
+
+            (enc_type, parts) => Err(EncStringParseError::InvalidType {
+                enc_type: enc_type.to_string(),
+                parts,
+            }
+            .into()),
+        }
+    }
+}
+
+#[allow(unused)]
+impl AsymmEncString {
+    /// TODO: Convert this to a trait method
+    #[cfg(feature = "internal")]
+    pub(crate) fn decrypt_with_private_key(&self, key: &RsaPrivateKey) -> Result<Vec<u8>> {
+        Ok(match self {
+            Self::Rsa2048_OaepSha256_B64 { data } => key.decrypt(Oaep::new::<sha2::Sha256>(), data),
+            Self::Rsa2048_OaepSha1_B64 { data } => key.decrypt(Oaep::new::<sha1::Sha1>(), data),
+            #[allow(deprecated)]
+            Self::Rsa2048_OaepSha256_HmacSha256_B64 { data, mac: _ } => {
+                key.decrypt(Oaep::new::<sha2::Sha256>(), data)
+            }
+            #[allow(deprecated)]
+            Self::Rsa2048_OaepSha1_HmacSha256_B64 { data, mac: _ } => {
+                key.decrypt(Oaep::new::<sha1::Sha1>(), data)
+            }
+        }
+        .map_err(|_| CryptoError::KeyDecrypt)?)
+    }
+}
+
+impl Display for AsymmEncString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let parts: Vec<&[u8]> = match self {
+            AsymmEncString::Rsa2048_OaepSha256_B64 { data } => vec![data],
+            AsymmEncString::Rsa2048_OaepSha1_B64 { data } => vec![data],
+            #[allow(deprecated)]
+            AsymmEncString::Rsa2048_OaepSha256_HmacSha256_B64 { data, mac } => vec![data, mac],
+            #[allow(deprecated)]
+            AsymmEncString::Rsa2048_OaepSha1_HmacSha256_B64 { data, mac } => vec![data, mac],
+        };
+
+        let encoded_parts: Vec<String> = parts
+            .iter()
+            .map(|part| BASE64_ENGINE.encode(part))
+            .collect();
+
+        write!(f, "{}.{}", self.enc_type(), encoded_parts.join("|"))?;
+
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AsymmEncString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct CSVisitor;
+        impl Visitor<'_> for CSVisitor {
+            type Value = AsymmEncString;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "a valid string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                AsymmEncString::from_str(v).map_err(|e| E::custom(format!("{:?}", e)))
+            }
+        }
+
+        deserializer.deserialize_str(CSVisitor)
+    }
+}
+
+impl serde::Serialize for AsymmEncString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl AsymmEncString {
+    /// The numerical representation of the encryption type of the [AsymmEncString].
+    const fn enc_type(&self) -> u8 {
+        match self {
+            AsymmEncString::Rsa2048_OaepSha256_B64 { .. } => 3,
+            AsymmEncString::Rsa2048_OaepSha1_B64 { .. } => 4,
+            #[allow(deprecated)]
+            AsymmEncString::Rsa2048_OaepSha256_HmacSha256_B64 { .. } => 5,
+            #[allow(deprecated)]
+            AsymmEncString::Rsa2048_OaepSha1_HmacSha256_B64 { .. } => 6,
+        }
+    }
+}
+
+/// Usually we wouldn't want to expose AsymmEncStrings in the API or the schemas.
+/// But during the transition phase we will expose endpoints using the AsymmEncString type.
+impl schemars::JsonSchema for AsymmEncString {
+    fn schema_name() -> String {
+        "AsymmEncString".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        gen.subschema_for::<String>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AsymmEncString;
+
+    #[cfg(feature = "internal")]
+    #[test]
+    fn test_enc_string_rsa2048_oaep_sha1_hmac_sha256_b64() {
+        use rsa::{pkcs8::DecodePrivateKey, RsaPrivateKey};
+
+        let rsa_private_key: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCXRVrCX+2hfOQS
+8HzYUS2oc/jGVTZpv+/Ryuoh9d8ihYX9dd0cYh2tl6KWdFc88lPUH11Oxqy20Rk2
+e5r/RF6T9yM0Me3NPnaKt+hlhLtfoc0h86LnhD56A9FDUfuI0dVnPcrwNv0YJIo9
+4LwxtbqBULNvXl6wJ7WAbODrCQy5ZgMVg+iH+gGpwiqsZqHt+KuoHWcN53MSPDfa
+F4/YMB99U3TziJMOOJask1TEEnakMPln11PczNDazT17DXIxYrbPfutPdh6sLs6A
+QOajdZijfEvepgnOe7cQ7aeatiOJFrjTApKPGxOVRzEMX4XS4xbyhH0QxQeB6l16
+l8C0uxIBAgMBAAECggEASaWfeVDA3cVzOPFSpvJm20OTE+R6uGOU+7vh36TX/POq
+92qBuwbd0h0oMD32FxsXywd2IxtBDUSiFM9699qufTVuM0Q3tZw6lHDTOVG08+tP
+dr8qSbMtw7PGFxN79fHLBxejjO4IrM9lapjWpxEF+11x7r+wM+0xRZQ8sNFYG46a
+PfIaty4BGbL0I2DQ2y8I57iBCAy69eht59NLMm27fRWGJIWCuBIjlpfzET1j2HLX
+UIh5bTBNzqaN039WH49HczGE3mQKVEJZc/efk3HaVd0a1Sjzyn0QY+N1jtZN3jTR
+buDWA1AknkX1LX/0tUhuS3/7C3ejHxjw4Dk1ZLo5/QKBgQDIWvqFn0+IKRSu6Ua2
+hDsufIHHUNLelbfLUMmFthxabcUn4zlvIscJO00Tq/ezopSRRvbGiqnxjv/mYxuc
+vOUBeZtlus0Q9RTACBtw9TGoNTmQbEunJ2FOSlqbQxkBBAjgGEppRPt30iGj/VjA
+hCATq2MYOa/X4dVR51BqQAFIEwKBgQDBSIfTFKC/hDk6FKZlgwvupWYJyU9Rkyfs
+tPErZFmzoKhPkQ3YORo2oeAYmVUbS9I2iIYpYpYQJHX8jMuCbCz4ONxTCuSIXYQY
+UcUq4PglCKp31xBAE6TN8SvhfME9/MvuDssnQinAHuF0GDAhF646T3LLS1not6Vs
+zv7brwSoGwKBgQC88v/8cGfi80ssQZeMnVvq1UTXIeQcQnoY5lGHJl3K8mbS3TnX
+E6c9j417Fdz+rj8KWzBzwWXQB5pSPflWcdZO886Xu/mVGmy9RWgLuVFhXwCwsVEP
+jNX5ramRb0/vY0yzenUCninBsIxFSbIfrPtLUYCc4hpxr+sr2Mg/y6jpvQKBgBez
+MRRs3xkcuXepuI2R+BCXL1/b02IJTUf1F+1eLLGd7YV0H+J3fgNc7gGWK51hOrF9
+JBZHBGeOUPlaukmPwiPdtQZpu4QNE3l37VlIpKTF30E6mb+BqR+nht3rUjarnMXg
+AoEZ18y6/KIjpSMpqC92Nnk/EBM9EYe6Cf4eA9ApAoGAeqEUg46UTlJySkBKURGp
+Is3v1kkf5I0X8DnOhwb+HPxNaiEdmO7ckm8+tPVgppLcG0+tMdLjigFQiDUQk2y3
+WjyxP5ZvXu7U96jaJRI8PFMoE06WeVYcdIzrID2HvqH+w0UQJFrLJ/0Mn4stFAEz
+XKZBokBGnjFnTnKcs7nv/O8=
+-----END PRIVATE KEY-----";
+        let private_key = RsaPrivateKey::from_pkcs8_pem(rsa_private_key).unwrap();
+        let enc_str: &str = "6.ThnNc67nNr7GELyuhGGfsXNP2zJnNqhrIsjntEQ27r2qmn8vwdHbTbfO0cwt6YgSibDN0PjiCZ1O3Wb/IFq+vwvyRwFqF9145wBF8CQCbkhV+M0XvO99kh0daovtt120Nve/5ETI5PbPag9VdalKRQWZypJaqQHm5TAQVf4F5wtLlCLMBkzqTk+wkFe7BPMTGn07T+O3eJbTxXvyMZewQ7icJF0MZVA7VyWX9qElmZ89FCKowbf1BMr5pbcQ+0KdXcSVW3to43VkTp7k7COwsuH3M/i1AuVP5YN8ixjyRpvaeGqX/ap2nCHK2Wj5VxgCGT7XEls6ZknnAp9nB9qVjQ==|s3ntw5H/KKD/qsS0lUghTHl5Sm9j6m7YEdNHf0OeAFQ=";
+        let enc_string: AsymmEncString = enc_str.parse().unwrap();
+
+        assert_eq!(enc_string.enc_type(), 6);
+
+        let res = enc_string.decrypt_with_private_key(&private_key).unwrap();
+
+        assert_eq!(std::str::from_utf8(&res).unwrap(), "EncryptMe!");
+    }
+
+    #[test]
+    fn test_enc_string_serialization() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Test {
+            key: AsymmEncString,
+        }
+
+        let cipher = "6.ThnNc67nNr7GELyuhGGfsXNP2zJnNqhrIsjntEQ27r2qmn8vwdHbTbfO0cwt6YgSibDN0PjiCZ1O3Wb/IFq+vwvyRwFqF9145wBF8CQCbkhV+M0XvO99kh0daovtt120Nve/5ETI5PbPag9VdalKRQWZypJaqQHm5TAQVf4F5wtLlCLMBkzqTk+wkFe7BPMTGn07T+O3eJbTxXvyMZewQ7icJF0MZVA7VyWX9qElmZ89FCKowbf1BMr5pbcQ+0KdXcSVW3to43VkTp7k7COwsuH3M/i1AuVP5YN8ixjyRpvaeGqX/ap2nCHK2Wj5VxgCGT7XEls6ZknnAp9nB9qVjQ==|s3ntw5H/KKD/qsS0lUghTHl5Sm9j6m7YEdNHf0OeAFQ=";
+        let serialized = format!("{{\"key\":\"{cipher}\"}}");
+
+        let t = serde_json::from_str::<Test>(&serialized).unwrap();
+        assert_eq!(t.key.enc_type(), 6);
+        assert_eq!(t.key.to_string(), cipher);
+        assert_eq!(serde_json::to_string(&t).unwrap(), serialized);
+    }
+}

--- a/crates/bitwarden/src/crypto/enc_string/mod.rs
+++ b/crates/bitwarden/src/crypto/enc_string/mod.rs
@@ -1,0 +1,54 @@
+mod asymmetric;
+mod symmetric;
+
+pub use asymmetric::AsymmEncString;
+use base64::Engine;
+pub use symmetric::EncString;
+
+use crate::{
+    error::{EncStringParseError, Result},
+    util::BASE64_ENGINE,
+};
+
+#[cfg(feature = "mobile")]
+fn check_length(buf: &[u8], expected: usize) -> Result<()> {
+    if buf.len() < expected {
+        return Err(EncStringParseError::InvalidLength {
+            expected,
+            got: buf.len(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn from_b64_vec(s: &str) -> Result<Vec<u8>> {
+    Ok(BASE64_ENGINE
+        .decode(s)
+        .map_err(EncStringParseError::InvalidBase64)?)
+}
+
+fn from_b64<const N: usize>(s: &str) -> Result<[u8; N]> {
+    Ok(from_b64_vec(s)?
+        .try_into()
+        .map_err(|e: Vec<_>| EncStringParseError::InvalidLength {
+            expected: N,
+            got: e.len(),
+        })?)
+}
+
+fn split_enc_string(s: &str) -> (&str, Vec<&str>) {
+    let header_parts: Vec<_> = s.split('.').collect();
+
+    if header_parts.len() == 2 {
+        (header_parts[0], header_parts[1].split('|').collect())
+    } else {
+        // Support legacy format with no header
+        let parts: Vec<_> = s.split('|').collect();
+        if parts.len() == 3 {
+            ("1", parts) // AesCbc128_HmacSha256_B64
+        } else {
+            ("0", parts) // AesCbc256_B64
+        }
+    }
+}

--- a/crates/bitwarden/src/crypto/enc_string/symmetric.rs
+++ b/crates/bitwarden/src/crypto/enc_string/symmetric.rs
@@ -2,20 +2,20 @@ use std::{fmt::Display, str::FromStr};
 
 use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::Engine;
-#[cfg(feature = "internal")]
-use rsa::{Oaep, RsaPrivateKey};
 use serde::{de::Visitor, Deserialize};
 
-use super::{KeyDecryptable, KeyEncryptable, LocateKey};
+#[cfg(feature = "mobile")]
+use super::check_length;
+use super::{from_b64, from_b64_vec, split_enc_string};
 use crate::{
-    crypto::{decrypt_aes256_hmac, SymmetricCryptoKey},
+    crypto::{decrypt_aes256_hmac, KeyDecryptable, KeyEncryptable, LocateKey, SymmetricCryptoKey},
     error::{CryptoError, EncStringParseError, Error, Result},
     util::BASE64_ENGINE,
 };
 
 /// # Encrypted string primitive
 ///
-/// [EncString] is a Bitwarden specific primitive that represents an encrypted string. They are
+/// [EncString] is a Bitwarden specific primitive that represents a symmetrically encrypted string. They are
 /// are used together with the [KeyDecryptable] and [KeyEncryptable] traits to encrypt and decrypt
 /// data using [SymmetricCryptoKey]s.
 ///
@@ -24,9 +24,6 @@ use crate::{
 ///
 /// ## Note
 ///
-/// We are currently in the progress of splitting the [EncString] into distinct AES and RSA
-/// variants. To provide better control of which encryption algorithm is expected.
-///
 /// For backwards compatibility we will rarely if ever be able to remove support for decrypting old
 /// variants, but we should be opinionated in which variants are used for encrypting.
 ///
@@ -34,8 +31,6 @@ use crate::{
 /// - [AesCbc256_B64](EncString::AesCbc256_B64)
 /// - [AesCbc128_HmacSha256_B64](EncString::AesCbc128_HmacSha256_B64)
 /// - [AesCbc256_HmacSha256_B64](EncString::AesCbc256_HmacSha256_B64)
-/// - [Rsa2048_OaepSha256_B64](EncString::Rsa2048_OaepSha256_B64)
-/// - [Rsa2048_OaepSha1_B64](EncString::Rsa2048_OaepSha1_B64)
 ///
 /// ## Serialization
 ///
@@ -45,7 +40,6 @@ use crate::{
 /// The scheme is one of the following schemes:
 /// - `[type].[iv]|[data]`
 /// - `[type].[iv]|[data]|[mac]`
-/// - `[type].[data]`
 ///
 /// Where:
 /// - `[type]`: is a digit number representing the variant.
@@ -69,16 +63,6 @@ pub enum EncString {
         mac: [u8; 32],
         data: Vec<u8>,
     },
-    /// 3
-    Rsa2048_OaepSha256_B64 { data: Vec<u8> },
-    /// 4
-    Rsa2048_OaepSha1_B64 { data: Vec<u8> },
-    /// 5
-    #[deprecated]
-    Rsa2048_OaepSha256_HmacSha256_B64 { data: Vec<u8> },
-    /// 6
-    #[deprecated]
-    Rsa2048_OaepSha1_HmacSha256_B64 { data: Vec<u8> },
 }
 
 /// To avoid printing sensitive information, [EncString] debug prints to `EncString`.
@@ -93,32 +77,7 @@ impl FromStr for EncString {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (enc_type, parts): (&str, Vec<_>) = {
-            let header_parts: Vec<_> = s.split('.').collect();
-
-            if header_parts.len() == 2 {
-                (header_parts[0], header_parts[1].split('|').collect())
-            } else {
-                // Support legacy format with no header
-                let parts: Vec<_> = s.split('|').collect();
-                if parts.len() == 3 {
-                    ("1", parts) // AesCbc128_HmacSha256_B64
-                } else {
-                    ("0", parts) // AesCbc256_B64
-                }
-            }
-        };
-
-        fn from_b64_vec(s: &str) -> Result<Vec<u8>> {
-            Ok(BASE64_ENGINE
-                .decode(s)
-                .map_err(EncStringParseError::InvalidBase64)?)
-        }
-
-        fn from_b64<const N: usize>(s: &str) -> Result<[u8; N]> {
-            Ok(from_b64_vec(s)?.try_into().map_err(invalid_len_error(N))?)
-        }
-
+        let (enc_type, parts) = split_enc_string(s);
         match (enc_type, parts.len()) {
             ("0", 2) => {
                 let iv = from_b64(parts[0])?;
@@ -137,24 +96,6 @@ impl FromStr for EncString {
                     Ok(EncString::AesCbc256_HmacSha256_B64 { iv, mac, data })
                 }
             }
-            ("3", 1) => {
-                let data = from_b64_vec(parts[0])?;
-                Ok(EncString::Rsa2048_OaepSha256_B64 { data })
-            }
-            ("4", 1) => {
-                let data = from_b64_vec(parts[0])?;
-                Ok(EncString::Rsa2048_OaepSha1_B64 { data })
-            }
-            #[allow(deprecated)]
-            ("5", 2) => {
-                let data = from_b64_vec(parts[0])?;
-                Ok(EncString::Rsa2048_OaepSha256_HmacSha256_B64 { data })
-            }
-            #[allow(deprecated)]
-            ("6", 2) => {
-                let data = from_b64_vec(parts[0])?;
-                Ok(EncString::Rsa2048_OaepSha1_HmacSha256_B64 { data })
-            }
 
             (enc_type, parts) => Err(EncStringParseError::InvalidType {
                 enc_type: enc_type.to_string(),
@@ -172,46 +113,12 @@ impl EncString {
         s.map(|s| s.parse()).transpose()
     }
 
-    /// TODO: Convert this to a trait method
-    #[cfg(feature = "internal")]
-    pub(crate) fn decrypt_with_private_key(&self, key: &RsaPrivateKey) -> Result<Vec<u8>> {
-        Ok(match self {
-            EncString::Rsa2048_OaepSha256_B64 { data } => {
-                key.decrypt(Oaep::new::<sha2::Sha256>(), data)
-            }
-            EncString::Rsa2048_OaepSha1_B64 { data } => {
-                key.decrypt(Oaep::new::<sha1::Sha1>(), data)
-            }
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha256_HmacSha256_B64 { data } => {
-                key.decrypt(Oaep::new::<sha2::Sha256>(), data)
-            }
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha1_HmacSha256_B64 { data } => {
-                key.decrypt(Oaep::new::<sha1::Sha1>(), data)
-            }
-            _ => return Err(CryptoError::InvalidKey.into()),
-        }
-        .map_err(|_| CryptoError::KeyDecrypt)?)
-    }
-
     #[cfg(feature = "mobile")]
     pub(crate) fn from_buffer(buf: &[u8]) -> Result<Self> {
         if buf.is_empty() {
             return Err(EncStringParseError::NoType.into());
         }
         let enc_type = buf[0];
-
-        fn check_length(buf: &[u8], expected: usize) -> Result<()> {
-            if buf.len() < expected {
-                return Err(EncStringParseError::InvalidLength {
-                    expected,
-                    got: buf.len(),
-                }
-                .into());
-            }
-            Ok(())
-        }
 
         match enc_type {
             0 => {
@@ -232,28 +139,6 @@ impl EncString {
                 } else {
                     Ok(EncString::AesCbc256_HmacSha256_B64 { iv, mac, data })
                 }
-            }
-            3 => {
-                check_length(buf, 2)?;
-                let data = buf[1..].to_vec();
-                Ok(EncString::Rsa2048_OaepSha256_B64 { data })
-            }
-            4 => {
-                check_length(buf, 2)?;
-                let data = buf[1..].to_vec();
-                Ok(EncString::Rsa2048_OaepSha1_B64 { data })
-            }
-            #[allow(deprecated)]
-            5 => {
-                check_length(buf, 2)?;
-                let data = buf[1..].to_vec();
-                Ok(EncString::Rsa2048_OaepSha256_HmacSha256_B64 { data })
-            }
-            #[allow(deprecated)]
-            6 => {
-                check_length(buf, 2)?;
-                let data = buf[1..].to_vec();
-                Ok(EncString::Rsa2048_OaepSha1_HmacSha256_B64 { data })
             }
             _ => Err(EncStringParseError::InvalidType {
                 enc_type: enc_type.to_string(),
@@ -282,20 +167,6 @@ impl EncString {
                 buf.extend_from_slice(mac);
                 buf.extend_from_slice(data);
             }
-
-            EncString::Rsa2048_OaepSha256_B64 { data }
-            | EncString::Rsa2048_OaepSha1_B64 { data } => {
-                buf = Vec::with_capacity(1 + data.len());
-                buf.push(self.enc_type());
-                buf.extend_from_slice(data);
-            }
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha256_HmacSha256_B64 { data }
-            | EncString::Rsa2048_OaepSha1_HmacSha256_B64 { data } => {
-                buf = Vec::with_capacity(1 + data.len());
-                buf.push(self.enc_type());
-                buf.extend_from_slice(data);
-            }
         }
 
         Ok(buf)
@@ -308,12 +179,6 @@ impl Display for EncString {
             EncString::AesCbc256_B64 { iv, data } => vec![iv, data],
             EncString::AesCbc128_HmacSha256_B64 { iv, mac, data } => vec![iv, data, mac],
             EncString::AesCbc256_HmacSha256_B64 { iv, mac, data } => vec![iv, data, mac],
-            EncString::Rsa2048_OaepSha256_B64 { data } => vec![data],
-            EncString::Rsa2048_OaepSha1_B64 { data } => vec![data],
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha256_HmacSha256_B64 { data } => vec![data],
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha1_HmacSha256_B64 { data } => vec![data],
         };
 
         let encoded_parts: Vec<String> = parts
@@ -367,7 +232,7 @@ impl EncString {
         mac_key: GenericArray<u8, U32>,
         key: GenericArray<u8, U32>,
     ) -> Result<EncString> {
-        let (iv, mac, data) = super::encrypt_aes256_hmac(data_dec, mac_key, key)?;
+        let (iv, mac, data) = crate::crypto::encrypt_aes256_hmac(data_dec, mac_key, key)?;
         Ok(EncString::AesCbc256_HmacSha256_B64 { iv, mac, data })
     }
 
@@ -377,20 +242,7 @@ impl EncString {
             EncString::AesCbc256_B64 { .. } => 0,
             EncString::AesCbc128_HmacSha256_B64 { .. } => 1,
             EncString::AesCbc256_HmacSha256_B64 { .. } => 2,
-            EncString::Rsa2048_OaepSha256_B64 { .. } => 3,
-            EncString::Rsa2048_OaepSha1_B64 { .. } => 4,
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha256_HmacSha256_B64 { .. } => 5,
-            #[allow(deprecated)]
-            EncString::Rsa2048_OaepSha1_HmacSha256_B64 { .. } => 6,
         }
-    }
-}
-
-fn invalid_len_error(expected: usize) -> impl Fn(Vec<u8>) -> EncStringParseError {
-    move |e: Vec<_>| EncStringParseError::InvalidLength {
-        expected,
-        got: e.len(),
     }
 }
 
@@ -429,7 +281,7 @@ impl KeyDecryptable<String> for EncString {
 
 /// Usually we wouldn't want to expose EncStrings in the API or the schemas.
 /// But during the transition phase we will expose endpoints using the EncString type.
-impl schemars::JsonSchema for crate::crypto::EncString {
+impl schemars::JsonSchema for EncString {
     fn schema_name() -> String {
         "EncString".to_string()
     }
@@ -453,50 +305,6 @@ mod tests {
 
         let decrypted_str: String = cipher.decrypt_with_key(&key).unwrap();
         assert_eq!(decrypted_str, test_string);
-    }
-
-    #[cfg(feature = "internal")]
-    #[test]
-    fn test_enc_string_rsa2048_oaep_sha1_hmac_sha256_b64() {
-        use rsa::{pkcs8::DecodePrivateKey, RsaPrivateKey};
-
-        let rsa_private_key: &str = "-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCXRVrCX+2hfOQS
-8HzYUS2oc/jGVTZpv+/Ryuoh9d8ihYX9dd0cYh2tl6KWdFc88lPUH11Oxqy20Rk2
-e5r/RF6T9yM0Me3NPnaKt+hlhLtfoc0h86LnhD56A9FDUfuI0dVnPcrwNv0YJIo9
-4LwxtbqBULNvXl6wJ7WAbODrCQy5ZgMVg+iH+gGpwiqsZqHt+KuoHWcN53MSPDfa
-F4/YMB99U3TziJMOOJask1TEEnakMPln11PczNDazT17DXIxYrbPfutPdh6sLs6A
-QOajdZijfEvepgnOe7cQ7aeatiOJFrjTApKPGxOVRzEMX4XS4xbyhH0QxQeB6l16
-l8C0uxIBAgMBAAECggEASaWfeVDA3cVzOPFSpvJm20OTE+R6uGOU+7vh36TX/POq
-92qBuwbd0h0oMD32FxsXywd2IxtBDUSiFM9699qufTVuM0Q3tZw6lHDTOVG08+tP
-dr8qSbMtw7PGFxN79fHLBxejjO4IrM9lapjWpxEF+11x7r+wM+0xRZQ8sNFYG46a
-PfIaty4BGbL0I2DQ2y8I57iBCAy69eht59NLMm27fRWGJIWCuBIjlpfzET1j2HLX
-UIh5bTBNzqaN039WH49HczGE3mQKVEJZc/efk3HaVd0a1Sjzyn0QY+N1jtZN3jTR
-buDWA1AknkX1LX/0tUhuS3/7C3ejHxjw4Dk1ZLo5/QKBgQDIWvqFn0+IKRSu6Ua2
-hDsufIHHUNLelbfLUMmFthxabcUn4zlvIscJO00Tq/ezopSRRvbGiqnxjv/mYxuc
-vOUBeZtlus0Q9RTACBtw9TGoNTmQbEunJ2FOSlqbQxkBBAjgGEppRPt30iGj/VjA
-hCATq2MYOa/X4dVR51BqQAFIEwKBgQDBSIfTFKC/hDk6FKZlgwvupWYJyU9Rkyfs
-tPErZFmzoKhPkQ3YORo2oeAYmVUbS9I2iIYpYpYQJHX8jMuCbCz4ONxTCuSIXYQY
-UcUq4PglCKp31xBAE6TN8SvhfME9/MvuDssnQinAHuF0GDAhF646T3LLS1not6Vs
-zv7brwSoGwKBgQC88v/8cGfi80ssQZeMnVvq1UTXIeQcQnoY5lGHJl3K8mbS3TnX
-E6c9j417Fdz+rj8KWzBzwWXQB5pSPflWcdZO886Xu/mVGmy9RWgLuVFhXwCwsVEP
-jNX5ramRb0/vY0yzenUCninBsIxFSbIfrPtLUYCc4hpxr+sr2Mg/y6jpvQKBgBez
-MRRs3xkcuXepuI2R+BCXL1/b02IJTUf1F+1eLLGd7YV0H+J3fgNc7gGWK51hOrF9
-JBZHBGeOUPlaukmPwiPdtQZpu4QNE3l37VlIpKTF30E6mb+BqR+nht3rUjarnMXg
-AoEZ18y6/KIjpSMpqC92Nnk/EBM9EYe6Cf4eA9ApAoGAeqEUg46UTlJySkBKURGp
-Is3v1kkf5I0X8DnOhwb+HPxNaiEdmO7ckm8+tPVgppLcG0+tMdLjigFQiDUQk2y3
-WjyxP5ZvXu7U96jaJRI8PFMoE06WeVYcdIzrID2HvqH+w0UQJFrLJ/0Mn4stFAEz
-XKZBokBGnjFnTnKcs7nv/O8=
------END PRIVATE KEY-----";
-        let private_key = RsaPrivateKey::from_pkcs8_pem(rsa_private_key).unwrap();
-        let enc_str: &str = "6.ThnNc67nNr7GELyuhGGfsXNP2zJnNqhrIsjntEQ27r2qmn8vwdHbTbfO0cwt6YgSibDN0PjiCZ1O3Wb/IFq+vwvyRwFqF9145wBF8CQCbkhV+M0XvO99kh0daovtt120Nve/5ETI5PbPag9VdalKRQWZypJaqQHm5TAQVf4F5wtLlCLMBkzqTk+wkFe7BPMTGn07T+O3eJbTxXvyMZewQ7icJF0MZVA7VyWX9qElmZ89FCKowbf1BMr5pbcQ+0KdXcSVW3to43VkTp7k7COwsuH3M/i1AuVP5YN8ixjyRpvaeGqX/ap2nCHK2Wj5VxgCGT7XEls6ZknnAp9nB9qVjQ==|s3ntw5H/KKD/qsS0lUghTHl5Sm9j6m7YEdNHf0OeAFQ=";
-        let enc_string: EncString = enc_str.parse().unwrap();
-
-        assert_eq!(enc_string.enc_type(), 6);
-
-        let res = enc_string.decrypt_with_private_key(&private_key).unwrap();
-
-        assert_eq!(std::str::from_utf8(&res).unwrap(), "EncryptMe!");
     }
 
     #[test]

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -27,7 +27,7 @@ use hmac::digest::OutputSizeUser;
 use crate::error::Result;
 
 mod enc_string;
-pub use enc_string::EncString;
+pub use enc_string::{AsymmEncString, EncString};
 mod encryptable;
 pub use encryptable::{Decryptable, Encryptable, LocateKey};
 mod key_encryptable;

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -106,8 +106,10 @@ pub enum CryptoError {
 pub enum EncStringParseError {
     #[error("No type detected, missing '.' separator")]
     NoType,
-    #[error("Invalid type, got {enc_type} with {parts} parts")]
-    InvalidType { enc_type: String, parts: usize },
+    #[error("Invalid symmetric type, got type {enc_type} with {parts} parts")]
+    InvalidTypeSymm { enc_type: String, parts: usize },
+    #[error("Invalid asymmetric type, got type {enc_type} with {parts} parts")]
+    InvalidTypeAsymm { enc_type: String, parts: usize },
     #[error("Error decoding base64: {0}")]
     InvalidBase64(#[from] base64::DecodeError),
     #[error("Invalid length: expected {expected}, got {got}")]

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     client::kdf::Kdf,
-    crypto::EncString,
+    crypto::{AsymmEncString, EncString},
     error::{Error, Result},
     Client,
 };
@@ -87,7 +87,7 @@ pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequ
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct InitOrgCryptoRequest {
     /// The encryption keys for all the organizations the user is a part of
-    pub organization_keys: HashMap<uuid::Uuid, EncString>,
+    pub organization_keys: HashMap<uuid::Uuid, AsymmEncString>,
 }
 
 #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/uniffi_support.rs
+++ b/crates/bitwarden/src/uniffi_support.rs
@@ -2,7 +2,11 @@ use std::{num::NonZeroU32, str::FromStr};
 
 use uuid::Uuid;
 
-use crate::{crypto::EncString, error::Error, UniffiCustomTypeConverter};
+use crate::{
+    crypto::{AsymmEncString, EncString},
+    error::Error,
+    UniffiCustomTypeConverter,
+};
 
 uniffi::custom_type!(NonZeroU32, u32);
 
@@ -21,6 +25,20 @@ impl UniffiCustomTypeConverter for NonZeroU32 {
 uniffi::custom_type!(EncString, String);
 
 impl UniffiCustomTypeConverter for EncString {
+    type Builtin = String;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+        Self::from_str(&val).map_err(|e| e.into())
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.to_string()
+    }
+}
+
+uniffi::custom_type!(AsymmEncString, String);
+
+impl UniffiCustomTypeConverter for AsymmEncString {
     type Builtin = String;
 
     fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Split `EncString` into an asymmetric variant. I've left the symmetric variant with the name `EncString` as it's the most common variant to avoid major changes.

This is somewhat related to #447 and should be merged first so that PR can take advantage of the symm/asymm separation.

I've moved the `EncString` files into their own folder to organize the crypto directory a bit better too.
