### PR TITLE
Fix lib architectures in language SDKs

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-unknown-linux-gnu
-          path: languages/csharp/Bitwarden.Sdk/ubuntu-x64
+          path: languages/csharp/Bitwarden.Sdk/linux-x64
 
       - name: Download x86_64-pc-windows-msvc files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   generate_schemas:

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-apple-darwin
-          path: languages/java/src/main/resources/darwin-x64
+          path: languages/java/src/main/resources/darwin-x86-64
 
       - name: Download aarch64-apple-darwin files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
@@ -51,13 +51,13 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-unknown-linux-gnu
-          path: languages/java/src/main/resources/ubuntu-x64
+          path: languages/java/src/main/resources/linux-x86-64
 
       - name: Download x86_64-pc-windows-msvc files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-pc-windows-msvc
-          path: languages/java/src/main/resources/windows-x64
+          path: languages/java/src/main/resources/win32-x86-64
 
       - name: Publish Maven
         uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ps/fix-arch
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ps/fix-arch
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-dotnet.yml
+++ b/.github/workflows/publish-dotnet.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-unknown-linux-gnu
-          path: languages/csharp/Bitwarden.Sdk/ubuntu-x64
+          path: languages/csharp/Bitwarden.Sdk/linux-x64
 
       - name: Download x86_64-pc-windows-msvc files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-unknown-linux-gnu
-          path: temp/ubuntu-x64
+          path: temp/linux-x64
 
       - name: Download x86_64-pc-windows-msvc files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
@@ -59,11 +59,11 @@ jobs:
       - name: Copy lib files
         run: |
           mkdir -p languages/php/src/lib/macos-arm64
-          mkdir -p languages/php/src/lib/ubuntu-x64
+          mkdir -p languages/php/src/lib/linux-x64
           mkdir -p languages/php/src/lib/macos-x64
           mkdir -p languages/php/src/lib/windows-x64
 
-          platforms=("macos-arm64" "ubuntu-x64" "macos-x64" "windows-x64")
+          platforms=("macos-arm64" "linux-x64" "macos-x64" "windows-x64")
           files=("libbitwarden_c.dylib" "libbitwarden_c.so" "libbitwarden_c.dylib" "bitwarden_c.dll")
 
           for ((i=0; i<${#platforms[@]}; i++)); do

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: libbitwarden_c_files-x86_64-unknown-linux-gnu
-          path: temp/ubuntu-x64
+          path: temp/linux-x64
 
       - name: Download x86_64-pc-windows-msvc files
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
@@ -60,11 +60,11 @@ jobs:
       - name: Copy lib files
         run: |
           mkdir -p languages/ruby/bitwarden_sdk/lib/macos-arm64
-          mkdir -p languages/ruby/bitwarden_sdk/lib/ubuntu-x64
+          mkdir -p languages/ruby/bitwarden_sdk/lib/linux-x64
           mkdir -p languages/ruby/bitwarden_sdk/lib/macos-x64
           mkdir -p languages/ruby/bitwarden_sdk/lib/windows-x64
 
-          platforms=("macos-arm64" "ubuntu-x64" "macos-x64" "windows-x64")
+          platforms=("macos-arm64" "linux-x64" "macos-x64" "windows-x64")
           files=("libbitwarden_c.dylib" "libbitwarden_c.so" "libbitwarden_c.dylib" "bitwarden_c.dll")
 
           for ((i=0; i<${#platforms[@]}; i++)); do

--- a/languages/csharp/Bitwarden.Sdk/Bitwarden.Sdk.csproj
+++ b/languages/csharp/Bitwarden.Sdk/Bitwarden.Sdk.csproj
@@ -62,7 +62,7 @@
       <PackageCopyToOutput>true</PackageCopyToOutput>
       <PackagePath>runtimes/osx-arm64/native</PackagePath>
     </Content>
-    <Content Include="ubuntu-x64/libbitwarden_c*.so">
+    <Content Include="linux-x64/libbitwarden_c*.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <PackageCopyToOutput>true</PackageCopyToOutput>
       <PackagePath>runtimes/linux-x64/native</PackagePath>

--- a/languages/php/src/BitwardenLib.php
+++ b/languages/php/src/BitwardenLib.php
@@ -27,7 +27,7 @@ class BitwardenLib
                 $lib_file = __DIR__.'/../../../target/debug/bitwarden_c.dll';
             }
         } elseif (PHP_OS === 'Linux') {
-            $lib_file = '/lib/ubuntu-x64/libbitwarden_c.so';
+            $lib_file = '/lib/linux-x64/libbitwarden_c.so';
             if (file_exists($lib_file) == false) {
                 $lib_file = __DIR__.'/../../../target/debug/libbitwarden_c.so';
             }

--- a/languages/ruby/bitwarden_sdk/bitwarden-sdk.gemspec
+++ b/languages/ruby/bitwarden_sdk/bitwarden-sdk.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
 
-  spec.files += Dir.glob('lib/ubuntu-x64/**/*')
+  spec.files += Dir.glob('lib/linux-x64/**/*')
   spec.files += Dir.glob('lib/macos-x64/**/*')
   spec.files += Dir.glob('lib/windows-x64/**/*')
   spec.files += Dir.glob('lib/macos-arm64/**/*')

--- a/languages/ruby/bitwarden_sdk/lib/bitwarden_lib.rb
+++ b/languages/ruby/bitwarden_sdk/lib/bitwarden_lib.rb
@@ -19,7 +19,7 @@ module BitwardenSDK
                            end
               File.exist?(local_file) ? local_file : File.expand_path('../../../../target/debug/libbitwarden_c.dylib', __dir__)
             when /linux/
-              local_file = File.expand_path('ubuntu-x64/libbitwarden_c.so', __dir__)
+              local_file = File.expand_path('linux-x64/libbitwarden_c.so', __dir__)
               File.exist?(local_file) ? local_file : File.expand_path('../../../../target/debug/libbitwarden_c.so', __dir__)
             when /mswin|mingw/
               local_file = File.expand_path('windows-x64/bitwarden_c.dll', __dir__)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

- Rename `ubuntu-x64` to `linux-x64` to better match the usage.
- Resolve java using the wrong prefixes. It should be `x86_64` for architecture, and windows should use `win32`.

Resolves #491 

## Before you submit

- Please add **unit tests** where it makes sense to do so
