### PR TITLE
[DEVOPS-1785] Replace Ruby publish composite action with individual steps

### DIFF
--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -8,8 +8,7 @@ on:
       - main
       - rc
       - hotfix-rc
-    paths:
-      - "crates/**"
+
 
 jobs:
   build_rust:

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Set remote URL
         run: |
           # Attribute commits to the last committer on HEAD
-          git config --global user.email "$(git log -1 --pretty=format:'%ae')"
-          git config --global user.name "$(git log -1 --pretty=format:'%an')"
+          git config --global user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
+          git config --global user.name "bitwarden-devops-bot"
           git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
 
       - name: Configure trusted publishing credentials

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -105,12 +105,27 @@ jobs:
           for ((i=0; i<${#platforms[@]}; i++)); do
             cp "temp/${platforms[$i]}/${files[$i]}" "languages/ruby/bitwarden_sdk_secrets/lib/${platforms[$i]}/${files[$i]}"
           done
-        shell: bash
 
       - name: Build gem
         run: gem build bitwarden-sdk-secrets.gemspec
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
-      - name: Push gem to Rubygems
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        uses: rubygems/release-gem@035c7c1c1c14d277318867ced5037926d2395300 # v1.0.1
+      - name: Set remote URL
+        run: |
+          # Attribute commits to the last committer on HEAD
+          git config --global user.email "$(git log -1 --pretty=format:'%ae')"
+          git config --global user.name "$(git log -1 --pretty=format:'%an')"
+          git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
+
+      - name: Configure trusted publishing credentials
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
+      - name: Run release rake task
+        if: ${{ inputs.release_type == 'Release' }}
+        run: bundle exec rake release
+        working-directory: languages/ruby/bitwarden_sdk_secrets
+
+      - name: Wait for release to propagate
+        if: ${{ inputs.release_type == 'Release' }}
+        run: gem exec rubygems-await pkg/*.gem
+        working-directory: languages/ruby/bitwarden_sdk_secrets


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Use individual steps instead of composite action for Ruby publish to rubygem.org. Change is needed because the path where the Ruby code lives cannot be specified in `rubygems/release-gem` action.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/publish-ruby.yml** Use individual steps instead of composite action for Ruby publish to rubygem.org. Change is needed because the path where the Ruby code lives cannot be specified in `rubygems/release-gem` action.
- **.github/workflows/build-rust-cross-platform.yml:** Remove `path` in `push` trigger to build always

## Before you submit

- Please add **unit tests** where it makes sense to do so
