### PR TITLE
Change jwt parsing to use URL_SAFE_NO_PAD

### DIFF
--- a/crates/bitwarden/src/auth/jwt_token.rs
+++ b/crates/bitwarden/src/auth/jwt_token.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use base64::Engine;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
-use crate::{error::Result, util::BASE64_ENGINE};
+use crate::error::Result;
 
 /// A Bitwarden secrets manager JWT Token.
 ///
@@ -31,7 +31,7 @@ impl FromStr for JWTToken {
         if split.len() != 3 {
             return Err("JWT token has an invalid number of parts".into());
         }
-        let decoded = BASE64_ENGINE.decode(split[1])?;
+        let decoded = URL_SAFE_NO_PAD.decode(split[1])?;
         Ok(serde_json::from_slice(&decoded)?)
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

JWT should be url encoded and never use padding.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
