### PR TITLE
Use same version for bitwarden crates

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,12 +11,7 @@ on:
         type: choice
         options:
           - bitwarden
-          - bitwarden-api-api
-          - bitwarden-api-identity
-          - bitwarden-crypto
-          - bitwarden-generators
-          - bitwarden-json
-          - cli
+          - bws
           - napi
           - python-sdk
           - ruby-sdk
@@ -43,7 +38,7 @@ jobs:
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Install cargo-release
-        run: cargo install cargo-edit
+        run: cargo install cargo-edit --locked
 
       - name: Login to Azure - CI Subscription
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
@@ -101,49 +96,19 @@ jobs:
 
       - name: Bump napi crate Version
         if: ${{ inputs.project == 'napi' }}
-        run: cargo-set-version set-version -p bitwarden-napi ${{ inputs.version_number }}
+        run: cargo set-version -p bitwarden-napi ${{ inputs.version_number }}
 
       ### bitwarden
 
       - name: Bump bitwarden crate Version
         if: ${{ inputs.project == 'bitwarden' }}
-        run: cargo-set-version set-version -p bitwarden ${{ inputs.version_number }}
+        run: cargo set-version -p bitwarden ${{ inputs.version_number }}
 
-      ### bitwarden-api-api
+      ### bws
 
-      - name: Bump bitwarden-api-api crate Version
-        if: ${{ inputs.project == 'bitwarden-api-api' }}
-        run: cargo-set-version set-version -p bitwarden-api-api ${{ inputs.version_number }}
-
-      ### bitwarden-api-identity
-
-      - name: Bump bitwarden-api-identity crate Version
-        if: ${{ inputs.project == 'bitwarden-api-identity' }}
-        run: cargo-set-version set-version -p bitwarden-api-identity ${{ inputs.version_number }}
-
-      ### bitwarden-crypto
-
-      - name: Bump bitwarden-crypto crate Version
-        if: ${{ inputs.project == 'bitwarden-crypto' }}
-        run: cargo-set-version set-version -p bitwarden-crypto ${{ inputs.version_number }}
-
-      ### bitwarden-generators
-
-      - name: Bump bitwarden-generators crate Version
-        if: ${{ inputs.project == 'bitwarden-generators' }}
-        run: cargo-set-version set-version -p bitwarden-generators ${{ inputs.version_number }}
-
-      ### cli
-
-      - name: Bump cli Version
-        if: ${{ inputs.project == 'cli' }}
-        run: cargo-set-version set-version -p bws ${{ inputs.version_number }}
-
-      ### bitwarden-json
-
-      - name: Bump bitwarden-json crate Version
-        if: ${{ inputs.project == 'bitwarden-json' }}
-        run: cargo-set-version set-version -p bitwarden-json ${{ inputs.version_number }}
+      - name: Bump bws Version
+        if: ${{ inputs.project == 'bws' }}
+        run: cargo set-version -p bws ${{ inputs.version_number }}
 
       ### python
       - name: Bump python-sdk Version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-api-api"
-version = "0.2.3"
+version = "0.4.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-api-identity"
-version = "0.2.3"
+version = "0.4.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-cli"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-crypto"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "argon2",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-exporters"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bitwarden-crypto",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-generators"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bitwarden-crypto",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = ["crates/*"]
 
 # Global settings for all crates should be defined here
 [workspace.package]
+# Update using `cargo set-version -p bitwarden <new-version>`
+version = "0.4.0"
 authors = ["Bitwarden Inc"]
 edition = "2021"
 # Note: Changing rust-version should be considered a breaking change
@@ -15,12 +17,12 @@ keywords = ["bitwarden"]
 
 # Define dependencies that are expected to be consistent across all crates
 [workspace.dependencies]
-bitwarden = { path = "crates/bitwarden", version = "0.4.0" }
-bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "0.2.3" }
-bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=0.2.3" }
-bitwarden-crypto = { path = "crates/bitwarden-crypto", version = "=0.1.0" }
-bitwarden-exporters = { path = "crates/bitwarden-exporters", version = "=0.1.0" }
-bitwarden-generators = { path = "crates/bitwarden-generators", version = "=0.1.0" }
+bitwarden = { path = "crates/bitwarden", version = "=0.4.0" }
+bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "=0.4.0" }
+bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=0.4.0" }
+bitwarden-crypto = { path = "crates/bitwarden-crypto", version = "=0.4.0" }
+bitwarden-exporters = { path = "crates/bitwarden-exporters", version = "=0.4.0" }
+bitwarden-generators = { path = "crates/bitwarden-generators", version = "=0.4.0" }
 
 # Compile all dependencies with some optimizations when building this crate on debug
 # This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords = ["bitwarden"]
 bitwarden = { path = "crates/bitwarden", version = "=0.4.0" }
 bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "=0.4.0" }
 bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=0.4.0" }
+bitwarden-cli = { path = "crates/bitwarden-cli", version = "=0.4.0" }
 bitwarden-crypto = { path = "crates/bitwarden-crypto", version = "=0.4.0" }
 bitwarden-exporters = { path = "crates/bitwarden-exporters", version = "=0.4.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=0.4.0" }

--- a/crates/bitwarden-api-api/Cargo.toml
+++ b/crates/bitwarden-api-api/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bitwarden-api-api"
-version = "0.2.3"
 description = """
 Api bindings for the Bitwarden API.
 """
 categories = ["api-bindings"]
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-api-identity/Cargo.toml
+++ b/crates/bitwarden-api-identity/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bitwarden-api-identity"
-version = "0.2.3"
 description = """
 Api bindings for the Bitwarden Identity API.
 """
 categories = ["api-bindings"]
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-cli/Cargo.toml
+++ b/crates/bitwarden-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitwarden-cli"
-version = "0.1.0"
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bitwarden-crypto"
-version = "0.1.0"
 description = """
 Internal crate for the bitwarden crate. Do not use.
 """
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bitwarden-exporters"
-version = "0.1.0"
 description = """
 Internal crate for the bitwarden crate. Do not use.
 """
 exclude = ["/resources"]
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-generators/Cargo.toml
+++ b/crates/bitwarden-generators/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bitwarden-generators"
-version = "0.1.0"
 description = """
 Internal crate for the bitwarden crate. Do not use.
 """
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -21,9 +21,8 @@ secrets = ["bitwarden/secrets"]   # Secrets manager API
 
 [dependencies]
 async-lock = ">=3.3.0, <4.0"
+bitwarden = { workspace = true }
 log = ">=0.4.18, <0.5"
 schemars = ">=0.8.12, <0.9"
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
-
-bitwarden = { workspace = true }

--- a/crates/bitwarden-napi/Cargo.toml
+++ b/crates/bitwarden-napi/Cargo.toml
@@ -18,14 +18,13 @@ license-file.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+bitwarden-json = { path = "../bitwarden-json", version = "0.3.0", features = [
+    "secrets",
+] }
 env_logger = "0.11.1"
 log = "0.4.20"
 napi = { version = "2", features = ["async"] }
 napi-derive = "2"
-
-bitwarden-json = { path = "../bitwarden-json", version = "0.3.0", features = [
-    "secrets",
-] }
 
 [build-dependencies]
 napi-build = "2.1.0"

--- a/crates/bitwarden-py/Cargo.toml
+++ b/crates/bitwarden-py/Cargo.toml
@@ -16,10 +16,9 @@ name = "bitwarden_py"
 crate-type = ["cdylib"]
 
 [dependencies]
+bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 pyo3 = { version = "0.20.2", features = ["extension-module"] }
 pyo3-log = "0.9.0"
-
-bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 
 [build-dependencies]
 pyo3-build-config = { version = "0.20.2" }

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -19,6 +19,9 @@ bench = false
 
 [dependencies]
 async-lock = "3.3.0"
+bitwarden = { workspace = true, features = ["mobile", "internal"] }
+bitwarden-crypto = { workspace = true, features = ["mobile"] }
+bitwarden-generators = { workspace = true, features = ["mobile"] }
 chrono = { version = ">=0.4.26, <0.5", features = [
     "serde",
     "std",
@@ -26,10 +29,6 @@ chrono = { version = ">=0.4.26, <0.5", features = [
 env_logger = "0.11.1"
 schemars = { version = ">=0.8, <0.9", optional = true }
 uniffi = "=0.26.1"
-
-bitwarden = { workspace = true, features = ["mobile", "internal"] }
-bitwarden-crypto = { workspace = true, features = ["mobile"] }
-bitwarden-generators = { workspace = true, features = ["mobile"] }
 
 [build-dependencies]
 uniffi = { version = "=0.26.1", features = ["build"] }

--- a/crates/bitwarden-wasm/Cargo.toml
+++ b/crates/bitwarden-wasm/Cargo.toml
@@ -15,6 +15,10 @@ keywords.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+bitwarden-json = { path = "../bitwarden-json", features = [
+    "secrets",
+    "internal",
+] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 js-sys = "0.3.68"
@@ -22,11 +26,6 @@ log = "0.4.20"
 serde = { version = "1.0.196", features = ["derive"] }
 wasm-bindgen = { version = "0.2.91", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.41"
-
-bitwarden-json = { path = "../bitwarden-json", features = [
-    "secrets",
-    "internal",
-] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.41"

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bitwarden"
-version = "0.4.0"
 description = """
 Bitwarden Secrets Manager SDK
 """
 keywords = ["bitwarden", "secrets-manager"]
 
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.20"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 
 bitwarden = { workspace = true, features = ["internal", "mobile"] }
-bitwarden-cli = { path = "../bitwarden-cli", version = "0.1.0" }
+bitwarden-cli = { path = "../bitwarden-cli", version = "0.4.0" }
 
 [dev-dependencies]
 tempfile = "3.10.0"

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -15,7 +15,7 @@ license-file.workspace = true
 
 [dependencies]
 bitwarden = { workspace = true, features = ["internal", "mobile"] }
-bitwarden-cli = { path = "../bitwarden-cli", version = "0.4.0" }
+bitwarden-cli = { workspace = true }
 clap = { version = "4.5.1", features = ["derive", "env"] }
 color-eyre = "0.6"
 env_logger = "0.11.1"

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -14,15 +14,14 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
+bitwarden = { workspace = true, features = ["internal", "mobile"] }
+bitwarden-cli = { path = "../bitwarden-cli", version = "0.4.0" }
 clap = { version = "4.5.1", features = ["derive", "env"] }
 color-eyre = "0.6"
 env_logger = "0.11.1"
 inquire = "0.6.2"
 log = "0.4.20"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
-
-bitwarden = { workspace = true, features = ["internal", "mobile"] }
-bitwarden-cli = { path = "../bitwarden-cli", version = "0.4.0" }
 
 [dev-dependencies]
 tempfile = "3.10.0"

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -18,6 +18,7 @@ license-file.workspace = true
 bat = { version = "0.24.0", features = [
     "regex-onig",
 ], default-features = false }
+bitwarden = { workspace = true, features = ["secrets"] }
 chrono = { version = "0.4.34", features = [
     "clock",
     "std",
@@ -41,8 +42,6 @@ thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 toml = "0.8.10"
 uuid = { version = "^1.7.0", features = ["serde"] }
-
-bitwarden = { workspace = true, features = ["secrets"] }
 
 [dev-dependencies]
 tempfile = "3.10.0"

--- a/crates/bws/Cargo.toml
+++ b/crates/bws/Cargo.toml
@@ -19,7 +19,7 @@ bat = { version = "0.24.0", features = [
     "regex-onig",
 ], default-features = false }
 bitwarden = { workspace = true, features = ["secrets"] }
-chrono = { version = "0.4.34", features = [
+chrono = { version = "0.4.35", features = [
     "clock",
     "std",
 ], default-features = false }

--- a/crates/sdk-schemas/Cargo.toml
+++ b/crates/sdk-schemas/Cargo.toml
@@ -20,10 +20,9 @@ internal = [
 
 [dependencies]
 anyhow = "1.0.79"
+bitwarden = { workspace = true }
+bitwarden-json = { path = "../bitwarden-json" }
+bitwarden-uniffi = { path = "../bitwarden-uniffi" }
 itertools = "0.12.1"
 schemars = { version = "0.8.16", features = ["preserve_order"] }
 serde_json = "1.0.113"
-
-bitwarden = { path = "../bitwarden" }
-bitwarden-json = { path = "../bitwarden-json" }
-bitwarden-uniffi = { path = "../bitwarden-uniffi" }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Rather than maintaining separate versions for every crate let's keep them locked. That means the rust sdk packages will always have the same version. Unfortunately a side effect of this is that every package will be released even if that package hasn't changed.

## Before you submit

- Please add **unit tests** where it makes sense to do so
