### PR TITLE
[DEVOPS-1785] Fix publish ruby sdk workflow permissions

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -12,9 +12,11 @@ on:
         options:
           - Release
           - Dry Run
-    permissions:
-      id-token: write
-      contents: write
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   setup:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/publish-ruby.yml:** Add `contents: read` permission and fix indentation

## Before you submit

- Please add **unit tests** where it makes sense to do so
