### PR TITLE
Make model IDs optional

### DIFF
--- a/crates/bitwarden/src/vault/collection.rs
+++ b/crates/bitwarden/src/vault/collection.rs
@@ -13,7 +13,7 @@ use crate::{
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct Collection {
-    id: Uuid,
+    id: Option<Uuid>,
     organization_id: Uuid,
 
     name: EncString,
@@ -27,7 +27,7 @@ pub struct Collection {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct CollectionView {
-    id: Uuid,
+    id: Option<Uuid>,
     organization_id: Uuid,
 
     name: String,
@@ -66,7 +66,7 @@ impl TryFrom<CollectionDetailsResponseModel> for Collection {
 
     fn try_from(collection: CollectionDetailsResponseModel) -> Result<Self> {
         Ok(Collection {
-            id: collection.id.ok_or(Error::MissingFields)?,
+            id: collection.id,
             organization_id: collection.organization_id.ok_or(Error::MissingFields)?,
             name: collection.name.ok_or(Error::MissingFields)?.parse()?,
             external_id: collection.external_id,

--- a/crates/bitwarden/src/vault/folder.rs
+++ b/crates/bitwarden/src/vault/folder.rs
@@ -13,7 +13,7 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct Folder {
-    id: Uuid,
+    id: Option<Uuid>,
     name: EncString,
     revision_date: DateTime<Utc>,
 }
@@ -22,7 +22,7 @@ pub struct Folder {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct FolderView {
-    id: Uuid,
+    id: Option<Uuid>,
     name: String,
     revision_date: DateTime<Utc>,
 }
@@ -54,7 +54,7 @@ impl TryFrom<FolderResponseModel> for Folder {
 
     fn try_from(folder: FolderResponseModel) -> Result<Self> {
         Ok(Folder {
-            id: folder.id.ok_or(Error::MissingFields)?,
+            id: folder.id,
             name: EncString::try_from_optional(folder.name)?.ok_or(Error::MissingFields)?,
             revision_date: folder.revision_date.ok_or(Error::MissingFields)?.parse()?,
         })

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -63,8 +63,8 @@ pub enum SendType {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct Send {
-    pub id: Uuid,
-    pub access_id: String,
+    pub id: Option<Uuid>,
+    pub access_id: Option<String>,
 
     pub name: EncString,
     pub notes: Option<EncString>,
@@ -89,8 +89,8 @@ pub struct Send {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct SendView {
-    pub id: Uuid,
-    pub access_id: String,
+    pub id: Option<Uuid>,
+    pub access_id: Option<String>,
 
     pub name: String,
     pub notes: Option<String>,
@@ -115,8 +115,8 @@ pub struct SendView {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct SendListView {
-    pub id: Uuid,
-    pub access_id: String,
+    pub id: Option<Uuid>,
+    pub access_id: Option<String>,
 
     pub name: String,
 
@@ -270,8 +270,8 @@ impl TryFrom<SendResponseModel> for Send {
 
     fn try_from(send: SendResponseModel) -> Result<Self> {
         Ok(Send {
-            id: send.id.ok_or(Error::MissingFields)?,
-            access_id: send.access_id.ok_or(Error::MissingFields)?,
+            id: send.id,
+            access_id: send.access_id,
             name: send.name.ok_or(Error::MissingFields)?.parse()?,
             notes: EncString::try_from_optional(send.notes)?,
             key: send.key.ok_or(Error::MissingFields)?.parse()?,
@@ -348,8 +348,8 @@ mod tests {
 
         // Create a send object, the only value we really care about here is the key
         let send = Send {
-            id: "d7fb1e7f-9053-43c0-a02c-b0690098685a".parse().unwrap(),
-            access_id: "fx7711OQwEOgLLBpAJhoWg".into(),
+            id: Some("d7fb1e7f-9053-43c0-a02c-b0690098685a".parse().unwrap()),
+            access_id: Some("fx7711OQwEOgLLBpAJhoWg".into()),
             name: "2.u5vXPAepUZ+4lI2vGGKiGg==|hEouC4SvCCb/ifzZzLcfSw==|E2VZUVffehczfIuRSlX2vnPRfflBtXef5tzsWvRrtfM="
                 .parse()
                 .unwrap(),


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Previously some of the model structs had non-optional IDs, this won't work when trying to encrypt a new item, as you won't have an ID until you POST it to the server.

This PR changes the id fields to be optional, matching what we already do on Cipher.