### PR TITLE
[PM-7214] Remove uniffi workaround

### DIFF
--- a/crates/bitwarden-crypto/src/uniffi_support.rs
+++ b/crates/bitwarden-crypto/src/uniffi_support.rs
@@ -59,10 +59,3 @@ impl UniffiCustomTypeConverter for SensitiveString {
         obj.expose().to_owned()
     }
 }
-
-/// Uniffi doesn't seem to be generating the SensitiveString unless it's being used by
-/// a record somewhere. This is a workaround to make sure the type is generated.
-#[derive(uniffi::Record)]
-struct SupportSensitiveString {
-    sensitive_string: SensitiveString,
-}


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We're using SensitiveString type in the API now, so this workaround is not necessary anymore
