### PR TITLE
[SM-1189] Fix renew for service account access token logins

### DIFF
--- a/crates/bitwarden/src/auth/renew.rs
+++ b/crates/bitwarden/src/auth/renew.rs
@@ -57,7 +57,7 @@ pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
                     .await?;
 
                     if let (
-                        IdentityTokenResponse::Authenticated(r),
+                        IdentityTokenResponse::Payload(r),
                         Some(state_file),
                         Ok(enc_settings),
                     ) = (&result, state_file, client.get_encryption_settings())
@@ -80,6 +80,10 @@ pub(crate) async fn renew_token(client: &mut Client) -> Result<()> {
                 return Ok(());
             }
             IdentityTokenResponse::Authenticated(r) => {
+                client.set_tokens(r.access_token, r.refresh_token, r.expires_in);
+                return Ok(());
+            }
+            IdentityTokenResponse::Payload(r) => {
                 client.set_tokens(r.access_token, r.refresh_token, r.expires_in);
                 return Ok(());
             }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix `renew_token` to properly `client.set_tokens(r.access_token, r.refresh_token, r.expires_in)` when logged in via service account access token.


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **crates/bitwarden/src/auth/renew.rs:**
Match to the `IdentityTokenResponse:Payload` returned by the access token request to the identity server.

## Before you submit

- Please add **unit tests** where it makes sense to do so
