### PR TITLE
[PM-7068] - Use a distroless container image for `bws`

### DIFF
--- a/crates/bws/Dockerfile
+++ b/crates/bws/Dockerfile
@@ -17,10 +17,14 @@ COPY . /app
 WORKDIR /app/crates/bws
 RUN cargo build --release --bin bws
 
+# Bundle bws dependencies
+RUN mkdir /lib-bws
+RUN ldd /app/target/release/bws | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % cp % /lib-bws
+
 ###############################################
 #                  App stage                  #
 ###############################################
-FROM debian:bookworm-slim
+FROM scratch
 
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"
@@ -28,14 +32,11 @@ LABEL com.bitwarden.product="bitwarden"
 # Copy built project from the build stage
 WORKDIR /usr/local/bin
 COPY --from=build /app/target/release/bws .
+
+# Copy certs
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 
-# Create a non-root user
-RUN useradd -ms /bin/bash app
-
-# Switch to the non-root user
-USER app
-
-WORKDIR /home/app
+# Copy bws dependencies
+COPY --from=build /lib-bws /lib
 
 ENTRYPOINT ["bws"]

--- a/crates/bws/Dockerfile
+++ b/crates/bws/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app
 
 # Build project
 WORKDIR /app/crates/bws
-RUN cargo build --release
+RUN cargo build --release --bin bws
 
 ###############################################
 #                  App stage                  #

--- a/crates/bws/Dockerfile
+++ b/crates/bws/Dockerfile
@@ -21,6 +21,9 @@ RUN cargo build --release --bin bws
 RUN mkdir /lib-bws
 RUN ldd /app/target/release/bws | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % cp % /lib-bws
 
+# Make a HOME directory for the app stage
+RUN mkdir -p /home/app
+
 ###############################################
 #                  App stage                  #
 ###############################################
@@ -28,6 +31,10 @@ FROM scratch
 
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"
+
+# Set a HOME directory
+COPY --from=build /home/app /home/app
+ENV HOME=/home/app
 
 # Copy built project from the build stage
 WORKDIR /usr/local/bin


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Addresses [PM-7068](https://bitwarden.atlassian.net/browse/PM-7068). Build the `bws` Docker image from an empty file system. This results in a much smaller Docker image (~16MB, uncompressed) with a smaller threat surface than bundling it with a distro.

## Code changes

- **./crates/bws/Dockerfile:** Use `scratch` for the final build stage. This results in a distroless image that only contains our binary, the libraries that it depends on, and the CA certificates needed for SSL to work. The `ldd` line automatically determines what dependencies we need to copy over so we don't have to manually maintain a list of them.

## Before you submit

- Please add **unit tests** where it makes sense to do so


[PM-7068]: https://bitwarden.atlassian.net/browse/PM-7068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ