### PR TITLE
SM-1147: Switch to try_init with pyo3_log

### DIFF
--- a/crates/bitwarden-py/src/client.rs
+++ b/crates/bitwarden-py/src/client.rs
@@ -8,7 +8,10 @@ pub struct BitwardenClient(JsonClient);
 impl BitwardenClient {
     #[new]
     pub fn new(settings_string: Option<String>) -> Self {
-        _ = pyo3_log::try_init();
+        // This will only fail if another logger was already initialized, so we can ignore the
+        // result
+        let _ = pyo3_log::try_init();
+
         Self(JsonClient::new(settings_string))
     }
 

--- a/crates/bitwarden-py/src/client.rs
+++ b/crates/bitwarden-py/src/client.rs
@@ -8,7 +8,7 @@ pub struct BitwardenClient(JsonClient);
 impl BitwardenClient {
     #[new]
     pub fn new(settings_string: Option<String>) -> Self {
-        pyo3_log::init();
+        _ = pyo3_log::try_init();
         Self(JsonClient::new(settings_string))
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When running the `ansible-playbook` command, we needed to export the following variable: `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`. This suppresses fork safety warnings on Mac OS. With this set, you can safely query for individual secrets. However, if you query for secrets within an Ansible loop or with a Jinja2 template, we receive an error that is caused by setting up a logger more than once. (This error comes from the `pyo3_log` crate.)

If we switch to using the `pyo3_log::try_init` function, we ignore the case where a logger is already set up if the attempt fails. This happens because the `pyo3_log::init` function [can panic](https://github.com/vorner/pyo3-log/blob/70819388bfcb58a7ca91a27179a73cea0abde31e/src/lib.rs#L569). This also introduces panic safety.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **client.rs:** Switch to `try_init`

## Before you submit

- Please add **unit tests** where it makes sense to do so
