### PR TITLE
add get-by-ids to Go wrapper

### DIFF
--- a/languages/go/example/example.go
+++ b/languages/go/example/example.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 
 	sdk "github.com/bitwarden/sdk/languages/go"
@@ -83,9 +85,28 @@ func main() {
 		panic(err)
 	}
 
-	if _, err = bitwardenClient.Projects.Delete([]string{projectID}); err != nil {
+	secretIdentifiers, err := bitwardenClient.Secrets.List(organizationID.String())
+	if err != nil {
 		panic(err)
 	}
+
+	// Get secrets with a list of IDs
+	secretIDs := make([]string, len(secretIdentifiers.Data))
+	for i, identifier := range secretIdentifiers.Data {
+		secretIDs[i] = identifier.ID
+	}
+
+	secrets, err := bitwardenClient.Secrets.GetByIDS(secretIDs)
+	if err != nil {
+		log.Fatalf("Error getting secrets: %v", err)
+	}
+
+	jsonSecrets, err := json.MarshalIndent(secrets, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshalling secrets to JSON: %v", err)
+	}
+
+	fmt.Println(string(jsonSecrets))
 
 	defer bitwardenClient.Close()
 }

--- a/languages/go/example/example.go
+++ b/languages/go/example/example.go
@@ -85,6 +85,10 @@ func main() {
 		panic(err)
 	}
 
+	if _, err = bitwardenClient.Projects.Delete([]string{projectID}); err != nil {
+		panic(err)
+	}
+
 	secretIdentifiers, err := bitwardenClient.Secrets.List(organizationID.String())
 	if err != nil {
 		panic(err)

--- a/languages/go/secrets.go
+++ b/languages/go/secrets.go
@@ -4,6 +4,7 @@ type SecretsInterface interface {
 	Create(key, value, note string, organizationID string, projectIDs []string) (*SecretResponse, error)
 	List(organizationID string) (*SecretIdentifiersResponse, error)
 	Get(secretID string) (*SecretResponse, error)
+	GetByIDS(secretIDs []string) (*SecretsResponse, error)
 	Update(secretID string, key, value, note string, organizationID string, projectIDs []string) (*SecretResponse, error)
 	Delete(secretIDs []string) (*SecretsDeleteResponse, error)
 }
@@ -70,6 +71,22 @@ func (s *Secrets) Get(id string) (*SecretResponse, error) {
 	}
 
 	var response SecretResponse
+	if err := s.executeCommand(command, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (s *Secrets) GetByIDS(ids []string) (*SecretsResponse, error) {
+	command := Command{
+		Secrets: &SecretsCommand{
+			GetByIDS: &SecretsGetRequest{
+				IDS: ids,
+			},
+		},
+	}
+
+	var response SecretsResponse
 	if err := s.executeCommand(command, &response); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Allow secret fetching by a list of IDs, rather than requesting multiple secrets individually. Exposes the functionality from #150 in Go.

## Code changes

- **languages/go/secrets.go:** Add `GetByIDS` func.
- **languages/go/example/example.go:** Get secrets by ID. Added JSON output for QA/ease-of-use.