### PR TITLE
Support generating a random send key if none is provided

### DIFF
--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -78,7 +78,7 @@ fn hkdf_expand<T: ArrayLength<u8>>(prk: &[u8], info: Option<&str>) -> Result<Gen
     Ok(key)
 }
 
-/// Generate 16 bytes that are cryptographically secure
+/// Generate random bytes that are cryptographically secure
 pub(crate) fn generate_random_bytes<T>() -> T
 where
     Standard: Distribution<T>,

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -23,7 +23,10 @@
 
 use aes::cipher::{generic_array::GenericArray, ArrayLength, Unsigned};
 use hmac::digest::OutputSizeUser;
-use rand::Rng;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 
 use crate::error::Result;
 
@@ -76,6 +79,9 @@ fn hkdf_expand<T: ArrayLength<u8>>(prk: &[u8], info: Option<&str>) -> Result<Gen
 }
 
 /// Generate 16 bytes that are cryptographically secure
-pub(crate) fn generate_16_bytes() -> [u8; 16] {
+pub(crate) fn generate_random_bytes<T>() -> T
+where
+    Standard: Distribution<T>,
+{
     rand::thread_rng().gen()
 }

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -23,6 +23,7 @@
 
 use aes::cipher::{generic_array::GenericArray, ArrayLength, Unsigned};
 use hmac::digest::OutputSizeUser;
+use rand::Rng;
 
 use crate::error::Result;
 
@@ -72,4 +73,9 @@ fn hkdf_expand<T: ArrayLength<u8>>(prk: &[u8], info: Option<&str>) -> Result<Gen
     hkdf.expand(i, &mut key).map_err(|_| "invalid length")?;
 
     Ok(key)
+}
+
+/// Generate 16 bytes that are cryptographically secure
+pub(crate) fn generate_16_bytes() -> [u8; 16] {
+    rand::thread_rng().gen()
 }

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -4,7 +4,7 @@ use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::Engine;
 
 use crate::{
-    crypto::derive_shareable_key,
+    crypto::{derive_shareable_key, generate_16_bytes},
     error::{CryptoError, Error},
     util::BASE64_ENGINE,
 };
@@ -20,8 +20,7 @@ impl SymmetricCryptoKey {
     const MAC_LEN: usize = 32;
 
     pub fn generate(name: &str) -> Self {
-        use rand::Rng;
-        let secret: [u8; 16] = rand::thread_rng().gen();
+        let secret = generate_16_bytes();
         derive_shareable_key(secret, name, None)
     }
 

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -4,7 +4,7 @@ use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::Engine;
 
 use crate::{
-    crypto::{derive_shareable_key, generate_16_bytes},
+    crypto::{derive_shareable_key, generate_random_bytes},
     error::{CryptoError, Error},
     util::BASE64_ENGINE,
 };
@@ -20,7 +20,7 @@ impl SymmetricCryptoKey {
     const MAC_LEN: usize = 32;
 
     pub fn generate(name: &str) -> Self {
-        let secret = generate_16_bytes();
+        let secret: [u8; 16] = generate_random_bytes();
         derive_shareable_key(secret, name, None)
     }
 

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -1,7 +1,6 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use bitwarden_api_api::models::{SendFileModel, SendResponseModel, SendTextModel};
 use chrono::{DateTime, Utc};
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -9,8 +8,8 @@ use uuid::Uuid;
 
 use crate::{
     crypto::{
-        derive_shareable_key, EncString, KeyDecryptable, KeyEncryptable, LocateKey,
-        SymmetricCryptoKey,
+        derive_shareable_key, generate_16_bytes, EncString, KeyDecryptable, KeyEncryptable,
+        LocateKey, SymmetricCryptoKey,
     },
     error::{CryptoError, Error, Result},
 };
@@ -250,10 +249,7 @@ impl KeyEncryptable<Send> for SendView {
             Some(k) => URL_SAFE_NO_PAD
                 .decode(k)
                 .map_err(|_| CryptoError::InvalidKey)?,
-            None => {
-                let r: [u8; 16] = rand::thread_rng().gen();
-                r.to_vec()
-            }
+            None => generate_16_bytes().to_vec(),
         };
         let send_key = Send::derive_shareable_key(&k)?;
 

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     crypto::{
-        derive_shareable_key, generate_16_bytes, EncString, KeyDecryptable, KeyEncryptable,
+        derive_shareable_key, generate_random_bytes, EncString, KeyDecryptable, KeyEncryptable,
         LocateKey, SymmetricCryptoKey,
     },
     error::{CryptoError, Error, Result},
@@ -249,7 +249,10 @@ impl KeyEncryptable<Send> for SendView {
             Some(k) => URL_SAFE_NO_PAD
                 .decode(k)
                 .map_err(|_| CryptoError::InvalidKey)?,
-            None => generate_16_bytes().to_vec(),
+            None => {
+                let key: [u8; 16] = generate_random_bytes();
+                key.to_vec()
+            }
         };
         let send_key = Send::derive_shareable_key(&k)?;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When creating a new send, we should generate a key for it.

## Before you submit

- Please add **unit tests** where it makes sense to do so
