### PR TITLE
[DEVOPS-1785] Change ruby publish workflow to use api key method

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -107,26 +107,50 @@ jobs:
             cp "temp/${platforms[$i]}/${files[$i]}" "languages/ruby/bitwarden_sdk_secrets/lib/${platforms[$i]}/${files[$i]}"
           done
 
+      - name: Login to Azure
+        uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
+        with:
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "rubygem-api-key"
+
       - name: bundle install
         run: bundle install
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
-      - name: Set remote URL
+      - name: Push gem to Rubygems
         run: |
-          # Attribute commits to the last committer on HEAD
-          git config --global user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-          git config --global user.name "bitwarden-devops-bot"
-          git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
-
-      - name: Configure trusted publishing credentials
-        uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
-
-      - name: Run release rake task
-        if: ${{ inputs.release_type == 'Release' }}
-        run: bundle exec rake release
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: ${{ steps.retrieve-secrets.outputs.rubygem-api-key }}
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
-      - name: Wait for release to propagate
-        if: ${{ inputs.release_type == 'Release' }}
-        run: gem exec rubygems-await pkg/*.gem
-        working-directory: languages/ruby/bitwarden_sdk_secrets
+      # - name: Set remote URL
+      #   run: |
+      #     # Attribute commits to the last committer on HEAD
+      #     git config --global user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
+      #     git config --global user.name "bitwarden-devops-bot"
+      #     git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
+
+      # - name: Configure trusted publishing credentials
+      #   uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+
+      # - name: Run release rake task
+      #   if: ${{ inputs.release_type == 'Release' }}
+      #   run: bundle exec rake release
+      #   working-directory: languages/ruby/bitwarden_sdk_secrets
+
+      # - name: Wait for release to propagate
+      #   if: ${{ inputs.release_type == 'Release' }}
+      #   run: gem exec rubygems-await pkg/*.gem
+      #   working-directory: languages/ruby/bitwarden_sdk_secrets
+

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -129,7 +129,7 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem push *.gem
+          gem push pkg/*.gem
         env:
           GEM_HOST_API_KEY: ${{ steps.retrieve-secrets.outputs.rubygem-api-key }}
         working-directory: languages/ruby/bitwarden_sdk_secrets

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -123,13 +123,17 @@ jobs:
         run: bundle install
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
+      - name: Build gem
+        run: gem build bitwarden-sdk.gemspec
+        working-directory: languages/ruby/bitwarden_sdk_secrets
+
       - name: Push gem to Rubygems
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem push pkg/*.gem
+          gem push *.gem
         env:
           GEM_HOST_API_KEY: ${{ steps.retrieve-secrets.outputs.rubygem-api-key }}
         working-directory: languages/ruby/bitwarden_sdk_secrets

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
   id-token: write
 
-# jobs:
+jobs:
 #   setup:
 #     name: Setup
 #     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -124,7 +124,7 @@ jobs:
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
       - name: Build gem
-        run: gem build bitwarden-sdk.gemspec
+        run: gem build bitwarden-sdk-secrets.gemspec
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
       - name: Push gem to Rubygems

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -17,28 +17,28 @@ permissions:
   contents: read
   id-token: write
 
-jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+# jobs:
+#   setup:
+#     name: Setup
+#     runs-on: ubuntu-22.04
+#     steps:
+#       - name: Checkout repo
+#         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Branch check
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
-            echo "==================================="
-            exit 1
-          fi
+#       - name: Branch check
+#         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+#         run: |
+#           if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
+#             echo "==================================="
+#             echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+#             echo "==================================="
+#             exit 1
+#           fi
 
   publish_ruby:
     name: Publish Ruby
     runs-on: ubuntu-22.04
-    needs: setup
+    # needs: setup
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -18,27 +18,27 @@ permissions:
   id-token: write
 
 jobs:
-#   setup:
-#     name: Setup
-#     runs-on: ubuntu-22.04
-#     steps:
-#       - name: Checkout repo
-#         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  setup:
+    name: Setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-#       - name: Branch check
-#         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-#         run: |
-#           if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
-#             echo "==================================="
-#             echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
-#             echo "==================================="
-#             exit 1
-#           fi
+      - name: Branch check
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+            echo "==================================="
+            exit 1
+          fi
 
   publish_ruby:
     name: Publish Ruby
     runs-on: ubuntu-22.04
-    # needs: setup
+    needs: setup
     steps:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -54,7 +54,7 @@ jobs:
           workflow: generate_schemas.yml
           path: languages/ruby/bitwarden_sdk_secrets/lib
           workflow_conclusion: success
-          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: schemas.rb
 
       - name: Download x86_64-apple-darwin artifact
@@ -63,7 +63,7 @@ jobs:
           workflow: build-rust-cross-platform.yml
           path: temp/macos-x64
           workflow_conclusion: success
-          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-apple-darwin
 
       - name: Download aarch64-apple-darwin artifact
@@ -71,7 +71,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-aarch64-apple-darwin
           path: temp/macos-arm64
 
@@ -80,7 +80,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-unknown-linux-gnu
           path: temp/linux-x64
 
@@ -89,7 +89,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-pc-windows-msvc
           path: temp/windows-x64
 
@@ -137,24 +137,3 @@ jobs:
         env:
           GEM_HOST_API_KEY: ${{ steps.retrieve-secrets.outputs.rubygem-api-key }}
         working-directory: languages/ruby/bitwarden_sdk_secrets
-
-      # - name: Set remote URL
-      #   run: |
-      #     # Attribute commits to the last committer on HEAD
-      #     git config --global user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-      #     git config --global user.name "bitwarden-devops-bot"
-      #     git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
-
-      # - name: Configure trusted publishing credentials
-      #   uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
-
-      # - name: Run release rake task
-      #   if: ${{ inputs.release_type == 'Release' }}
-      #   run: bundle exec rake release
-      #   working-directory: languages/ruby/bitwarden_sdk_secrets
-
-      # - name: Wait for release to propagate
-      #   if: ${{ inputs.release_type == 'Release' }}
-      #   run: gem exec rubygems-await pkg/*.gem
-      #   working-directory: languages/ruby/bitwarden_sdk_secrets
-

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -54,7 +54,7 @@ jobs:
           workflow: generate_schemas.yml
           path: languages/ruby/bitwarden_sdk_secrets/lib
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: schemas.rb
 
       - name: Download x86_64-apple-darwin artifact
@@ -63,7 +63,7 @@ jobs:
           workflow: build-rust-cross-platform.yml
           path: temp/macos-x64
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-apple-darwin
 
       - name: Download aarch64-apple-darwin artifact
@@ -71,7 +71,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-aarch64-apple-darwin
           path: temp/macos-arm64
 
@@ -80,7 +80,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-unknown-linux-gnu
           path: temp/linux-x64
 
@@ -89,7 +89,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: rc # ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: libbitwarden_c_files-x86_64-pc-windows-msvc
           path: temp/windows-x64
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/publish-ruby.yml:** Use `gem push` with rubygem API key instead of automated release steps.

## Before you submit

- Please add **unit tests** where it makes sense to do so
