### PR TITLE
[PM-7066] Use Sensitive in MasterKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ name = "bitwarden-wasm"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "bitwarden-crypto",
  "bitwarden-json",
  "console_error_panic_hook",
  "console_log",
@@ -583,6 +584,7 @@ version = "0.0.2"
 dependencies = [
  "bitwarden",
  "bitwarden-cli",
+ "bitwarden-crypto",
  "clap",
  "color-eyre",
  "env_logger",

--- a/crates/bitwarden-crypto/src/sensitive/sensitive.rs
+++ b/crates/bitwarden-crypto/src/sensitive/sensitive.rs
@@ -67,6 +67,13 @@ impl TryFrom<SensitiveVec> for SensitiveString {
     }
 }
 
+impl From<SensitiveString> for SensitiveVec {
+    fn from(mut s: SensitiveString) -> Self {
+        let value = std::mem::take(&mut s.value);
+        Sensitive::new(Box::new(value.into_bytes()))
+    }
+}
+
 impl SensitiveString {
     pub fn decode_base64<T: base64::Engine>(self, engine: T) -> Result<SensitiveVec, CryptoError> {
         // Prevent accidental copies by allocating the full size
@@ -139,15 +146,18 @@ impl<V: Zeroize + JsonSchema> JsonSchema for Sensitive<V> {
     }
 }
 
-impl Sensitive<String> {
-    // We use a lot of `&str` in our tests, so we expose this helper
-    // to make it easier.
-    // IMPORTANT: This should not be used outside of test code
-    // Note that we can't just mark it with #[cfg(test)] because that only applies
-    // when testing this crate, not when testing other crates that depend on it.
-    // By at least limiting it to &'static str we should be able to avoid accidental usages
-    pub fn test(value: &'static str) -> Self {
-        Self::new(Box::new(value.to_string()))
+// We use a lot of `&str` and `&[u8]` in our tests, so we expose this helper
+// to make it easier.
+// IMPORTANT: This should not be used outside of test code
+// Note that we can't just mark it with #[cfg(test)] because that only applies
+// when testing this crate, not when testing other crates that depend on it.
+// By at least limiting it to &'static str we should be able to avoid accidental usages
+impl<V: Zeroize> Sensitive<V> {
+    pub fn test<T: ?Sized>(value: &'static T) -> Self
+    where
+        &'static T: Into<V>,
+    {
+        Self::new(Box::new(value.into()))
     }
 }
 
@@ -159,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let string = Sensitive::test("test");
+        let string = SensitiveString::test("test");
         assert_eq!(
             format!("{:?}", string),
             "Sensitive { type: \"alloc::string::String\", value: \"********\" }"

--- a/crates/bitwarden-crypto/src/sensitive/sensitive.rs
+++ b/crates/bitwarden-crypto/src/sensitive/sensitive.rs
@@ -151,7 +151,7 @@ impl<V: Zeroize + JsonSchema> JsonSchema for Sensitive<V> {
 // IMPORTANT: This should not be used outside of test code
 // Note that we can't just mark it with #[cfg(test)] because that only applies
 // when testing this crate, not when testing other crates that depend on it.
-// By at least limiting it to &'static str we should be able to avoid accidental usages
+// By at least limiting it to &'static reference we should be able to avoid accidental usages
 impl<V: Zeroize> Sensitive<V> {
     pub fn test<T: ?Sized>(value: &'static T) -> Self
     where

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -49,15 +49,15 @@ impl Client {
 
         match cmd {
             #[cfg(feature = "internal")]
-            Command::PasswordLogin(req) => client.auth().login_password(&req).await.into_string(),
+            Command::PasswordLogin(req) => client.auth().login_password(req).await.into_string(),
             #[cfg(feature = "secrets")]
             Command::AccessTokenLogin(req) => {
                 client.auth().login_access_token(&req).await.into_string()
             }
             #[cfg(feature = "internal")]
-            Command::GetUserApiKey(req) => client.get_user_api_key(&req).await.into_string(),
+            Command::GetUserApiKey(req) => client.get_user_api_key(req).await.into_string(),
             #[cfg(feature = "internal")]
-            Command::ApiKeyLogin(req) => client.auth().login_api_key(&req).await.into_string(),
+            Command::ApiKeyLogin(req) => client.auth().login_api_key(req).await.into_string(),
             #[cfg(feature = "internal")]
             Command::Sync(req) => client.sync(&req).await.into_string(),
             #[cfg(feature = "internal")]

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -4,7 +4,9 @@ use bitwarden::auth::{
     password::MasterPasswordPolicyOptions, AuthRequestResponse, RegisterKeyResponse,
     RegisterTdeKeyResponse,
 };
-use bitwarden_crypto::{AsymmetricEncString, HashPurpose, Kdf, TrustDeviceResponse};
+use bitwarden_crypto::{
+    AsymmetricEncString, HashPurpose, Kdf, SensitiveString, TrustDeviceResponse,
+};
 
 use crate::{error::Result, Client};
 
@@ -49,7 +51,7 @@ impl ClientAuth {
     pub async fn hash_password(
         &self,
         email: String,
-        password: String,
+        password: SensitiveString,
         kdf_params: Kdf,
         purpose: HashPurpose,
     ) -> Result<String> {
@@ -67,7 +69,7 @@ impl ClientAuth {
     pub async fn make_register_keys(
         &self,
         email: String,
-        password: String,
+        password: SensitiveString,
         kdf: Kdf,
     ) -> Result<RegisterKeyResponse> {
         Ok(self
@@ -98,7 +100,11 @@ impl ClientAuth {
     /// To retrieve the user's password hash, use [`ClientAuth::hash_password`] with
     /// `HashPurpose::LocalAuthentication` during login and persist it. If the login method has no
     /// password, use the email OTP.
-    pub async fn validate_password(&self, password: String, password_hash: String) -> Result<bool> {
+    pub async fn validate_password(
+        &self,
+        password: SensitiveString,
+        password_hash: String,
+    ) -> Result<bool> {
         Ok(self
             .0
              .0
@@ -116,7 +122,7 @@ impl ClientAuth {
     /// This works by comparing the provided password against the encrypted user key.
     pub async fn validate_password_user_key(
         &self,
-        password: String,
+        password: SensitiveString,
         encrypted_user_key: String,
     ) -> Result<String> {
         Ok(self

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -53,7 +53,10 @@ impl ClientCrypto {
 
     /// Update the user's password, which will re-encrypt the user's encryption key with the new
     /// password. This returns the new encrypted user key and the new password hash.
-    pub async fn update_password(&self, new_password: String) -> Result<UpdatePasswordResponse> {
+    pub async fn update_password(
+        &self,
+        new_password: SensitiveString,
+    ) -> Result<UpdatePasswordResponse> {
         Ok(self
             .0
              .0
@@ -67,7 +70,7 @@ impl ClientCrypto {
     /// Generates a PIN protected user key from the provided PIN. The result can be stored and later
     /// used to initialize another client instance by using the PIN and the PIN key with
     /// `initialize_user_crypto`.
-    pub async fn derive_pin_key(&self, pin: String) -> Result<DerivePinKeyResponse> {
+    pub async fn derive_pin_key(&self, pin: SensitiveString) -> Result<DerivePinKeyResponse> {
         Ok(self.0 .0.write().await.crypto().derive_pin_key(pin).await?)
     }
 

--- a/crates/bitwarden-wasm/Cargo.toml
+++ b/crates/bitwarden-wasm/Cargo.toml
@@ -19,6 +19,7 @@ argon2 = { version = ">=0.5.0, <0.6", features = [
     "alloc",
     "zeroize",
 ], default-features = false }
+bitwarden-crypto = { workspace = true }
 bitwarden-json = { path = "../bitwarden-json", features = [
     "secrets",
     "internal",

--- a/crates/bitwarden/src/auth/auth_request.rs
+++ b/crates/bitwarden/src/auth/auth_request.rs
@@ -122,7 +122,7 @@ fn test_auth_request() {
 mod tests {
     use std::num::NonZeroU32;
 
-    use bitwarden_crypto::Kdf;
+    use bitwarden_crypto::{Kdf, SensitiveVec};
 
     use super::*;
     use crate::mobile::crypto::{AuthRequestMethod, InitUserCryptoMethod, InitUserCryptoRequest};
@@ -132,7 +132,7 @@ mod tests {
         let mut client = Client::new(None);
 
         let master_key = bitwarden_crypto::MasterKey::derive(
-            "asdfasdfasdf".as_bytes(),
+            &SensitiveVec::test(b"asdfasdfasdf"),
             "test@bitwarden.com".as_bytes(),
             &Kdf::PBKDF2 {
                 iterations: NonZeroU32::new(600_000).unwrap(),
@@ -206,9 +206,12 @@ mod tests {
         // Initialize an existing client which is unlocked
         let mut existing_device = Client::new(None);
 
-        let master_key =
-            bitwarden_crypto::MasterKey::derive("asdfasdfasdf".as_bytes(), email.as_bytes(), &kdf)
-                .unwrap();
+        let master_key = bitwarden_crypto::MasterKey::derive(
+            &SensitiveVec::test(b"asdfasdfasdf"),
+            email.as_bytes(),
+            &kdf,
+        )
+        .unwrap();
 
         existing_device
             .initialize_user_crypto_master_key(master_key, user_key, private_key.parse().unwrap())

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "internal")]
-use bitwarden_crypto::{AsymmetricEncString, DeviceKey, TrustDeviceResponse};
+use bitwarden_crypto::{AsymmetricEncString, DeviceKey, SensitiveString, TrustDeviceResponse};
 
 #[cfg(feature = "mobile")]
 use crate::auth::login::NewAuthRequestResponse;
@@ -68,7 +68,7 @@ impl<'a> ClientAuth<'a> {
     pub fn make_register_keys(
         &self,
         email: String,
-        password: String,
+        password: SensitiveString,
         kdf: Kdf,
     ) -> Result<RegisterKeyResponse> {
         make_register_keys(email, password, kdf)
@@ -83,7 +83,7 @@ impl<'a> ClientAuth<'a> {
         make_register_tde_keys(self.client, email, org_public_key, remember_device)
     }
 
-    pub async fn register(&mut self, input: &RegisterRequest) -> Result<()> {
+    pub async fn register(&mut self, input: RegisterRequest) -> Result<()> {
         register(self.client, input).await
     }
 
@@ -96,29 +96,33 @@ impl<'a> ClientAuth<'a> {
 
     pub async fn login_password(
         &mut self,
-        input: &PasswordLoginRequest,
+        input: PasswordLoginRequest,
     ) -> Result<PasswordLoginResponse> {
         login_password(self.client, input).await
     }
 
     pub async fn login_api_key(
         &mut self,
-        input: &ApiKeyLoginRequest,
+        input: ApiKeyLoginRequest,
     ) -> Result<ApiKeyLoginResponse> {
         login_api_key(self.client, input).await
     }
 
-    pub async fn send_two_factor_email(&mut self, tf: &TwoFactorEmailRequest) -> Result<()> {
+    pub async fn send_two_factor_email(&mut self, tf: TwoFactorEmailRequest) -> Result<()> {
         send_two_factor_email(self.client, tf).await
     }
 
-    pub fn validate_password(&self, password: String, password_hash: String) -> Result<bool> {
+    pub fn validate_password(
+        &self,
+        password: SensitiveString,
+        password_hash: String,
+    ) -> Result<bool> {
         validate_password(self.client, password, password_hash)
     }
 
     pub fn validate_password_user_key(
         &self,
-        password: String,
+        password: SensitiveString,
         encrypted_user_key: String,
     ) -> Result<String> {
         validate_password_user_key(self.client, password, encrypted_user_key)

--- a/crates/bitwarden/src/auth/login/api_key.rs
+++ b/crates/bitwarden/src/auth/login/api_key.rs
@@ -1,4 +1,4 @@
-use bitwarden_crypto::{EncString, MasterKey};
+use bitwarden_crypto::{EncString, MasterKey, SensitiveString};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,12 +15,12 @@ use crate::{
 
 pub(crate) async fn login_api_key(
     client: &mut Client,
-    input: &ApiKeyLoginRequest,
+    input: ApiKeyLoginRequest,
 ) -> Result<ApiKeyLoginResponse> {
     //info!("api key logging in");
     //debug!("{:#?}, {:#?}", client, input);
 
-    let response = request_api_identity_tokens(client, input).await?;
+    let response = request_api_identity_tokens(client, &input).await?;
 
     if let IdentityTokenResponse::Authenticated(r) = &response {
         let access_token_obj: JWTToken = r.access_token.parse()?;
@@ -38,7 +38,7 @@ pub(crate) async fn login_api_key(
             r.expires_in,
         );
 
-        let master_key = MasterKey::derive(input.password.as_bytes(), email.as_bytes(), &kdf)?;
+        let master_key = MasterKey::derive(&input.password.into(), email.as_bytes(), &kdf)?;
 
         client.set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
             client_id: input.client_id.to_owned(),
@@ -76,7 +76,7 @@ pub struct ApiKeyLoginRequest {
     pub client_secret: String,
 
     /// Bitwarden account master password
-    pub password: String,
+    pub password: SensitiveString,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/crates/bitwarden/src/auth/login/two_factor.rs
+++ b/crates/bitwarden/src/auth/login/two_factor.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::TwoFactorEmailRequestModel;
-use bitwarden_crypto::HashPurpose;
+use bitwarden_crypto::{HashPurpose, SensitiveString};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -9,15 +9,15 @@ use crate::{auth::determine_password_hash, error::Result, Client};
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TwoFactorEmailRequest {
-    /// User Password
-    pub password: String,
     /// User email
     pub email: String,
+    /// User Password
+    pub password: SensitiveString,
 }
 
 pub(crate) async fn send_two_factor_email(
     client: &mut Client,
-    input: &TwoFactorEmailRequest,
+    input: TwoFactorEmailRequest,
 ) -> Result<()> {
     // TODO: This should be resolved from the client
     let kdf = client.auth().prelogin(input.email.clone()).await?;
@@ -25,7 +25,7 @@ pub(crate) async fn send_two_factor_email(
     let password_hash = determine_password_hash(
         &input.email,
         &kdf,
-        &input.password,
+        &input.password.into(),
         HashPurpose::ServerAuthorization,
     )?;
 

--- a/crates/bitwarden/src/auth/mod.rs
+++ b/crates/bitwarden/src/auth/mod.rs
@@ -11,7 +11,7 @@ pub use jwt_token::JWTToken;
 #[cfg(feature = "internal")]
 mod register;
 #[cfg(feature = "internal")]
-use bitwarden_crypto::{HashPurpose, MasterKey};
+use bitwarden_crypto::{HashPurpose, MasterKey, SensitiveVec};
 #[cfg(feature = "internal")]
 pub use register::{RegisterKeyResponse, RegisterRequest};
 #[cfg(feature = "internal")]
@@ -32,11 +32,11 @@ use crate::{client::Kdf, error::Result};
 fn determine_password_hash(
     email: &str,
     kdf: &Kdf,
-    password: &str,
+    password: &SensitiveVec,
     purpose: HashPurpose,
 ) -> Result<String> {
-    let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), kdf)?;
-    Ok(master_key.derive_master_key_hash(password.as_bytes(), purpose)?)
+    let master_key = MasterKey::derive(password, email.as_bytes(), kdf)?;
+    Ok(master_key.derive_master_key_hash(password, purpose)?)
 }
 
 #[cfg(test)]
@@ -50,14 +50,14 @@ mod tests {
     fn test_determine_password_hash() {
         use super::determine_password_hash;
 
-        let password = "password123";
+        let password = SensitiveVec::test(b"password123");
         let email = "test@bitwarden.com";
         let kdf = Kdf::PBKDF2 {
             iterations: NonZeroU32::new(100_000).unwrap(),
         };
         let purpose = HashPurpose::LocalAuthorization;
 
-        let result = determine_password_hash(email, &kdf, password, purpose).unwrap();
+        let result = determine_password_hash(email, &kdf, &password, purpose).unwrap();
 
         assert_eq!(result, "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU=");
     }

--- a/crates/bitwarden/src/auth/password/validate.rs
+++ b/crates/bitwarden/src/auth/password/validate.rs
@@ -1,4 +1,4 @@
-use bitwarden_crypto::{HashPurpose, MasterKey};
+use bitwarden_crypto::{HashPurpose, MasterKey, SensitiveString};
 
 use crate::{
     auth::determine_password_hash,
@@ -10,7 +10,7 @@ use crate::{
 /// Validate if the provided password matches the password hash stored in the client.
 pub(crate) fn validate_password(
     client: &Client,
-    password: String,
+    password: SensitiveString,
     password_hash: String,
 ) -> Result<bool> {
     let login_method = client
@@ -25,7 +25,7 @@ pub(crate) fn validate_password(
                 let hash = determine_password_hash(
                     email,
                     kdf,
-                    &password,
+                    &password.into(),
                     HashPurpose::LocalAuthorization,
                 )?;
 
@@ -40,7 +40,7 @@ pub(crate) fn validate_password(
 #[cfg(feature = "internal")]
 pub(crate) fn validate_password_user_key(
     client: &Client,
-    password: String,
+    password: bitwarden_crypto::SensitiveString,
     encrypted_user_key: String,
 ) -> Result<String> {
     let login_method = client
@@ -52,7 +52,8 @@ pub(crate) fn validate_password_user_key(
         match login_method {
             UserLoginMethod::Username { email, kdf, .. }
             | UserLoginMethod::ApiKey { email, kdf, .. } => {
-                let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), kdf)?;
+                let password_vec = password.into();
+                let master_key = MasterKey::derive(&password_vec, email.as_bytes(), kdf)?;
                 let user_key = master_key
                     .decrypt_user_key(encrypted_user_key.parse()?)
                     .map_err(|_| "wrong password")?;
@@ -68,7 +69,7 @@ pub(crate) fn validate_password_user_key(
                 }
 
                 Ok(master_key
-                    .derive_master_key_hash(password.as_bytes(), HashPurpose::LocalAuthorization)?)
+                    .derive_master_key_hash(&password_vec, HashPurpose::LocalAuthorization)?)
             }
         }
     } else {
@@ -78,6 +79,8 @@ pub(crate) fn validate_password_user_key(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_crypto::SensitiveString;
+
     use crate::auth::password::{validate::validate_password_user_key, validate_password};
 
     #[test]
@@ -95,7 +98,7 @@ mod tests {
             client_id: "1".to_string(),
         }));
 
-        let password = "password123".to_string();
+        let password = SensitiveString::test("password123");
         let password_hash = "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU=".to_string();
 
         let result = validate_password(&client, password, password_hash);
@@ -108,11 +111,13 @@ mod tests {
     fn test_validate_password_user_key() {
         use std::num::NonZeroU32;
 
+        use bitwarden_crypto::SensitiveVec;
+
         use crate::client::{Client, Kdf, LoginMethod, UserLoginMethod};
 
         let mut client = Client::new(None);
 
-        let password = "asdfasdfasdf";
+        let password = SensitiveVec::test(b"asdfasdfasdf");
         let email = "test@bitwarden.com";
         let kdf = Kdf::PBKDF2 {
             iterations: NonZeroU32::new(600_000).unwrap(),
@@ -125,8 +130,53 @@ mod tests {
         }));
 
         let master_key =
-            bitwarden_crypto::MasterKey::derive(password.as_bytes(), email.as_bytes(), &kdf)
-                .unwrap();
+            bitwarden_crypto::MasterKey::derive(&password, email.as_bytes(), &kdf).unwrap();
+
+        let user_key = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
+        let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
+
+        client
+            .initialize_user_crypto_master_key(master_key, user_key.parse().unwrap(), private_key)
+            .unwrap();
+
+        let result = validate_password_user_key(
+            &client,
+            SensitiveString::test("asdfasdfasdf"),
+            user_key.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(result, "aOvkBXFhSdgrBWR3hZCMRoML9+h5yRblU3lFphCdkeA=");
+        assert!(
+            validate_password(&client, password.try_into().unwrap(), result.to_string()).unwrap()
+        )
+    }
+
+    #[cfg(feature = "internal")]
+    #[test]
+    fn test_validate_password_user_key_wrong_password() {
+        use std::num::NonZeroU32;
+
+        use bitwarden_crypto::SensitiveVec;
+
+        use crate::client::{Client, Kdf, LoginMethod, UserLoginMethod};
+
+        let mut client = Client::new(None);
+
+        let password = SensitiveVec::test(b"asdfasdfasdf");
+        let email = "test@bitwarden.com";
+        let kdf = Kdf::PBKDF2 {
+            iterations: NonZeroU32::new(600_000).unwrap(),
+        };
+
+        client.set_login_method(LoginMethod::User(UserLoginMethod::Username {
+            email: email.to_string(),
+            kdf: kdf.clone(),
+            client_id: "1".to_string(),
+        }));
+
+        let master_key =
+            bitwarden_crypto::MasterKey::derive(&password, email.as_bytes(), &kdf).unwrap();
 
         let user_key = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
         let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
@@ -136,47 +186,8 @@ mod tests {
             .unwrap();
 
         let result =
-            validate_password_user_key(&client, "asdfasdfasdf".to_string(), user_key.to_string())
-                .unwrap();
-
-        assert_eq!(result, "aOvkBXFhSdgrBWR3hZCMRoML9+h5yRblU3lFphCdkeA=");
-        assert!(validate_password(&client, "asdfasdfasdf".to_string(), result.to_string()).unwrap())
-    }
-
-    #[cfg(feature = "internal")]
-    #[test]
-    fn test_validate_password_user_key_wrong_password() {
-        use std::num::NonZeroU32;
-
-        use crate::client::{Client, Kdf, LoginMethod, UserLoginMethod};
-
-        let mut client = Client::new(None);
-
-        let password = "asdfasdfasdf";
-        let email = "test@bitwarden.com";
-        let kdf = Kdf::PBKDF2 {
-            iterations: NonZeroU32::new(600_000).unwrap(),
-        };
-
-        client.set_login_method(LoginMethod::User(UserLoginMethod::Username {
-            email: email.to_string(),
-            kdf: kdf.clone(),
-            client_id: "1".to_string(),
-        }));
-
-        let master_key =
-            bitwarden_crypto::MasterKey::derive(password.as_bytes(), email.as_bytes(), &kdf)
-                .unwrap();
-
-        let user_key = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
-        let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
-
-        client
-            .initialize_user_crypto_master_key(master_key, user_key.parse().unwrap(), private_key)
-            .unwrap();
-
-        let result = validate_password_user_key(&client, "abc".to_string(), user_key.to_string())
-            .unwrap_err();
+            validate_password_user_key(&client, SensitiveString::test("abc"), user_key.to_string())
+                .unwrap_err();
 
         assert_eq!(result.to_string(), "Internal error: wrong password");
     }

--- a/crates/bitwarden/src/auth/register.rs
+++ b/crates/bitwarden/src/auth/register.rs
@@ -2,7 +2,9 @@ use bitwarden_api_identity::{
     apis::accounts_api::accounts_register_post,
     models::{KeysRequestModel, RegisterRequestModel},
 };
-use bitwarden_crypto::{default_pbkdf2_iterations, HashPurpose, MasterKey, RsaKeyPair};
+use bitwarden_crypto::{
+    default_pbkdf2_iterations, HashPurpose, MasterKey, RsaKeyPair, SensitiveString,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -13,27 +15,27 @@ use crate::{client::Kdf, error::Result, Client};
 pub struct RegisterRequest {
     pub email: String,
     pub name: Option<String>,
-    pub password: String,
+    pub password: SensitiveString,
     pub password_hint: Option<String>,
 }
 
 /// Half baked implementation of user registration
-pub(super) async fn register(client: &mut Client, req: &RegisterRequest) -> Result<()> {
+pub(super) async fn register(client: &mut Client, req: RegisterRequest) -> Result<()> {
     let config = client.get_api_configurations().await;
 
     let kdf = Kdf::default();
 
-    let keys = make_register_keys(req.email.to_owned(), req.password.to_owned(), kdf)?;
+    let keys = make_register_keys(req.email.clone(), req.password, kdf)?;
 
     accounts_register_post(
         &config.identity,
         Some(RegisterRequestModel {
-            name: req.name.to_owned(),
-            email: req.email.to_owned(),
+            name: req.name,
+            email: req.email,
             master_password_hash: keys.master_password_hash,
-            master_password_hint: req.password_hint.to_owned(),
+            master_password_hint: req.password_hint,
             captcha_response: None, // TODO: Add
-            key: Some(keys.encrypted_user_key.to_string()),
+            key: Some(keys.encrypted_user_key),
             keys: Some(Box::new(KeysRequestModel {
                 public_key: Some(keys.keys.public),
                 encrypted_private_key: keys.keys.private.to_string(),
@@ -54,12 +56,13 @@ pub(super) async fn register(client: &mut Client, req: &RegisterRequest) -> Resu
 
 pub(super) fn make_register_keys(
     email: String,
-    password: String,
+    password: SensitiveString,
     kdf: Kdf,
 ) -> Result<RegisterKeyResponse> {
-    let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), &kdf)?;
+    let password_vec = password.into();
+    let master_key = MasterKey::derive(&password_vec, email.as_bytes(), &kdf)?;
     let master_password_hash =
-        master_key.derive_master_key_hash(password.as_bytes(), HashPurpose::ServerAuthorization)?;
+        master_key.derive_master_key_hash(&password_vec, HashPurpose::ServerAuthorization)?;
     let (user_key, encrypted_user_key) = master_key.make_user_key()?;
     let keys = user_key.make_key_pair()?;
 

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -197,7 +197,7 @@ impl Client {
     #[cfg(feature = "internal")]
     pub async fn get_user_api_key(
         &mut self,
-        input: &SecretVerificationRequest,
+        input: SecretVerificationRequest,
     ) -> Result<UserApiKeyResponse> {
         get_user_api_key(self, input).await
     }

--- a/crates/bitwarden/src/mobile/client_crypto.rs
+++ b/crates/bitwarden/src/mobile/client_crypto.rs
@@ -35,13 +35,13 @@ impl<'a> ClientCrypto<'a> {
     #[cfg(feature = "internal")]
     pub async fn update_password(
         &mut self,
-        new_password: String,
+        new_password: SensitiveString,
     ) -> Result<UpdatePasswordResponse> {
         update_password(self.client, new_password)
     }
 
     #[cfg(feature = "internal")]
-    pub async fn derive_pin_key(&mut self, pin: String) -> Result<DerivePinKeyResponse> {
+    pub async fn derive_pin_key(&mut self, pin: SensitiveString) -> Result<DerivePinKeyResponse> {
         derive_pin_key(self.client, pin)
     }
 

--- a/crates/bitwarden/src/mobile/client_kdf.rs
+++ b/crates/bitwarden/src/mobile/client_kdf.rs
@@ -1,4 +1,4 @@
-use bitwarden_crypto::HashPurpose;
+use bitwarden_crypto::{HashPurpose, SensitiveString};
 
 use crate::{client::Kdf, error::Result, mobile::kdf::hash_password, Client};
 
@@ -10,7 +10,7 @@ impl<'a> ClientKdf<'a> {
     pub async fn hash_password(
         &self,
         email: String,
-        password: String,
+        password: SensitiveString,
         kdf_params: Kdf,
         purpose: HashPurpose,
     ) -> Result<String> {

--- a/crates/bitwarden/src/mobile/kdf.rs
+++ b/crates/bitwarden/src/mobile/kdf.rs
@@ -1,15 +1,16 @@
-use bitwarden_crypto::{HashPurpose, Kdf, MasterKey};
+use bitwarden_crypto::{HashPurpose, Kdf, MasterKey, SensitiveString};
 
 use crate::{error::Result, Client};
 
 pub async fn hash_password(
     _client: &Client,
     email: String,
-    password: String,
+    password: SensitiveString,
     kdf_params: Kdf,
     purpose: HashPurpose,
 ) -> Result<String> {
-    let master_key = MasterKey::derive(password.as_bytes(), email.as_bytes(), &kdf_params)?;
+    let password_vec = password.into();
+    let master_key = MasterKey::derive(&password_vec, email.as_bytes(), &kdf_params)?;
 
-    Ok(master_key.derive_master_key_hash(password.as_bytes(), purpose)?)
+    Ok(master_key.derive_master_key_hash(&password_vec, purpose)?)
 }

--- a/crates/bitwarden/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden/src/platform/generate_fingerprint.rs
@@ -54,6 +54,8 @@ pub(crate) fn generate_user_fingerprint(
 mod tests {
     use std::num::NonZeroU32;
 
+    use bitwarden_crypto::SensitiveVec;
+
     use super::*;
     use crate::{client::Kdf, Client};
 
@@ -66,7 +68,7 @@ mod tests {
         let mut client = Client::new(None);
 
         let master_key = bitwarden_crypto::MasterKey::derive(
-            "asdfasdfasdf".as_bytes(),
+            &SensitiveVec::test(b"asdfasdfasdf"),
             "robb@stark.com".as_bytes(),
             &Kdf::PBKDF2 {
                 iterations: NonZeroU32::new(600_000).unwrap(),

--- a/crates/bitwarden/src/platform/secret_verification_request.rs
+++ b/crates/bitwarden/src/platform/secret_verification_request.rs
@@ -1,3 +1,4 @@
+use bitwarden_crypto::SensitiveString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct SecretVerificationRequest {
     /// The user's master password to use for user verification. If supplied, this will be used for
     /// verification purposes.
-    pub master_password: Option<String>,
+    pub master_password: Option<SensitiveString>,
     /// Alternate user verification method through OTP. This is provided for users who have no
     /// master password due to use of Customer Managed Encryption. Must be present and valid if
     /// master_password is absent.

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -361,7 +361,7 @@ impl TryFrom<SendTextModel> for SendText {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_crypto::{KeyDecryptable, KeyEncryptable, MasterKey};
+    use bitwarden_crypto::{KeyDecryptable, KeyEncryptable, MasterKey, SensitiveVec};
 
     use super::{Send, SendText, SendTextView, SendType};
     use crate::{
@@ -373,7 +373,7 @@ mod tests {
     fn test_get_send_key() {
         // Initialize user encryption with some test data
         let master_key = MasterKey::derive(
-            "asdfasdfasdf".as_bytes(),
+            &SensitiveVec::test(b"asdfasdfasdf"),
             "test@bitwarden.com".as_bytes(),
             &Kdf::PBKDF2 {
                 iterations: 345123.try_into().unwrap(),
@@ -400,7 +400,7 @@ mod tests {
 
     fn build_encryption_settings() -> EncryptionSettings {
         let master_key = MasterKey::derive(
-            "asdfasdfasdf".as_bytes(),
+            &SensitiveVec::test(b"asdfasdfasdf"),
             "test@bitwarden.com".as_bytes(),
             &Kdf::PBKDF2 {
                 iterations: 600_000.try_into().unwrap(),

--- a/crates/bitwarden/tests/register.rs
+++ b/crates/bitwarden/tests/register.rs
@@ -8,19 +8,19 @@ async fn test_register_initialize_crypto() {
         mobile::crypto::{InitUserCryptoMethod, InitUserCryptoRequest},
         Client,
     };
-    use bitwarden_crypto::Kdf;
+    use bitwarden_crypto::{Kdf, SensitiveString};
 
     let mut client = Client::new(None);
 
     let email = "test@bitwarden.com";
-    let password = "test123";
+    let password = SensitiveString::test("test123");
     let kdf = Kdf::PBKDF2 {
         iterations: NonZeroU32::new(600_000).unwrap(),
     };
 
     let register_response = client
         .auth()
-        .make_register_keys(email.to_owned(), password.to_owned(), kdf.clone())
+        .make_register_keys(email.to_owned(), password.clone(), kdf.clone())
         .unwrap();
 
     // Ensure we can initialize the crypto with the new keys
@@ -32,7 +32,7 @@ async fn test_register_initialize_crypto() {
             private_key: register_response.keys.private.to_string(),
 
             method: InitUserCryptoMethod::Password {
-                password: password.to_owned(),
+                password,
                 user_key: register_response.encrypted_user_key,
             },
         })

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -16,6 +16,7 @@ license-file.workspace = true
 [dependencies]
 bitwarden = { workspace = true, features = ["internal", "mobile"] }
 bitwarden-cli = { workspace = true }
+bitwarden-crypto = { workspace = true }
 clap = { version = "4.5.1", features = ["derive", "env"] }
 color-eyre = "0.6"
 env_logger = "0.11.1"

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -15,8 +15,9 @@ use log::{debug, error, info};
 pub(crate) async fn login_password(mut client: Client, email: Option<String>) -> Result<()> {
     let email = text_prompt_when_none("Email", email)?;
 
-    let password = Password::new("Password").without_confirmation().prompt()?;
-    let password = SensitiveString::new(Box::new(password));
+    let password = SensitiveString::new(Box::new(
+        Password::new("Password").without_confirmation().prompt()?,
+    ));
 
     let kdf = client.auth().prelogin(email.clone()).await?;
 
@@ -101,8 +102,9 @@ pub(crate) async fn login_api_key(
     let client_id = text_prompt_when_none("Client ID", client_id)?;
     let client_secret = text_prompt_when_none("Client Secret", client_secret)?;
 
-    let password = Password::new("Password").without_confirmation().prompt()?;
-    let password = SensitiveString::new(Box::new(password));
+    let password = SensitiveString::new(Box::new(
+        Password::new("Password").without_confirmation().prompt()?,
+    ));
 
     let result = client
         .auth()

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -7,6 +7,7 @@ use bitwarden::{
     Client,
 };
 use bitwarden_cli::text_prompt_when_none;
+use bitwarden_crypto::SensitiveString;
 use color_eyre::eyre::{bail, Result};
 use inquire::{Password, Text};
 use log::{debug, error, info};
@@ -15,12 +16,13 @@ pub(crate) async fn login_password(mut client: Client, email: Option<String>) ->
     let email = text_prompt_when_none("Email", email)?;
 
     let password = Password::new("Password").without_confirmation().prompt()?;
+    let password = SensitiveString::new(Box::new(password));
 
     let kdf = client.auth().prelogin(email.clone()).await?;
 
     let result = client
         .auth()
-        .login_password(&PasswordLoginRequest {
+        .login_password(PasswordLoginRequest {
             email: email.clone(),
             password: password.clone(),
             two_factor: None,
@@ -48,7 +50,7 @@ pub(crate) async fn login_password(mut client: Client, email: Option<String>) ->
             // Send token
             client
                 .auth()
-                .send_two_factor_email(&TwoFactorEmailRequest {
+                .send_two_factor_email(TwoFactorEmailRequest {
                     email: email.clone(),
                     password: password.clone(),
                 })
@@ -68,7 +70,7 @@ pub(crate) async fn login_password(mut client: Client, email: Option<String>) ->
 
         let result = client
             .auth()
-            .login_password(&PasswordLoginRequest {
+            .login_password(PasswordLoginRequest {
                 email,
                 password,
                 two_factor,
@@ -100,10 +102,11 @@ pub(crate) async fn login_api_key(
     let client_secret = text_prompt_when_none("Client Secret", client_secret)?;
 
     let password = Password::new("Password").without_confirmation().prompt()?;
+    let password = SensitiveString::new(Box::new(password));
 
     let result = client
         .auth()
-        .login_api_key(&ApiKeyLoginRequest {
+        .login_api_key(ApiKeyLoginRequest {
             client_id,
             client_secret,
             password,

--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -192,8 +192,7 @@ async fn process_commands() -> Result<()> {
             let mut client = bitwarden::Client::new(settings);
 
             let email = text_prompt_when_none("Email", email)?;
-            let password = Password::new("Password").prompt()?;
-            let password = SensitiveString::new(Box::new(password));
+            let password = SensitiveString::new(Box::new(Password::new("Password").prompt()?));
 
             client
                 .auth()

--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -4,6 +4,7 @@ use bitwarden::{
     generators::{PassphraseGeneratorRequest, PasswordGeneratorRequest},
 };
 use bitwarden_cli::{install_color_eyre, text_prompt_when_none, Color};
+use bitwarden_crypto::SensitiveString;
 use clap::{command, Args, CommandFactory, Parser, Subcommand};
 use color_eyre::eyre::Result;
 use inquire::Password;
@@ -192,10 +193,11 @@ async fn process_commands() -> Result<()> {
 
             let email = text_prompt_when_none("Email", email)?;
             let password = Password::new("Password").prompt()?;
+            let password = SensitiveString::new(Box::new(password));
 
             client
                 .auth()
-                .register(&RegisterRequest {
+                .register(RegisterRequest {
                     email,
                     name,
                     password,


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Use Sensitive in MasterKey and bubble up the Sensitive change for all the requests that contain a password or pin. Note that this requires changing the request structs to be taken by value.
