### PR TITLE
POC Complete key purpose markers

### DIFF
--- a/crates/bitwarden/src/auth/login/access_token.rs
+++ b/crates/bitwarden/src/auth/login/access_token.rs
@@ -13,7 +13,7 @@ use crate::{
         JWTToken,
     },
     client::{AccessToken, LoginMethod, ServiceAccountLoginMethod},
-    crypto::{EncString, KeyDecryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, SymmetricCryptoKey},
     error::{Error, Result},
     secrets_manager::state::{self, ClientState},
     Client,
@@ -125,7 +125,8 @@ fn load_tokens_from_state(
             let organization_id: Uuid = organization_id
                 .parse()
                 .map_err(|_| "Bad organization id.")?;
-            let encryption_key: SymmetricCryptoKey = client_state.encryption_key.parse()?;
+            let encryption_key: SymmetricCryptoKey<purpose::UserEncryption> =
+                client_state.encryption_key.parse()?;
 
             client.set_tokens(client_state.token, None, time_till_expiration as u64);
             client.initialize_crypto_single_key(encryption_key);

--- a/crates/bitwarden/src/auth/renew.rs
+++ b/crates/bitwarden/src/auth/renew.rs
@@ -62,7 +62,7 @@ pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
                         Ok(enc_settings),
                     ) = (&result, state_file, client.get_encryption_settings())
                     {
-                        if let Some(enc_key) = enc_settings.get_key(&None) {
+                        if let Some(enc_key) = enc_settings.get_user_key() {
                             let state =
                                 ClientState::new(r.access_token.clone(), enc_key.to_base64());
                             _ = state::set(state_file, access_token, state);

--- a/crates/bitwarden/src/client/access_token.rs
+++ b/crates/bitwarden/src/client/access_token.rs
@@ -4,7 +4,7 @@ use base64::Engine;
 use uuid::Uuid;
 
 use crate::{
-    crypto::{derive_shareable_key, SymmetricCryptoKey},
+    crypto::{derive_shareable_key, purpose, SymmetricCryptoKey},
     error::AccessTokenInvalidError,
     util::STANDARD_INDIFFERENT,
 };
@@ -12,7 +12,7 @@ use crate::{
 pub struct AccessToken {
     pub access_token_id: Uuid,
     pub client_secret: String,
-    pub encryption_key: SymmetricCryptoKey,
+    pub encryption_key: SymmetricCryptoKey<purpose::PayloadEncryption>,
 }
 
 // We don't want to log the more sensitive fields from an AccessToken
@@ -55,7 +55,7 @@ impl FromStr for AccessToken {
             }
         })?;
         let encryption_key =
-            derive_shareable_key(encryption_key, "accesstoken", Some("sm-access-token"));
+            derive_shareable_key(encryption_key, "accesstoken", Some("sm-access-token")).into();
 
         Ok(AccessToken {
             access_token_id,

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -21,7 +21,7 @@ use crate::{
         client_settings::{ClientSettings, DeviceType},
         encryption_settings::EncryptionSettings,
     },
-    crypto::SymmetricCryptoKey,
+    crypto::{purpose, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -235,7 +235,7 @@ impl Client {
     #[cfg(feature = "mobile")]
     pub(crate) fn initialize_user_crypto_decrypted_key(
         &mut self,
-        user_key: SymmetricCryptoKey,
+        user_key: SymmetricCryptoKey<purpose::UserEncryption>,
         private_key: EncString,
     ) -> Result<&EncryptionSettings> {
         self.encryption_settings = Some(EncryptionSettings::new_decrypted_key(
@@ -271,7 +271,7 @@ impl Client {
 
     pub(crate) fn initialize_crypto_single_key(
         &mut self,
-        key: SymmetricCryptoKey,
+        key: SymmetricCryptoKey<purpose::UserEncryption>,
     ) -> &EncryptionSettings {
         self.encryption_settings = Some(EncryptionSettings::new_single_key(key));
         self.encryption_settings.as_ref().unwrap()

--- a/crates/bitwarden/src/crypto/asymmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/asymmetric_crypto_key.rs
@@ -1,20 +1,24 @@
+use std::marker::PhantomData;
+
 use rsa::RsaPrivateKey;
 
 use crate::{
-    crypto::CryptoKey,
+    crypto::{CryptoKey, KeyPurpose},
     error::{CryptoError, Result},
 };
 
 /// An asymmetric encryption key. Used to encrypt and decrypt [`EncString`](crate::crypto::EncString)
-pub struct AsymmetricCryptoKey {
+pub struct AsymmetricCryptoKey<Purpose: KeyPurpose> {
     pub(in crate::crypto) key: RsaPrivateKey,
+    _marker: PhantomData<Purpose>,
 }
 
-impl AsymmetricCryptoKey {
+impl<Purpose: KeyPurpose> AsymmetricCryptoKey<Purpose> {
     pub fn from_pem(pem: &str) -> Result<Self> {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
             key: rsa::RsaPrivateKey::from_pkcs8_pem(pem).map_err(|_| CryptoError::InvalidKey)?,
+            _marker: PhantomData,
         })
     }
 
@@ -22,6 +26,7 @@ impl AsymmetricCryptoKey {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
             key: rsa::RsaPrivateKey::from_pkcs8_der(der).map_err(|_| CryptoError::InvalidKey)?,
+            _marker: PhantomData,
         })
     }
 
@@ -47,10 +52,10 @@ impl AsymmetricCryptoKey {
     }
 }
 
-impl CryptoKey for AsymmetricCryptoKey {}
+impl<Purpose: KeyPurpose> CryptoKey<Purpose> for AsymmetricCryptoKey<Purpose> {}
 
 // We manually implement these to make sure we don't print any sensitive data
-impl std::fmt::Debug for AsymmetricCryptoKey {
+impl<Purpose: KeyPurpose> std::fmt::Debug for AsymmetricCryptoKey<Purpose> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsymmetricCryptoKey").finish()
     }
@@ -59,6 +64,8 @@ impl std::fmt::Debug for AsymmetricCryptoKey {
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
+
+    use crate::crypto::purpose;
 
     use super::AsymmetricCryptoKey;
 
@@ -96,8 +103,9 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let der_key_vec = STANDARD.decode("MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDiTQVuzhdygFz5qv14i+XFDGTnDravzUQT1hPKPGUZOUSZ1gwdNgkWqOIaOnR65BHEnL0sp4bnuiYcafeK2JAW5Sc8Z7IxBNSuAwhQmuKx3RochMIiuCkI2/p+JvUQoJu6FBNm8OoJ4CwmqqHGZESMfnpQDCuDrB3JdJEdXhtmnl0C48sGjOk3WaBMcgGqn8LbJDUlyu1zdqyvb0waJf0iV4PJm2fkUl7+57D/2TkpbCqURVnZK1FFIEg8mr6FzSN1F2pOfktkNYZwP7MSNR7o81CkRSCMr7EkIVa+MZYMBx106BMK7FXgWB7nbSpsWKxBk7ZDHkID2famrEcVtrzDAgMBAAECggEBAKwq9OssGGKgjhvUnyrLJHAZ0dqIMyzk+dotkLjX4gKiszJmyqiep6N5sStLNbsZMPtoU/RZMCW0VbJgXFhiEp2YkZU/Py5UAoqw++53J+kx0d/IkPphKbb3xUec0+1mg5O6GljDCQuiZXS1dIa/WfeZcezclW6Dz9WovY6ePjJ+8vEBR1icbNKzyeINd6MtPtpcgQPHtDwHvhPyUDbKDYGbLvjh9nui8h4+ZUlXKuVRjB0ChxiKV1xJRjkrEVoulOOicd5r597WfB2ghax3pvRZ4MdXemCXm3gQYqPVKachvGU+1cPQR/MBJZpxT+EZA97xwtFS3gqwbxJaNFcoE8ECgYEA9OaeYZhQPDo485tI1u/Z7L/3PNape9hBQIXoW7+MgcQ5NiWqYh8Jnj43EIYa0wM/ECQINr1Za8Q5e6KRJ30FcU+kfyjuQ0jeXdNELGU/fx5XXNg/vV8GevHwxRlwzqZTCg6UExUZzbYEQqd7l+wPyETGeua5xCEywA1nX/D101kCgYEA7I6aMFjhEjO71RmzNhqjKJt6DOghoOfQTjhaaanNEhLYSbenFz1mlb21mW67ulmz162saKdIYLxQNJIP8ZPmxh4ummOJI8w9ClHfo8WuCI2hCjJ19xbQJocSbTA5aJg6lA1IDVZMDbQwsnAByPRGpaLHBT/Q9ByeKvCMB+9amXsCgYEAx65yXSkP4sumPBrVHUub6MntERIGRxBgw/drKcPZEMWp0FiNwEuGUBxyUWrG3F69QK/gcqGZE6F/LSu0JvptQaKqgXQiMYJsrRvhbkFvsHpQyUcZUZL1ebFjm5HOxPAgrQaN/bEqxOwwNRjSUWEMzUImg3c06JIZCzbinvudtKECgYEAkY3JF/iIPI/yglP27lKDlCfeeHSYxI3+oTKRhzSAxx8rUGidenJAXeDGDauR/T7Wpt3pGNfddBBK9Z3uC4Iq3DqUCFE4f/taj7ADAJ1Q0Vh7/28/IJM77ojr8J1cpZwNZy2o6PPxhfkagaDjqEeN9Lrs5LD4nEvDkr5CG1vOjmMCgYEAvIBFKRm31NyF8jLiCVuPwC5PzrW5iThDmsWTaXFpB3esUsbICO2pEz872oeQS+Em4GO5vXUlpbbFPzupPFhA8iMJ8TAvemhvc7oM0OZqpU6p3K4seHf6BkwLxumoA3vDJfovu9RuXVcJVOnfDnqOsltgPomWZ7xVfMkm9niL2OA=").unwrap();
 
         // Load the two different formats and check they are the same key
-        let pem_key = AsymmetricCryptoKey::from_pem(pem_key_str).unwrap();
-        let der_key = AsymmetricCryptoKey::from_der(&der_key_vec).unwrap();
+        let pem_key = AsymmetricCryptoKey::<purpose::OrgEncryption>::from_pem(pem_key_str).unwrap();
+        let der_key =
+            AsymmetricCryptoKey::<purpose::OrgEncryption>::from_der(&der_key_vec).unwrap();
         assert_eq!(pem_key.key, der_key.key);
 
         // Check that the keys can be converted back to DER

--- a/crates/bitwarden/src/crypto/enc_string/asymmetric.rs
+++ b/crates/bitwarden/src/crypto/enc_string/asymmetric.rs
@@ -5,7 +5,7 @@ use rsa::Oaep;
 use serde::Deserialize;
 
 use crate::{
-    crypto::{AsymmetricCryptoKey, KeyDecryptable},
+    crypto::{AsymmetricCryptoKey, KeyDecryptable, KeyPurpose},
     error::{CryptoError, EncStringParseError, Error, Result},
 };
 
@@ -150,8 +150,10 @@ impl AsymmEncString {
     }
 }
 
-impl KeyDecryptable<AsymmetricCryptoKey, Vec<u8>> for AsymmEncString {
-    fn decrypt_with_key(&self, key: &AsymmetricCryptoKey) -> Result<Vec<u8>> {
+impl<Purpose: KeyPurpose> KeyDecryptable<AsymmetricCryptoKey<Purpose>, Purpose, Vec<u8>>
+    for AsymmEncString
+{
+    fn decrypt_with_key(&self, key: &AsymmetricCryptoKey<Purpose>) -> Result<Vec<u8>> {
         use AsymmEncString::*;
         Ok(match self {
             Rsa2048_OaepSha256_B64 { data } => key.key.decrypt(Oaep::new::<sha2::Sha256>(), data),
@@ -169,8 +171,10 @@ impl KeyDecryptable<AsymmetricCryptoKey, Vec<u8>> for AsymmEncString {
     }
 }
 
-impl KeyDecryptable<AsymmetricCryptoKey, String> for AsymmEncString {
-    fn decrypt_with_key(&self, key: &AsymmetricCryptoKey) -> Result<String> {
+impl<Purpose: KeyPurpose> KeyDecryptable<AsymmetricCryptoKey<Purpose>, Purpose, String>
+    for AsymmEncString
+{
+    fn decrypt_with_key(&self, key: &AsymmetricCryptoKey<Purpose>) -> Result<String> {
         let dec: Vec<u8> = self.decrypt_with_key(key)?;
         String::from_utf8(dec).map_err(|_| CryptoError::InvalidUtf8String.into())
     }
@@ -190,7 +194,8 @@ impl schemars::JsonSchema for AsymmEncString {
 
 #[cfg(test)]
 mod tests {
-    use super::AsymmEncString;
+    use super::{AsymmEncString, AsymmetricCryptoKey, KeyDecryptable};
+    use crate::crypto::purpose;
 
     const RSA_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCXRVrCX+2hfOQS
@@ -224,9 +229,8 @@ XKZBokBGnjFnTnKcs7nv/O8=
     #[cfg(feature = "internal")]
     #[test]
     fn test_enc_string_rsa2048_oaep_sha256_b64() {
-        use crate::crypto::{AsymmetricCryptoKey, KeyDecryptable};
-
-        let private_key = AsymmetricCryptoKey::from_pem(RSA_PRIVATE_KEY).unwrap();
+        let private_key =
+            AsymmetricCryptoKey::<purpose::UserOrOrgEncryption>::from_pem(RSA_PRIVATE_KEY).unwrap();
         let enc_str: &str = "3.YFqzW9LL/uLjCnl0RRLtndzGJ1FV27mcwQwGjfJPOVrgCX9nJSUYCCDd0iTIyOZ/zRxG47b6L1Z3qgkEfcxjmrSBq60gijc3E2TBMAg7OCLVcjORZ+i1sOVOudmOPWro6uA8refMrg4lqbieDlbLMzjVEwxfi5WpcL876cD0vYyRwvLO3bzFrsE7x33HHHtZeOPW79RqMn5efsB5Dj9wVheC9Ix9AYDjbo+rjg9qR6guwKmS7k2MSaIQlrDR7yu8LP+ePtiSjx+gszJV5jQGfcx60dtiLQzLS/mUD+RmU7B950Bpx0H7x56lT5yXZbWK5YkoP6qd8B8D2aKbP68Ywg==";
         let enc_string: AsymmEncString = enc_str.parse().unwrap();
 
@@ -239,9 +243,8 @@ XKZBokBGnjFnTnKcs7nv/O8=
     #[cfg(feature = "internal")]
     #[test]
     fn test_enc_string_rsa2048_oaep_sha1_b64() {
-        use crate::crypto::{AsymmetricCryptoKey, KeyDecryptable};
-
-        let private_key = AsymmetricCryptoKey::from_pem(RSA_PRIVATE_KEY).unwrap();
+        let private_key =
+            AsymmetricCryptoKey::<purpose::UserOrOrgEncryption>::from_pem(RSA_PRIVATE_KEY).unwrap();
         let enc_str: &str = "4.ZheRb3PCfAunyFdQYPfyrFqpuvmln9H9w5nDjt88i5A7ug1XE0LJdQHCIYJl0YOZ1gCOGkhFu/CRY2StiLmT3iRKrrVBbC1+qRMjNNyDvRcFi91LWsmRXhONVSPjywzrJJXglsztDqGkLO93dKXNhuKpcmtBLsvgkphk/aFvxbaOvJ/FHdK/iV0dMGNhc/9tbys8laTdwBlI5xIChpRcrfH+XpSFM88+Bu03uK67N9G6eU1UmET+pISJwJvMuIDMqH+qkT7OOzgL3t6I0H2LDj+CnsumnQmDsvQzDiNfTR0IgjpoE9YH2LvPXVP2wVUkiTwXD9cG/E7XeoiduHyHjw==";
         let enc_string: AsymmEncString = enc_str.parse().unwrap();
 
@@ -254,9 +257,8 @@ XKZBokBGnjFnTnKcs7nv/O8=
     #[cfg(feature = "internal")]
     #[test]
     fn test_enc_string_rsa2048_oaep_sha1_hmac_sha256_b64() {
-        use crate::crypto::{AsymmetricCryptoKey, KeyDecryptable};
-
-        let private_key = AsymmetricCryptoKey::from_pem(RSA_PRIVATE_KEY).unwrap();
+        let private_key =
+            AsymmetricCryptoKey::<purpose::UserOrOrgEncryption>::from_pem(RSA_PRIVATE_KEY).unwrap();
         let enc_str: &str = "6.ThnNc67nNr7GELyuhGGfsXNP2zJnNqhrIsjntEQ27r2qmn8vwdHbTbfO0cwt6YgSibDN0PjiCZ1O3Wb/IFq+vwvyRwFqF9145wBF8CQCbkhV+M0XvO99kh0daovtt120Nve/5ETI5PbPag9VdalKRQWZypJaqQHm5TAQVf4F5wtLlCLMBkzqTk+wkFe7BPMTGn07T+O3eJbTxXvyMZewQ7icJF0MZVA7VyWX9qElmZ89FCKowbf1BMr5pbcQ+0KdXcSVW3to43VkTp7k7COwsuH3M/i1AuVP5YN8ixjyRpvaeGqX/ap2nCHK2Wj5VxgCGT7XEls6ZknnAp9nB9qVjQ==|s3ntw5H/KKD/qsS0lUghTHl5Sm9j6m7YEdNHf0OeAFQ=";
         let enc_string: AsymmEncString = enc_str.parse().unwrap();
 

--- a/crates/bitwarden/src/crypto/encryptable.rs
+++ b/crates/bitwarden/src/crypto/encryptable.rs
@@ -1,84 +1,47 @@
-use std::{collections::HashMap, hash::Hash};
-
-use uuid::Uuid;
-
 use crate::{
     client::encryption_settings::EncryptionSettings,
     error::{Error, Result},
 };
 
-use super::{KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use super::{KeyDecryptable, KeyEncryptable, KeyPurpose, SymmetricCryptoKey};
 
-pub trait LocateKey {
+pub trait LocateKey<Purpose: KeyPurpose> {
     fn locate_key<'a>(
         &self,
         enc: &'a EncryptionSettings,
-        org_id: &Option<Uuid>,
-    ) -> Option<&'a SymmetricCryptoKey> {
-        enc.get_key(org_id)
-    }
+    ) -> Option<&'a SymmetricCryptoKey<Purpose>>;
 }
 
 /// Deprecated: please use LocateKey and KeyDecryptable instead
-pub trait Encryptable<Output> {
-    fn encrypt(self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Output>;
+pub trait Encryptable<Purpose: KeyPurpose, Output> {
+    fn encrypt(self, enc: &EncryptionSettings) -> Result<Output>;
 }
 
 /// Deprecated: please use LocateKey and KeyDecryptable instead
-pub trait Decryptable<Output> {
-    fn decrypt(&self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Output>;
+pub trait Decryptable<Purpose: KeyPurpose, Output> {
+    fn decrypt(&self, enc: &EncryptionSettings) -> Result<Output>;
 }
 
-impl<T: KeyEncryptable<SymmetricCryptoKey, Output> + LocateKey, Output> Encryptable<Output> for T {
-    fn encrypt(self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Output> {
-        let key = self.locate_key(enc, org_id).ok_or(Error::VaultLocked)?;
+impl<
+        T: KeyEncryptable<SymmetricCryptoKey<Purpose>, Purpose, Output> + LocateKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > Encryptable<Purpose, Output> for T
+{
+    fn encrypt(self, enc: &EncryptionSettings) -> Result<Output> {
+        let key = self.locate_key(enc).ok_or(Error::VaultLocked)?;
         self.encrypt_with_key(key)
     }
 }
 
-impl<T: KeyDecryptable<SymmetricCryptoKey, Output> + LocateKey, Output> Decryptable<Output> for T {
-    fn decrypt(&self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Output> {
-        let key = self.locate_key(enc, org_id).ok_or(Error::VaultLocked)?;
+impl<
+        Purpose: KeyPurpose,
+        T: KeyDecryptable<SymmetricCryptoKey<Purpose>, Purpose, Output> + LocateKey<Purpose>,
+        Output,
+    > Decryptable<Purpose, Output> for T
+{
+    fn decrypt(&self, enc: &EncryptionSettings) -> Result<Output> {
+        let key = self.locate_key(enc).ok_or(Error::VaultLocked)?;
         self.decrypt_with_key(key)
-    }
-}
-
-impl<T: Encryptable<Output>, Output> Encryptable<Vec<Output>> for Vec<T> {
-    fn encrypt(self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Vec<Output>> {
-        self.into_iter().map(|e| e.encrypt(enc, org_id)).collect()
-    }
-}
-
-impl<T: Decryptable<Output>, Output> Decryptable<Vec<Output>> for Vec<T> {
-    fn decrypt(&self, enc: &EncryptionSettings, org_id: &Option<Uuid>) -> Result<Vec<Output>> {
-        self.iter().map(|e| e.decrypt(enc, org_id)).collect()
-    }
-}
-
-impl<T: Encryptable<Output>, Output, Id: Hash + Eq> Encryptable<HashMap<Id, Output>>
-    for HashMap<Id, T>
-{
-    fn encrypt(
-        self,
-        enc: &EncryptionSettings,
-        org_id: &Option<Uuid>,
-    ) -> Result<HashMap<Id, Output>> {
-        self.into_iter()
-            .map(|(id, e)| Ok((id, e.encrypt(enc, org_id)?)))
-            .collect()
-    }
-}
-
-impl<T: Decryptable<Output>, Output, Id: Hash + Eq + Copy> Decryptable<HashMap<Id, Output>>
-    for HashMap<Id, T>
-{
-    fn decrypt(
-        &self,
-        enc: &EncryptionSettings,
-        org_id: &Option<Uuid>,
-    ) -> Result<HashMap<Id, Output>> {
-        self.iter()
-            .map(|(id, e)| Ok((*id, e.decrypt(enc, org_id)?)))
-            .collect()
     }
 }

--- a/crates/bitwarden/src/crypto/key_encryptable.rs
+++ b/crates/bitwarden/src/crypto/key_encryptable.rs
@@ -2,66 +2,120 @@ use std::{collections::HashMap, hash::Hash};
 
 use crate::error::Result;
 
-pub trait CryptoKey {}
+pub trait CryptoKey<Purpose: KeyPurpose> {}
 
-pub trait KeyEncryptable<Key: CryptoKey, Output> {
+pub trait KeyPurpose {}
+
+macro_rules! key_purpose {
+    ( $( $purpose:ident ,)* ) => {
+        $(
+            pub struct $purpose;
+            impl crate::crypto::KeyPurpose for $purpose {}
+        )*
+    };
+}
+
+pub mod purpose {
+    key_purpose![
+        Testing,
+        Master,
+        Shareable,
+        PayloadEncryption,
+        UserEncryption,
+        OrgEncryption,
+        UserOrOrgEncryption,
+        SendEncryption,
+        CipherEncryption,
+    ];
+}
+
+pub trait KeyEncryptable<Key: CryptoKey<Purpose>, Purpose: KeyPurpose, Output> {
     fn encrypt_with_key(self, key: &Key) -> Result<Output>;
 }
 
-pub trait KeyDecryptable<Key: CryptoKey, Output> {
+pub trait KeyDecryptable<Key: CryptoKey<Purpose>, Purpose: KeyPurpose, Output> {
     fn decrypt_with_key(&self, key: &Key) -> Result<Output>;
 }
 
-impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output> KeyEncryptable<Key, Option<Output>>
-    for Option<T>
+impl<
+        T: KeyEncryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyEncryptable<Key, Purpose, Option<Output>> for Option<T>
 {
     fn encrypt_with_key(self, key: &Key) -> Result<Option<Output>> {
         self.map(|e| e.encrypt_with_key(key)).transpose()
     }
 }
 
-impl<T: KeyDecryptable<Key, Output>, Key: CryptoKey, Output> KeyDecryptable<Key, Option<Output>>
-    for Option<T>
+impl<
+        T: KeyDecryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyDecryptable<Key, Purpose, Option<Output>> for Option<T>
 {
     fn decrypt_with_key(&self, key: &Key) -> Result<Option<Output>> {
         self.as_ref().map(|e| e.decrypt_with_key(key)).transpose()
     }
 }
 
-impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output> KeyEncryptable<Key, Output>
-    for Box<T>
+impl<
+        T: KeyEncryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyEncryptable<Key, Purpose, Output> for Box<T>
 {
     fn encrypt_with_key(self, key: &Key) -> Result<Output> {
         (*self).encrypt_with_key(key)
     }
 }
 
-impl<T: KeyDecryptable<Key, Output>, Key: CryptoKey, Output> KeyDecryptable<Key, Output>
-    for Box<T>
+impl<
+        T: KeyDecryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyDecryptable<Key, Purpose, Output> for Box<T>
 {
     fn decrypt_with_key(&self, key: &Key) -> Result<Output> {
         (**self).decrypt_with_key(key)
     }
 }
 
-impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output> KeyEncryptable<Key, Vec<Output>>
-    for Vec<T>
+impl<
+        T: KeyEncryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyEncryptable<Key, Purpose, Vec<Output>> for Vec<T>
 {
     fn encrypt_with_key(self, key: &Key) -> Result<Vec<Output>> {
         self.into_iter().map(|e| e.encrypt_with_key(key)).collect()
     }
 }
 
-impl<T: KeyDecryptable<Key, Output>, Key: CryptoKey, Output> KeyDecryptable<Key, Vec<Output>>
-    for Vec<T>
+impl<
+        T: KeyDecryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+    > KeyDecryptable<Key, Purpose, Vec<Output>> for Vec<T>
 {
     fn decrypt_with_key(&self, key: &Key) -> Result<Vec<Output>> {
         self.iter().map(|e| e.decrypt_with_key(key)).collect()
     }
 }
 
-impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output, Id: Hash + Eq>
-    KeyEncryptable<Key, HashMap<Id, Output>> for HashMap<Id, T>
+impl<
+        T: KeyEncryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+        Id: Hash + Eq,
+    > KeyEncryptable<Key, Purpose, HashMap<Id, Output>> for HashMap<Id, T>
 {
     fn encrypt_with_key(self, key: &Key) -> Result<HashMap<Id, Output>> {
         self.into_iter()
@@ -70,8 +124,13 @@ impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output, Id: Hash + Eq>
     }
 }
 
-impl<T: KeyDecryptable<Key, Output>, Key: CryptoKey, Output, Id: Hash + Eq + Copy>
-    KeyDecryptable<Key, HashMap<Id, Output>> for HashMap<Id, T>
+impl<
+        T: KeyDecryptable<Key, Purpose, Output>,
+        Key: CryptoKey<Purpose>,
+        Purpose: KeyPurpose,
+        Output,
+        Id: Hash + Eq + Copy,
+    > KeyDecryptable<Key, Purpose, HashMap<Id, Output>> for HashMap<Id, T>
 {
     fn decrypt_with_key(&self, key: &Key) -> Result<HashMap<Id, Output>> {
         self.iter()

--- a/crates/bitwarden/src/crypto/mod.rs
+++ b/crates/bitwarden/src/crypto/mod.rs
@@ -36,7 +36,7 @@ pub use enc_string::{AsymmEncString, EncString};
 mod encryptable;
 pub use encryptable::{Decryptable, Encryptable, LocateKey};
 mod key_encryptable;
-pub use key_encryptable::{CryptoKey, KeyDecryptable, KeyEncryptable};
+pub use key_encryptable::{purpose, CryptoKey, KeyDecryptable, KeyEncryptable, KeyPurpose};
 mod aes_ops;
 use aes_ops::{decrypt_aes256_hmac, encrypt_aes256_hmac};
 mod symmetric_crypto_key;

--- a/crates/bitwarden/src/crypto/rsa.rs
+++ b/crates/bitwarden/src/crypto/rsa.rs
@@ -9,6 +9,8 @@ use crate::{
     error::Result,
 };
 
+use super::purpose;
+
 #[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct RsaKeyPair {
     /// Base64 encoded DER representation of the public key
@@ -17,7 +19,9 @@ pub struct RsaKeyPair {
     pub private: EncString,
 }
 
-pub(super) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
+pub(super) fn make_key_pair(
+    key: &SymmetricCryptoKey<purpose::UserEncryption>,
+) -> Result<RsaKeyPair> {
     let mut rng = rand::thread_rng();
     let bits = 2048;
     let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");

--- a/crates/bitwarden/src/crypto/shareable_key.rs
+++ b/crates/bitwarden/src/crypto/shareable_key.rs
@@ -3,6 +3,8 @@ use hmac::{Hmac, Mac};
 
 use crate::crypto::{hkdf_expand, SymmetricCryptoKey};
 
+use super::purpose;
+
 /// Derive a shareable key using hkdf from secret and name.
 ///
 /// A specialized variant of this function was called `CryptoService.makeSendKey` in the Bitwarden
@@ -11,7 +13,7 @@ pub(crate) fn derive_shareable_key(
     secret: [u8; 16],
     name: &str,
     info: Option<&str>,
-) -> SymmetricCryptoKey {
+) -> SymmetricCryptoKey<purpose::Shareable> {
     // Because all inputs are fixed size, we can unwrap all errors here without issue
 
     // TODO: Are these the final `key` and `info` parameters or should we change them? I followed the pattern used for sends

--- a/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
+++ b/crates/bitwarden/src/crypto/symmetric_crypto_key.rs
@@ -1,28 +1,78 @@
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
 use aes::cipher::{generic_array::GenericArray, typenum::U32};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use rand::Rng;
 
 use crate::{
-    crypto::CryptoKey,
-    error::{CryptoError, Error},
+    crypto::{purpose, CryptoKey, KeyPurpose},
+    error::{CryptoError, Error, Result},
 };
 
 /// A symmetric encryption key. Used to encrypt and decrypt [`EncString`](crate::crypto::EncString)
-pub struct SymmetricCryptoKey {
+#[repr(C)]
+pub struct SymmetricCryptoKey<Purpose: KeyPurpose> {
     pub(super) key: GenericArray<u8, U32>,
     pub(super) mac_key: Option<GenericArray<u8, U32>>,
+
+    pub(super) _marker: std::marker::PhantomData<Purpose>,
 }
 
-impl SymmetricCryptoKey {
+macro_rules! from_convert {
+    ( $( $from:ident -> $to:ident ,)* ) => {
+        $(
+            impl From<SymmetricCryptoKey<$from>> for SymmetricCryptoKey<$to> {
+                fn from(key: SymmetricCryptoKey<$from>) -> Self {
+                    SymmetricCryptoKey {
+                        key: key.key,
+                        mac_key: key.mac_key,
+                        _marker: std::marker::PhantomData,
+                    }
+                }
+            }
+
+            impl From<&SymmetricCryptoKey<$from>> for &SymmetricCryptoKey<$to> {
+                fn from(key: &SymmetricCryptoKey<$from>) -> Self {
+                    // Safety: We're only transmuting the PhantomData which is a ZST and the type is repr(C), so this should be safe?
+                    // TODO: We should probably find a better way to do this if possible
+                    unsafe { std::mem::transmute(key) }
+                }
+            }
+        )*
+    };
+}
+mod conversion {
+    use super::{purpose::*, SymmetricCryptoKey};
+
+    from_convert! {
+        UserEncryption -> UserOrOrgEncryption,
+        OrgEncryption -> UserOrOrgEncryption,
+
+        UserOrOrgEncryption -> CipherEncryption,
+
+        Shareable -> SendEncryption,
+        Shareable -> PayloadEncryption,
+
+        // TODO: This hack is needed because EncryptionSettings mixes the concept of the single org key in secrets manager as the user key
+        UserEncryption -> OrgEncryption,
+    }
+
+    #[cfg(test)]
+    from_convert! {
+        Shareable -> Testing,
+        Testing -> UserEncryption,
+        Testing -> Master,
+    }
+}
+
+impl<Purpose: KeyPurpose> SymmetricCryptoKey<Purpose> {
     const KEY_LEN: usize = 32;
     const MAC_LEN: usize = 32;
 
     /// Generate a new random [SymmetricCryptoKey]
     pub fn generate(mut rng: impl rand::RngCore) -> Self {
-        let mut key = [0u8; Self::KEY_LEN];
-        let mut mac_key = [0u8; Self::MAC_LEN];
+        let mut key = [0u8; 32];
+        let mut mac_key = [0u8; 32];
 
         rng.fill(&mut key);
         rng.fill(&mut mac_key);
@@ -30,6 +80,7 @@ impl SymmetricCryptoKey {
         SymmetricCryptoKey {
             key: key.into(),
             mac_key: Some(mac_key.into()),
+            _marker: PhantomData,
         }
     }
 
@@ -55,7 +106,7 @@ impl SymmetricCryptoKey {
     }
 }
 
-impl FromStr for SymmetricCryptoKey {
+impl<Purpose: KeyPurpose> FromStr for SymmetricCryptoKey<Purpose> {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -64,7 +115,7 @@ impl FromStr for SymmetricCryptoKey {
     }
 }
 
-impl TryFrom<&[u8]> for SymmetricCryptoKey {
+impl<Purpose: KeyPurpose> TryFrom<&[u8]> for SymmetricCryptoKey<Purpose> {
     type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
@@ -72,11 +123,13 @@ impl TryFrom<&[u8]> for SymmetricCryptoKey {
             Ok(SymmetricCryptoKey {
                 key: GenericArray::clone_from_slice(&value[..Self::KEY_LEN]),
                 mac_key: Some(GenericArray::clone_from_slice(&value[Self::KEY_LEN..])),
+                _marker: PhantomData,
             })
         } else if value.len() == Self::KEY_LEN {
             Ok(SymmetricCryptoKey {
                 key: GenericArray::clone_from_slice(value),
                 mac_key: None,
+                _marker: PhantomData,
             })
         } else {
             Err(CryptoError::InvalidKeyLen.into())
@@ -84,38 +137,40 @@ impl TryFrom<&[u8]> for SymmetricCryptoKey {
     }
 }
 
-impl CryptoKey for SymmetricCryptoKey {}
+impl<Purpose: KeyPurpose> CryptoKey<Purpose> for SymmetricCryptoKey<Purpose> {}
 
 // We manually implement these to make sure we don't print any sensitive data
-impl std::fmt::Debug for SymmetricCryptoKey {
+impl<Purpose: KeyPurpose> std::fmt::Debug for SymmetricCryptoKey<Purpose> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SymmetricCryptoKey").finish()
     }
 }
 
 #[cfg(test)]
-pub fn derive_symmetric_key(name: &str) -> SymmetricCryptoKey {
+pub fn derive_symmetric_key(name: &str) -> SymmetricCryptoKey<purpose::Testing> {
     use crate::crypto::{derive_shareable_key, generate_random_bytes};
 
     let secret: [u8; 16] = generate_random_bytes();
-    derive_shareable_key(secret, name, None)
+    derive_shareable_key(secret, name, None).into()
 }
 
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
+    use crate::crypto::purpose;
+
     use super::{derive_symmetric_key, SymmetricCryptoKey};
 
     #[test]
     fn test_symmetric_crypto_key() {
         let key = derive_symmetric_key("test");
-        let key2 = SymmetricCryptoKey::from_str(&key.to_base64()).unwrap();
+        let key2 = SymmetricCryptoKey::<purpose::Testing>::from_str(&key.to_base64()).unwrap();
         assert_eq!(key.key, key2.key);
         assert_eq!(key.mac_key, key2.mac_key);
 
         let key = "UY4B5N4DA4UisCNClgZtRr6VLy9ZF5BXXC7cDZRqourKi4ghEMgISbCsubvgCkHf5DZctQjVot11/vVvN9NNHQ==";
-        let key2 = SymmetricCryptoKey::from_str(key).unwrap();
+        let key2 = SymmetricCryptoKey::<purpose::Testing>::from_str(key).unwrap();
         assert_eq!(key, key2.to_base64());
     }
 }

--- a/crates/bitwarden/src/crypto/user_key.rs
+++ b/crates/bitwarden/src/crypto/user_key.rs
@@ -6,10 +6,12 @@ use crate::{
     error::Result,
 };
 
-pub(crate) struct UserKey(pub(super) SymmetricCryptoKey);
+use super::purpose;
+
+pub(crate) struct UserKey(pub(super) SymmetricCryptoKey<purpose::UserEncryption>);
 
 impl UserKey {
-    pub(crate) fn new(key: SymmetricCryptoKey) -> Self {
+    pub(crate) fn new(key: SymmetricCryptoKey<purpose::UserEncryption>) -> Self {
         Self(key)
     }
 

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -67,7 +67,7 @@ pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequ
             client.initialize_user_crypto(&password, user_key, private_key)?;
         }
         InitUserCryptoMethod::DecryptedKey { decrypted_user_key } => {
-            let user_key = decrypted_user_key.parse::<SymmetricCryptoKey>()?;
+            let user_key = decrypted_user_key.parse::<SymmetricCryptoKey<_>>()?;
             client.initialize_user_crypto_decrypted_key(user_key, private_key)?;
         }
         InitUserCryptoMethod::Pin {
@@ -101,7 +101,7 @@ pub async fn initialize_org_crypto(client: &mut Client, req: InitOrgCryptoReques
 pub async fn get_user_encryption_key(client: &mut Client) -> Result<String> {
     let user_key = client
         .get_encryption_settings()?
-        .get_key(&None)
+        .get_user_key()
         .ok_or(Error::VaultLocked)?;
 
     Ok(user_key.to_base64())
@@ -133,7 +133,7 @@ pub fn derive_pin_key(client: &mut Client, pin: String) -> Result<DerivePinKeyRe
 
     let user_key = client
         .get_encryption_settings()?
-        .get_key(&None)
+        .get_user_key()
         .ok_or(Error::VaultLocked)?;
 
     Ok(DerivePinKeyResponse {
@@ -195,13 +195,13 @@ mod tests {
             client
                 .get_encryption_settings()
                 .unwrap()
-                .get_key(&None)
+                .get_user_key()
                 .unwrap()
                 .to_base64(),
             client2
                 .get_encryption_settings()
                 .unwrap()
-                .get_key(&None)
+                .get_user_key()
                 .unwrap()
                 .to_base64()
         );

--- a/crates/bitwarden/src/mobile/vault/client_ciphers.rs
+++ b/crates/bitwarden/src/mobile/vault/client_ciphers.rs
@@ -14,7 +14,7 @@ impl<'a> ClientCiphers<'a> {
     pub async fn encrypt(&self, cipher_view: CipherView) -> Result<Cipher> {
         let enc = self.client.get_encryption_settings()?;
 
-        let cipher = cipher_view.encrypt(enc, &None)?;
+        let cipher = cipher_view.encrypt(enc)?;
 
         Ok(cipher)
     }
@@ -22,7 +22,7 @@ impl<'a> ClientCiphers<'a> {
     pub async fn decrypt(&self, cipher: Cipher) -> Result<CipherView> {
         let enc = self.client.get_encryption_settings()?;
 
-        let cipher_view = cipher.decrypt(enc, &None)?;
+        let cipher_view = cipher.decrypt(enc)?;
 
         Ok(cipher_view)
     }
@@ -30,9 +30,9 @@ impl<'a> ClientCiphers<'a> {
     pub async fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>> {
         let enc = self.client.get_encryption_settings()?;
 
-        let cipher_views = ciphers.decrypt(enc, &None)?;
+        let cipher_views: Result<_> = ciphers.into_iter().map(|c| c.decrypt(enc)).collect();
 
-        Ok(cipher_views)
+        cipher_views
     }
 }
 

--- a/crates/bitwarden/src/mobile/vault/client_collection.rs
+++ b/crates/bitwarden/src/mobile/vault/client_collection.rs
@@ -14,7 +14,7 @@ impl<'a> ClientCollections<'a> {
     pub async fn decrypt(&self, collection: Collection) -> Result<CollectionView> {
         let enc = self.client.get_encryption_settings()?;
 
-        let view = collection.decrypt(enc, &None)?;
+        let view = collection.decrypt(enc)?;
 
         Ok(view)
     }
@@ -22,9 +22,9 @@ impl<'a> ClientCollections<'a> {
     pub async fn decrypt_list(&self, collections: Vec<Collection>) -> Result<Vec<CollectionView>> {
         let enc = self.client.get_encryption_settings()?;
 
-        let views = collections.decrypt(enc, &None)?;
+        let views: Result<_> = collections.into_iter().map(|c| c.decrypt(enc)).collect();
 
-        Ok(views)
+        views
     }
 }
 

--- a/crates/bitwarden/src/mobile/vault/client_folders.rs
+++ b/crates/bitwarden/src/mobile/vault/client_folders.rs
@@ -14,7 +14,7 @@ impl<'a> ClientFolders<'a> {
     pub async fn encrypt(&self, folder_view: FolderView) -> Result<Folder> {
         let enc = self.client.get_encryption_settings()?;
 
-        let folder = folder_view.encrypt(enc, &None)?;
+        let folder = folder_view.encrypt(enc)?;
 
         Ok(folder)
     }
@@ -22,7 +22,7 @@ impl<'a> ClientFolders<'a> {
     pub async fn decrypt(&self, folder: Folder) -> Result<FolderView> {
         let enc = self.client.get_encryption_settings()?;
 
-        let folder_view = folder.decrypt(enc, &None)?;
+        let folder_view = folder.decrypt(enc)?;
 
         Ok(folder_view)
     }
@@ -30,9 +30,9 @@ impl<'a> ClientFolders<'a> {
     pub async fn decrypt_list(&self, folders: Vec<Folder>) -> Result<Vec<FolderView>> {
         let enc = self.client.get_encryption_settings()?;
 
-        let views = folders.decrypt(enc, &None)?;
+        let views: Result<_> = folders.into_iter().map(|f| f.decrypt(enc)).collect();
 
-        Ok(views)
+        views
     }
 }
 

--- a/crates/bitwarden/src/mobile/vault/client_password_history.rs
+++ b/crates/bitwarden/src/mobile/vault/client_password_history.rs
@@ -14,7 +14,7 @@ impl<'a> ClientPasswordHistory<'a> {
     pub async fn encrypt(&self, history_view: PasswordHistoryView) -> Result<PasswordHistory> {
         let enc = self.client.get_encryption_settings()?;
 
-        let history = history_view.encrypt(enc, &None)?;
+        let history = history_view.encrypt(enc)?;
 
         Ok(history)
     }
@@ -25,9 +25,9 @@ impl<'a> ClientPasswordHistory<'a> {
     ) -> Result<Vec<PasswordHistoryView>> {
         let enc = self.client.get_encryption_settings()?;
 
-        let history_view = history.decrypt(enc, &None)?;
+        let history_view: Result<_> = history.into_iter().map(|h| h.decrypt(enc)).collect();
 
-        Ok(history_view)
+        history_view
     }
 }
 

--- a/crates/bitwarden/src/secrets_manager/projects/create.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/create.rs
@@ -25,7 +25,7 @@ pub(crate) async fn create_project(
 ) -> Result<ProjectResponse> {
     let key = client
         .get_encryption_settings()?
-        .get_key(&Some(input.organization_id))
+        .get_org_key(input.organization_id)
         .ok_or(Error::VaultLocked)?;
 
     let project = Some(ProjectCreateRequestModel {

--- a/crates/bitwarden/src/secrets_manager/projects/project_response.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/project_response.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     client::encryption_settings::EncryptionSettings,
-    crypto::{Decryptable, EncString},
+    crypto::{EncString, KeyDecryptable},
     error::{Error, Result},
 };
 
@@ -26,12 +26,13 @@ impl ProjectResponse {
         enc: &EncryptionSettings,
     ) -> Result<Self> {
         let organization_id = response.organization_id.ok_or(Error::MissingFields)?;
+        let key = enc.get_org_key(organization_id).ok_or(Error::VaultLocked)?;
 
         let name = response
             .name
             .ok_or(Error::MissingFields)?
             .parse::<EncString>()?
-            .decrypt(enc, &Some(organization_id))?;
+            .decrypt_with_key(key)?;
 
         Ok(ProjectResponse {
             id: response.id.ok_or(Error::MissingFields)?,

--- a/crates/bitwarden/src/secrets_manager/projects/update.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/update.rs
@@ -27,7 +27,7 @@ pub(crate) async fn update_project(
 ) -> Result<ProjectResponse> {
     let key = client
         .get_encryption_settings()?
-        .get_key(&Some(input.organization_id))
+        .get_org_key(input.organization_id)
         .ok_or(Error::VaultLocked)?;
 
     let project = Some(ProjectUpdateRequestModel {

--- a/crates/bitwarden/src/secrets_manager/secrets/create.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/create.rs
@@ -30,7 +30,7 @@ pub(crate) async fn create_secret(
 ) -> Result<SecretResponse> {
     let key = client
         .get_encryption_settings()?
-        .get_key(&Some(input.organization_id))
+        .get_org_key(input.organization_id)
         .ok_or(Error::VaultLocked)?;
 
     let secret = Some(SecretCreateRequestModel {

--- a/crates/bitwarden/src/secrets_manager/secrets/update.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/update.rs
@@ -30,7 +30,7 @@ pub(crate) async fn update_secret(
 ) -> Result<SecretResponse> {
     let key = client
         .get_encryption_settings()?
-        .get_key(&Some(input.organization_id))
+        .get_org_key(input.organization_id)
         .ok_or(Error::VaultLocked)?;
 
     let secret = Some(SecretUpdateRequestModel {

--- a/crates/bitwarden/src/vault/cipher/attachment.rs
+++ b/crates/bitwarden/src/vault/cipher/attachment.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -31,8 +31,17 @@ pub struct AttachmentView {
     pub key: Option<EncString>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Attachment> for AttachmentView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Attachment> {
+impl
+    KeyEncryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        Attachment,
+    > for AttachmentView
+{
+    fn encrypt_with_key(
+        self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<Attachment> {
         Ok(Attachment {
             id: self.id,
             url: self.url,
@@ -44,8 +53,17 @@ impl KeyEncryptable<SymmetricCryptoKey, Attachment> for AttachmentView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, AttachmentView> for Attachment {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<AttachmentView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        AttachmentView,
+    > for Attachment
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<AttachmentView> {
         Ok(AttachmentView {
             id: self.id.clone(),
             url: self.url.clone(),

--- a/crates/bitwarden/src/vault/cipher/card.rs
+++ b/crates/bitwarden/src/vault/cipher/card.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -31,8 +31,10 @@ pub struct CardView {
     pub number: Option<String>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Card> for CardView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Card> {
+impl KeyEncryptable<SymmetricCryptoKey<purpose::CipherEncryption>, purpose::CipherEncryption, Card>
+    for CardView
+{
+    fn encrypt_with_key(self, key: &SymmetricCryptoKey<purpose::CipherEncryption>) -> Result<Card> {
         Ok(Card {
             cardholder_name: self.cardholder_name.encrypt_with_key(key)?,
             exp_month: self.exp_month.encrypt_with_key(key)?,
@@ -44,8 +46,17 @@ impl KeyEncryptable<SymmetricCryptoKey, Card> for CardView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CardView> for Card {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CardView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        CardView,
+    > for Card
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<CardView> {
         Ok(CardView {
             cardholder_name: self.cardholder_name.decrypt_with_key(key)?,
             exp_month: self.exp_month.decrypt_with_key(key)?,

--- a/crates/bitwarden/src/vault/cipher/field.rs
+++ b/crates/bitwarden/src/vault/cipher/field.rs
@@ -5,7 +5,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use super::linked_id::LinkedIdType;
 use crate::{
-    crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -41,8 +41,13 @@ pub struct FieldView {
     linked_id: Option<LinkedIdType>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Field> for FieldView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Field> {
+impl KeyEncryptable<SymmetricCryptoKey<purpose::CipherEncryption>, purpose::CipherEncryption, Field>
+    for FieldView
+{
+    fn encrypt_with_key(
+        self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<Field> {
         Ok(Field {
             name: self.name.encrypt_with_key(key)?,
             value: self.value.encrypt_with_key(key)?,
@@ -52,8 +57,17 @@ impl KeyEncryptable<SymmetricCryptoKey, Field> for FieldView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, FieldView> for Field {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<FieldView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        FieldView,
+    > for Field
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<FieldView> {
         Ok(FieldView {
             name: self.name.decrypt_with_key(key)?,
             value: self.value.decrypt_with_key(key)?,

--- a/crates/bitwarden/src/vault/cipher/identity.rs
+++ b/crates/bitwarden/src/vault/cipher/identity.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -55,8 +55,17 @@ pub struct IdentityView {
     pub license_number: Option<String>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Identity> for IdentityView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Identity> {
+impl
+    KeyEncryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        Identity,
+    > for IdentityView
+{
+    fn encrypt_with_key(
+        self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<Identity> {
         Ok(Identity {
             title: self.title.encrypt_with_key(key)?,
             first_name: self.first_name.encrypt_with_key(key)?,
@@ -80,8 +89,17 @@ impl KeyEncryptable<SymmetricCryptoKey, Identity> for IdentityView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, IdentityView> for Identity {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<IdentityView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        IdentityView,
+    > for Identity
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<IdentityView> {
         Ok(IdentityView {
             title: self.title.decrypt_with_key(key)?,
             first_name: self.first_name.decrypt_with_key(key)?,

--- a/crates/bitwarden/src/vault/cipher/local_data.rs
+++ b/crates/bitwarden/src/vault/cipher/local_data.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    crypto::{KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::Result,
 };
 
@@ -22,8 +22,17 @@ pub struct LocalDataView {
     last_launched: Option<u32>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<LocalData> {
+impl
+    KeyEncryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        LocalData,
+    > for LocalDataView
+{
+    fn encrypt_with_key(
+        self,
+        _key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<LocalData> {
         Ok(LocalData {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,
@@ -31,8 +40,17 @@ impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, LocalDataView> for LocalData {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<LocalDataView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        LocalDataView,
+    > for LocalData
+{
+    fn decrypt_with_key(
+        &self,
+        _key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<LocalDataView> {
         Ok(LocalDataView {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,

--- a/crates/bitwarden/src/vault/cipher/login.rs
+++ b/crates/bitwarden/src/vault/cipher/login.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
-    crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -64,8 +64,17 @@ pub struct LoginView {
     pub autofill_on_page_load: Option<bool>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, LoginUri> for LoginUriView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<LoginUri> {
+impl
+    KeyEncryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        LoginUri,
+    > for LoginUriView
+{
+    fn encrypt_with_key(
+        self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<LoginUri> {
         Ok(LoginUri {
             uri: self.uri.encrypt_with_key(key)?,
             r#match: self.r#match,
@@ -73,8 +82,13 @@ impl KeyEncryptable<SymmetricCryptoKey, LoginUri> for LoginUriView {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Login> for LoginView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Login> {
+impl KeyEncryptable<SymmetricCryptoKey<purpose::CipherEncryption>, purpose::CipherEncryption, Login>
+    for LoginView
+{
+    fn encrypt_with_key(
+        self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<Login> {
         Ok(Login {
             username: self.username.encrypt_with_key(key)?,
             password: self.password.encrypt_with_key(key)?,
@@ -86,8 +100,17 @@ impl KeyEncryptable<SymmetricCryptoKey, Login> for LoginView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, LoginUriView> for LoginUri {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<LoginUriView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        LoginUriView,
+    > for LoginUri
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<LoginUriView> {
         Ok(LoginUriView {
             uri: self.uri.decrypt_with_key(key)?,
             r#match: self.r#match,
@@ -95,8 +118,17 @@ impl KeyDecryptable<SymmetricCryptoKey, LoginUriView> for LoginUri {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, LoginView> for Login {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<LoginView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        LoginView,
+    > for Login
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<LoginView> {
         Ok(LoginView {
             username: self.username.decrypt_with_key(key)?,
             password: self.password.decrypt_with_key(key)?,

--- a/crates/bitwarden/src/vault/cipher/secure_note.rs
+++ b/crates/bitwarden/src/vault/cipher/secure_note.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
-    crypto::{KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
+    crypto::{purpose, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -29,16 +29,34 @@ pub struct SecureNoteView {
     r#type: SecureNoteType,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SecureNote> for SecureNoteView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<SecureNote> {
+impl
+    KeyEncryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        SecureNote,
+    > for SecureNoteView
+{
+    fn encrypt_with_key(
+        self,
+        _key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<SecureNote> {
         Ok(SecureNote {
             r#type: self.r#type,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SecureNoteView> for SecureNote {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<SecureNoteView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::CipherEncryption>,
+        purpose::CipherEncryption,
+        SecureNoteView,
+    > for SecureNote
+{
+    fn decrypt_with_key(
+        &self,
+        _key: &SymmetricCryptoKey<purpose::CipherEncryption>,
+    ) -> Result<SecureNoteView> {
         Ok(SecureNoteView {
             r#type: self.r#type,
         })

--- a/crates/bitwarden/src/vault/collection.rs
+++ b/crates/bitwarden/src/vault/collection.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     client::encryption_settings::EncryptionSettings,
-    crypto::{EncString, KeyDecryptable, LocateKey, SymmetricCryptoKey},
+    crypto::{purpose, EncString, KeyDecryptable, LocateKey, SymmetricCryptoKey},
     error::{Error, Result},
 };
 
@@ -37,17 +37,25 @@ pub struct CollectionView {
     read_only: bool,
 }
 
-impl LocateKey for Collection {
+impl LocateKey<purpose::OrgEncryption> for Collection {
     fn locate_key<'a>(
         &self,
         enc: &'a EncryptionSettings,
-        _: &Option<Uuid>,
-    ) -> Option<&'a SymmetricCryptoKey> {
-        enc.get_key(&Some(self.organization_id))
+    ) -> Option<&'a SymmetricCryptoKey<purpose::OrgEncryption>> {
+        enc.get_org_key(self.organization_id)
     }
 }
-impl KeyDecryptable<SymmetricCryptoKey, CollectionView> for Collection {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CollectionView> {
+impl
+    KeyDecryptable<
+        SymmetricCryptoKey<purpose::OrgEncryption>,
+        purpose::OrgEncryption,
+        CollectionView,
+    > for Collection
+{
+    fn decrypt_with_key(
+        &self,
+        key: &SymmetricCryptoKey<purpose::OrgEncryption>,
+    ) -> Result<CollectionView> {
         Ok(CollectionView {
             id: self.id,
             organization_id: self.organization_id,


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
POC implementing working marker traits for encryption keys.

Some changes were needed to get this working:
- Split `EncSettings::get_key` into `get_user_key` and `get_org_key`, to have them typed correctly.
- Removed the `org_uuid` param from `locate_key`, as it didn't make sense anymore.
- Removed some impls from `Encryptable` which produced type conflicts with similar impls in `KeyEncryptable`.
- Implemented `UserEncryption` to `OrgEncryption` conversion to work around a mix up caused by EncryptionSettings using the single org key in secrets manager as the user key. This should be removed once we improve the EncryptionSettings situation.

TODO: Move functions like `to_base64` and `to_vec` to a new `Exportable` purpose, to limit their use.
