### PR TITLE
Change fastMail to use forDomain instead of url

### DIFF
--- a/crates/bitwarden-generators/src/username_forwarders/fastmail.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/fastmail.rs
@@ -34,7 +34,7 @@ pub async fn generate_with_api_url(
                         "new-masked-email": {
                             "state": "enabled",
                             "description": "",
-                            "url": website,
+                            "forDomain": website,
                             "emailPrefix": null,
                         },
                     },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

It seems the web clients use `forDomain` instead of `url` for website. This changes the SDK to send the same values.

## Before you submit

- Please add **unit tests** where it makes sense to do so
