### PR TITLE
SM-1091: Use rustfmt Nightly by Default

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt" ]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is a proposal to add a `rust-toolchain.toml` file to the repository, and use `rustfmt` nightly by default due to https://github.com/bitwarden/sdk/pull/512.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **rust-toolchain.toml:** Adds this file

## Before you submit

- Please add **unit tests** where it makes sense to do so
