### PR TITLE
Change attachment key to EncString

### DIFF
--- a/crates/bitwarden/src/vault/cipher/attachment.rs
+++ b/crates/bitwarden/src/vault/cipher/attachment.rs
@@ -28,7 +28,7 @@ pub struct AttachmentView {
     pub size: Option<String>,
     pub size_name: Option<String>,
     pub file_name: Option<String>,
-    pub key: Option<Vec<u8>>, // TODO: Should be made into SymmetricCryptoKey
+    pub key: Option<EncString>,
 }
 
 impl KeyEncryptable<Attachment> for AttachmentView {
@@ -39,7 +39,7 @@ impl KeyEncryptable<Attachment> for AttachmentView {
             size: self.size,
             size_name: self.size_name,
             file_name: self.file_name.encrypt_with_key(key)?,
-            key: self.key.as_deref().encrypt_with_key(key)?,
+            key: self.key,
         })
     }
 }
@@ -52,7 +52,7 @@ impl KeyDecryptable<AttachmentView> for Attachment {
             size: self.size.clone(),
             size_name: self.size_name.clone(),
             file_name: self.file_name.decrypt_with_key(key)?,
-            key: self.key.decrypt_with_key(key)?,
+            key: self.key.clone(),
         })
     }
 }


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Change `AttachmentView` key to be an `EncString`, and skip decrypting it. This is to avoid a uniffi issue with the representation of Vec<u8> on Android.

Note that this is very similar to what we're doing with Sends, where we don't decrypt the key on the model either until we're ready to decrypt the file.