### PR TITLE
[PM-6764] Move cipher to organization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "env_logger",
  "schemars",
  "uniffi",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = ">=0.4.26, <0.5", features = [
 env_logger = "0.11.1"
 schemars = { version = ">=0.8, <0.9", optional = true }
 uniffi = "=0.26.1"
+uuid = ">=1.3.3, <2"
 
 bitwarden = { workspace = true, features = ["mobile", "internal"] }
 bitwarden-crypto = { workspace = true, features = ["mobile"] }

--- a/crates/bitwarden-uniffi/src/uniffi_support.rs
+++ b/crates/bitwarden-uniffi/src/uniffi_support.rs
@@ -1,4 +1,5 @@
 use bitwarden_crypto::{AsymmetricEncString, EncString, SensitiveString};
+use uuid::Uuid;
 
 // Forward the type definitions to the main bitwarden crate
 type DateTime = chrono::DateTime<chrono::Utc>;
@@ -6,3 +7,4 @@ uniffi::ffi_converter_forward!(DateTime, bitwarden::UniFfiTag, crate::UniFfiTag)
 uniffi::ffi_converter_forward!(EncString, bitwarden::UniFfiTag, crate::UniFfiTag);
 uniffi::ffi_converter_forward!(AsymmetricEncString, bitwarden::UniFfiTag, crate::UniFfiTag);
 uniffi::ffi_converter_forward!(SensitiveString, bitwarden::UniFfiTag, crate::UniFfiTag);
+uniffi::ffi_converter_forward!(Uuid, bitwarden::UniFfiTag, crate::UniFfiTag);

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden::vault::{Cipher, CipherListView, CipherView};
+use uuid::Uuid;
 
 use crate::{Client, Result};
 
@@ -45,6 +46,23 @@ impl ClientCiphers {
             .vault()
             .ciphers()
             .decrypt_list(ciphers)
+            .await?)
+    }
+
+    /// Move a cipher to an organization, reencrypting the cipher key if necessary
+    pub async fn move_to_organization(
+        &self,
+        cipher: CipherView,
+        organization_id: Uuid,
+    ) -> Result<CipherView> {
+        Ok(self
+            .0
+             .0
+            .read()
+            .await
+            .vault()
+            .ciphers()
+            .move_to_organization(cipher, organization_id)
             .await?)
     }
 }

--- a/crates/bitwarden/src/mobile/vault/client_ciphers.rs
+++ b/crates/bitwarden/src/mobile/vault/client_ciphers.rs
@@ -1,4 +1,5 @@
 use bitwarden_crypto::{Decryptable, Encryptable, LocateKey};
+use uuid::Uuid;
 
 use super::client_vault::ClientVault;
 use crate::{
@@ -43,6 +44,16 @@ impl<'a> ClientCiphers<'a> {
         let cipher_views = ciphers.decrypt(enc, &None)?;
 
         Ok(cipher_views)
+    }
+
+    pub async fn move_to_organization(
+        &self,
+        mut cipher_view: CipherView,
+        organization_id: Uuid,
+    ) -> Result<CipherView> {
+        let enc = self.client.get_encryption_settings()?;
+        cipher_view.move_to_organization(enc, organization_id)?;
+        Ok(cipher_view)
     }
 }
 

--- a/languages/kotlin/doc.md
+++ b/languages/kotlin/doc.md
@@ -132,6 +132,18 @@ Generate keys needed for registration process
 
 **Output**: std::result::Result<RegisterKeyResponse,BitwardenError>
 
+### `make_register_tde_keys`
+
+Generate keys needed for TDE process
+
+**Arguments**:
+
+- self:
+- org_public_key: String
+- remember_device:
+
+**Output**: std::result::Result<RegisterTdeKeyResponse,BitwardenError>
+
 ### `validate_password`
 
 Validate the user password
@@ -288,6 +300,18 @@ Decrypt cipher list
 
 **Output**: std::result::Result<Vec,BitwardenError>
 
+### `move_to_organization`
+
+Move a cipher to an organization, reencrypting the cipher key if necessary
+
+**Arguments**:
+
+- self:
+- cipher: [CipherView](#cipherview)
+- organization_id: Uuid
+
+**Output**: std::result::Result<CipherView,BitwardenError>
+
 ## ClientCollections
 
 ### `decrypt`
@@ -346,7 +370,7 @@ as it can be used to decrypt all of the user&#x27;s data
 
 - self:
 
-**Output**: std::result::Result<String,BitwardenError>
+**Output**: std::result::Result<SensitiveString,BitwardenError>
 
 ### `update_password`
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Added function to allow moving a cipher to an organization, which requires reencrypting the cipher key if it has one.