### PR TITLE
Convert totp secret to uppercase

### DIFF
--- a/crates/bitwarden/src/vault/totp.rs
+++ b/crates/bitwarden/src/vault/totp.rs
@@ -129,7 +129,7 @@ impl FromStr for Totp {
     fn from_str(key: &str) -> Result<Self> {
         fn decode_secret(secret: &str) -> Result<Vec<u8>> {
             BASE32
-                .decode(secret.as_bytes())
+                .decode(secret.to_uppercase().as_bytes())
                 .map_err(|_| "Unable to decode secret".into())
         }
 
@@ -219,6 +219,20 @@ mod tests {
     #[test]
     fn test_generate_totp() {
         let key = "WQIQ25BRKZYCJVYP".to_string();
+        let time = Some(
+            DateTime::parse_from_rfc3339("2023-01-01T00:00:00.000Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        let response = generate_totp(key, time).unwrap();
+
+        assert_eq!(response.code, "194506".to_string());
+        assert_eq!(response.period, 30);
+    }
+
+    #[test]
+    fn test_lowercase_secret() {
+        let key = "wqiq25brkzycjvyp".to_string();
         let time = Some(
             DateTime::parse_from_rfc3339("2023-01-01T00:00:00.000Z")
                 .unwrap()


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Some totp providers use lowercase secrets. This isn't valid base32 though and needs to be transformed into uppercase prior to parsing.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
