### PR TITLE
[PM-7051] Implement make_register_tde_keys

### DIFF
--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use bitwarden::auth::{
     password::MasterPasswordPolicyOptions, AuthRequestResponse, RegisterKeyResponse,
+    RegisterTdeKeyResponse,
 };
 use bitwarden_crypto::{AsymmetricEncString, HashPurpose, Kdf, TrustDeviceResponse};
 
@@ -76,6 +77,21 @@ impl ClientAuth {
             .await
             .auth()
             .make_register_keys(email, password, kdf)?)
+    }
+
+    /// Generate keys needed for TDE process
+    pub async fn make_register_tde_keys(
+        &self,
+        org_public_key: String,
+        remember_device: bool,
+    ) -> Result<RegisterTdeKeyResponse> {
+        Ok(self
+            .0
+             .0
+            .write()
+            .await
+            .auth()
+            .make_register_tde_keys(org_public_key, remember_device)?)
     }
 
     /// Validate the user password

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -20,6 +20,7 @@ use crate::{
             MasterPasswordPolicyOptions,
         },
         register::{make_register_keys, register},
+        tde::{make_register_tde_keys, RegisterTdeKeyResponse},
         AuthRequestResponse, RegisterKeyResponse, RegisterRequest,
     },
     client::Kdf,
@@ -71,6 +72,14 @@ impl<'a> ClientAuth<'a> {
         kdf: Kdf,
     ) -> Result<RegisterKeyResponse> {
         make_register_keys(email, password, kdf)
+    }
+
+    pub fn make_register_tde_keys(
+        &mut self,
+        org_public_key: String,
+        remember_device: bool,
+    ) -> Result<RegisterTdeKeyResponse> {
+        make_register_tde_keys(self.client, org_public_key, remember_device)
     }
 
     pub async fn register(&mut self, input: &RegisterRequest) -> Result<()> {

--- a/crates/bitwarden/src/auth/mod.rs
+++ b/crates/bitwarden/src/auth/mod.rs
@@ -20,6 +20,10 @@ mod auth_request;
 pub use auth_request::AuthRequestResponse;
 #[cfg(feature = "mobile")]
 pub(crate) use auth_request::{auth_request_decrypt_master_key, auth_request_decrypt_user_key};
+#[cfg(feature = "internal")]
+mod tde;
+#[cfg(feature = "internal")]
+pub use tde::RegisterTdeKeyResponse;
 
 #[cfg(feature = "internal")]
 use crate::{client::Kdf, error::Result};

--- a/crates/bitwarden/src/auth/tde.rs
+++ b/crates/bitwarden/src/auth/tde.rs
@@ -1,0 +1,52 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use bitwarden_crypto::{
+    AsymmetricEncString, AsymmetricPublicCryptoKey, DeviceKey, EncString, SymmetricCryptoKey,
+    TrustDeviceResponse, UserKey,
+};
+
+use crate::{error::Result, Client};
+
+pub(super) fn make_register_tde_keys(
+    client: &mut Client,
+    org_public_key: String,
+    remember_device: bool,
+) -> Result<RegisterTdeKeyResponse> {
+    let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(org_public_key)?)?;
+
+    let mut rng = rand::thread_rng();
+
+    // Generate a new user key and key pair, and encrypt the user key with the org public key for
+    // admin password reset
+    let user_key = UserKey::new(SymmetricCryptoKey::generate(&mut rng));
+    let key_pair = user_key.make_key_pair()?;
+
+    let admin_reset =
+        AsymmetricEncString::encrypt_rsa2048_oaep_sha1(&user_key.0.to_vec(), &public_key)?;
+
+    let device_key = if remember_device {
+        Some(DeviceKey::trust_device(&user_key.0)?)
+    } else {
+        None
+    };
+
+    // Initialize the crypto with the generated user key, this way it doesn't need to leave the
+    // client
+    client.initialize_user_crypto_decrypted_key(user_key.0, key_pair.private.clone())?;
+
+    Ok(RegisterTdeKeyResponse {
+        private_key: key_pair.private,
+        public_key: key_pair.public,
+
+        admin_reset,
+        device_key,
+    })
+}
+
+#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+pub struct RegisterTdeKeyResponse {
+    pub private_key: EncString,
+    pub public_key: String,
+
+    pub admin_reset: AsymmetricEncString,
+    pub device_key: Option<TrustDeviceResponse>,
+}

--- a/crates/bitwarden/src/auth/tde.rs
+++ b/crates/bitwarden/src/auth/tde.rs
@@ -6,6 +6,9 @@ use bitwarden_crypto::{
 
 use crate::{error::Result, Client};
 
+/// This function generates a new user key and key pair, initializes the client's crypto with the
+/// generated user key, and encrypts the user key with the organization public key for admin
+/// password reset. If remember_device is true, it also generates a device key.
 pub(super) fn make_register_tde_keys(
     client: &mut Client,
     org_public_key: String,
@@ -15,8 +18,6 @@ pub(super) fn make_register_tde_keys(
 
     let mut rng = rand::thread_rng();
 
-    // Generate a new user key and key pair, and encrypt the user key with the org public key for
-    // admin password reset
     let user_key = UserKey::new(SymmetricCryptoKey::generate(&mut rng));
     let key_pair = user_key.make_key_pair()?;
 
@@ -29,8 +30,6 @@ pub(super) fn make_register_tde_keys(
         None
     };
 
-    // Initialize the crypto with the generated user key, this way it doesn't need to leave the
-    // client
     client.initialize_user_crypto_decrypted_key(user_key.0, key_pair.private.clone())?;
 
     Ok(RegisterTdeKeyResponse {

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -265,7 +265,7 @@ impl Client {
         Ok(self.encryption_settings.as_ref().unwrap())
     }
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "internal")]
     pub(crate) fn initialize_user_crypto_decrypted_key(
         &mut self,
         user_key: SymmetricCryptoKey,


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add support in the SDK to create the keys necessary for the just in time user for TDE