### PR TITLE
Remove reqwest wildcard dependency

### DIFF
--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -68,7 +68,7 @@ zxcvbn = ">= 2.2.2, <3.0"
 # There are a few exceptions to this:
 # - WASM doesn't require a TLS stack, as it just uses the browsers/node fetch
 # - Android uses webpki-roots for the moment
-reqwest = { version = "*", features = [
+reqwest = { version = ">=0.12, <0.13", features = [
     "rustls-tls-manual-roots",
 ], default-features = false }
 rustls-platform-verifier = "0.2.0"
@@ -76,7 +76,7 @@ rustls-platform-verifier = "0.2.0"
 [target.'cfg(target_os = "android")'.dependencies]
 # On android, the use of rustls-platform-verifier is more complicated and going through some changes at the moment, so we fall back to using webpki-roots
 # This means that for the moment android won't support self-signed certificates, even if they are included in the OS trust store
-reqwest = { version = "*", features = [
+reqwest = { version = ">=0.12, <0.13", features = [
     "rustls-tls-webpki-roots",
 ], default-features = false }
 


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Remove wildcard dep that forbids publishing to crates.io. Set the version to the same one used everywhere else.
