### PR TITLE
allow empty word separator in passphrases

### DIFF
--- a/crates/bitwarden-generators/src/passphrase.rs
+++ b/crates/bitwarden-generators/src/passphrase.rs
@@ -10,8 +10,6 @@ use crate::util::capitalize_first_letter;
 pub enum PassphraseError {
     #[error("'num_words' must be between {} and {}", minimum, maximum)]
     InvalidNumWords { minimum: u8, maximum: u8 },
-    #[error("'word_separator' cannot be empty")]
-    EmptyWordSeparator,
 }
 
 /// Passphrase generator request options.
@@ -68,10 +66,6 @@ impl PassphraseGeneratorRequest {
                 maximum: MAXIMUM_PASSPHRASE_NUM_WORDS,
             });
         }
-
-        if self.word_separator.chars().next().is_none() {
-            return Err(PassphraseError::EmptyWordSeparator);
-        };
 
         Ok(ValidPassphraseGeneratorOptions {
             num_words: self.num_words,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Allow the passphrase word separator to be the empty string ''. 

This change recently merged [in the clients repository](https://github.com/bitwarden/clients/commit/bb031f6779fe19afff3b89a8b9aff947c869cd41).

## Code changes

- **crates/bitwarden-generators/src/passphrase.rs:** Remove empty separator validation.

