### PR TITLE
Fix typo in `trust_device`

### DIFF
--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -130,7 +130,7 @@ impl ClientAuth {
     }
 
     /// Trust the current device
-    pub async fn t(&self) -> Result<TrustDeviceResponse> {
+    pub async fn trust_device(&self) -> Result<TrustDeviceResponse> {
         Ok(self.0 .0.write().await.auth().trust_device()?)
     }
 }

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -46,6 +46,16 @@ Generator operations
 
 **Output**: Arc<ClientGenerators>
 
+### `exporters`
+
+Exporters
+
+**Arguments**:
+
+- self: Arc<Self>
+
+**Output**: Arc<ClientExporters>
+
 ### `auth`
 
 Auth operations
@@ -138,6 +148,23 @@ password, use the email OTP.
 
 **Output**: std::result::Result<,BitwardenError>
 
+### `validate_password_user_key`
+
+Validate the user password without knowing the password hash
+
+Used for accounts that we know have master passwords but that have not logged in with a password.
+Some example are login with device or TDE.
+
+This works by comparing the provided password against the encrypted user key.
+
+**Arguments**:
+
+- self:
+- password: String
+- encrypted_user_key: String
+
+**Output**: std::result::Result<String,BitwardenError>
+
 ### `new_auth_request`
 
 Initialize a new auth request
@@ -159,6 +186,16 @@ Approve an auth request
 - public_key: String
 
 **Output**: std::result::Result<AsymmetricEncString,BitwardenError>
+
+### `trust_device`
+
+Trust the current device
+
+**Arguments**:
+
+- self:
+
+**Output**: std::result::Result<TrustDeviceResponse,BitwardenError>
 
 ## ClientAttachments
 
@@ -1283,6 +1320,37 @@ implementations.
                 <td>method</td>
                 <td></td>
                 <td></td>
+            </tr>
+        </table>
+    </td>
+</tr>
+<tr>
+    <th>deviceKey</th>
+    <th>object</th>
+    <th></th>
+</tr>
+<tr>
+    <td colspan="3">
+        <table>
+        <tr>
+            <th>Key</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+            <tr>
+                <td>device_key</td>
+                <td>string</td>
+                <td>The device's DeviceKey</td>
+            </tr>
+            <tr>
+                <td>protected_device_private_key</td>
+                <td></td>
+                <td>The Device Private Key</td>
+            </tr>
+            <tr>
+                <td>device_protected_user_key</td>
+                <td></td>
+                <td>The user's symmetric crypto key, encrypted with the Device Key.</td>
             </tr>
         </table>
     </td>


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Function was accidentally called `t` when it should have been called `trust_device`
