### PR TITLE
Refactor make_user_key to call SymmetricCryptoKey::generate

### DIFF
--- a/crates/bitwarden/src/crypto/enc_string/symmetric.rs
+++ b/crates/bitwarden/src/crypto/enc_string/symmetric.rs
@@ -274,11 +274,13 @@ impl schemars::JsonSchema for EncString {
 #[cfg(test)]
 mod tests {
     use super::EncString;
-    use crate::crypto::{KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+    use crate::crypto::{
+        symmetric_crypto_key::derive_symmetric_key, KeyDecryptable, KeyEncryptable,
+    };
 
     #[test]
     fn test_enc_string_roundtrip() {
-        let key = SymmetricCryptoKey::generate("test");
+        let key = derive_symmetric_key("test");
 
         let test_string = "encrypted_test_string".to_string();
         let cipher = test_string.clone().encrypt_with_key(&key).unwrap();

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -68,7 +68,7 @@ fn make_user_key(
     mut rng: impl rand::RngCore,
     master_key: &MasterKey,
 ) -> Result<(UserKey, EncString)> {
-    let user_key = SymmetricCryptoKey::generate_random(&mut rng)?;
+    let user_key = SymmetricCryptoKey::generate(&mut rng)?;
     let protected = master_key.encrypt_user_key(&user_key)?;
     Ok((UserKey::new(user_key), protected))
 }

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -130,7 +130,10 @@ mod tests {
     use rand::SeedableRng;
 
     use super::{make_user_key, stretch_master_key, HashPurpose, MasterKey};
-    use crate::{client::kdf::Kdf, crypto::SymmetricCryptoKey};
+    use crate::{
+        client::kdf::Kdf,
+        crypto::{symmetric_crypto_key::derive_symmetric_key, SymmetricCryptoKey},
+    };
 
     #[test]
     fn test_master_key_derive_pbkdf2() {
@@ -288,9 +291,9 @@ mod tests {
 
     #[test]
     fn test_make_user_key2() {
-        let master_key = MasterKey(SymmetricCryptoKey::generate("test1"));
+        let master_key = MasterKey(derive_symmetric_key("test1"));
 
-        let user_key = SymmetricCryptoKey::generate("test2");
+        let user_key = derive_symmetric_key("test2");
 
         let encrypted = master_key.encrypt_user_key(&user_key).unwrap();
         let decrypted = master_key.decrypt_user_key(encrypted).unwrap();

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -1,6 +1,5 @@
 use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use rand::Rng;
 use schemars::JsonSchema;
 use sha2::Digest;
 
@@ -69,10 +68,7 @@ fn make_user_key(
     mut rng: impl rand::RngCore,
     master_key: &MasterKey,
 ) -> Result<(UserKey, EncString)> {
-    let mut user_key = [0u8; 64];
-    rng.fill(&mut user_key);
-
-    let user_key = SymmetricCryptoKey::try_from(user_key.as_slice())?;
+    let user_key = SymmetricCryptoKey::generate_random(&mut rng)?;
     let protected = master_key.encrypt_user_key(&user_key)?;
     Ok((UserKey::new(user_key), protected))
 }

--- a/crates/bitwarden/src/crypto/master_key.rs
+++ b/crates/bitwarden/src/crypto/master_key.rs
@@ -68,7 +68,7 @@ fn make_user_key(
     mut rng: impl rand::RngCore,
     master_key: &MasterKey,
 ) -> Result<(UserKey, EncString)> {
-    let user_key = SymmetricCryptoKey::generate(&mut rng)?;
+    let user_key = SymmetricCryptoKey::generate(&mut rng);
     let protected = master_key.encrypt_user_key(&user_key)?;
     Ok((UserKey::new(user_key), protected))
 }

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -79,6 +79,7 @@ fn hkdf_expand<T: ArrayLength<u8>>(prk: &[u8], info: Option<&str>) -> Result<Gen
 }
 
 /// Generate random bytes that are cryptographically secure
+#[cfg(any(test, feature = "internal"))]
 pub(crate) fn generate_random_bytes<T>() -> T
 where
     Standard: Distribution<T>,

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -23,6 +23,7 @@
 
 use aes::cipher::{generic_array::GenericArray, ArrayLength, Unsigned};
 use hmac::digest::OutputSizeUser;
+#[cfg(any(test, feature = "internal"))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -83,17 +83,18 @@ impl std::fmt::Debug for SymmetricCryptoKey {
 }
 
 #[cfg(test)]
+pub fn derive_symmetric_key(name: &str) -> SymmetricCryptoKey {
+    use crate::crypto::{derive_shareable_key, generate_random_bytes};
+
+    let secret: [u8; 16] = generate_random_bytes();
+    derive_shareable_key(secret, name, None)
+}
+
+#[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use super::SymmetricCryptoKey;
-
-    pub fn derive_symmetric_key(name: &str) -> SymmetricCryptoKey {
-        use crate::crypto::{derive_shareable_key, generate_random_bytes};
-
-        let secret: [u8; 16] = generate_random_bytes();
-        derive_shareable_key(secret, name, None)
-    }
+    use super::{derive_symmetric_key, SymmetricCryptoKey};
 
     #[test]
     fn test_symmetric_crypto_key() {

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -17,11 +17,17 @@ impl SymmetricCryptoKey {
     const MAC_LEN: usize = 32;
 
     /// Generate a new random [SymmetricCryptoKey]
-    pub fn generate(mut rng: impl rand::RngCore) -> Result<Self, Error> {
-        let mut key: [u8; 64] = [0u8; 64];
-        rng.fill(&mut key);
+    pub fn generate(mut rng: impl rand::RngCore) -> Self {
+        let mut key = [0u8; Self::KEY_LEN];
+        let mut mac_key = [0u8; Self::MAC_LEN];
 
-        SymmetricCryptoKey::try_from(key.as_slice())
+        rng.fill(&mut key);
+        rng.fill(&mut mac_key);
+
+        SymmetricCryptoKey {
+            key: key.into(),
+            mac_key: Some(mac_key.into()),
+        }
     }
 
     pub fn to_base64(&self) -> String {

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::{engine::general_purpose::STANDARD, Engine};
+use rand::Rng;
 
 use crate::{
     crypto::{derive_shareable_key, generate_random_bytes},
@@ -17,6 +18,14 @@ pub struct SymmetricCryptoKey {
 impl SymmetricCryptoKey {
     const KEY_LEN: usize = 32;
     const MAC_LEN: usize = 32;
+
+    /// Generate a new random [SymmetricCryptoKey]
+    pub fn generate_random(mut rng: impl rand::RngCore) -> Result<Self, Error> {
+        let mut key: [u8; 64] = [0u8; 64];
+        rng.fill(&mut key);
+
+        SymmetricCryptoKey::try_from(key.as_slice())
+    }
 
     pub fn generate(name: &str) -> Self {
         let secret: [u8; 16] = generate_random_bytes();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The `MasterKey` previously had intimate knowledge about `SymmetricCryptKey` in order to be able to generate one. This refactor extracts the knowledge back into `SymmetricCryptoKey` by creating a `SymmetricCryptoKey::generate`.

## Before you submit

- Please add **unit tests** where it makes sense to do so
