### PR TITLE
Remove unused hash from fingerprint

### DIFF
--- a/crates/bitwarden-crypto/src/fingerprint.rs
+++ b/crates/bitwarden-crypto/src/fingerprint.rs
@@ -6,7 +6,6 @@
 
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
-use sha2::Digest;
 use thiserror::Error;
 
 use crate::{error::Result, wordlist::EFF_LONG_WORD_LIST, CryptoError};
@@ -17,10 +16,6 @@ use crate::{error::Result, wordlist::EFF_LONG_WORD_LIST, CryptoError};
 /// - `fingerprint_material`: user's id.
 /// - `public_key`: user's public key.
 pub fn fingerprint(fingerprint_material: &str, public_key: &[u8]) -> Result<String> {
-    let mut h = sha2::Sha256::new();
-    h.update(public_key);
-    h.finalize();
-
     let hkdf =
         hkdf::Hkdf::<sha2::Sha256>::from_prk(public_key).map_err(|_| CryptoError::InvalidKeyLen)?;
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In `fingerprint`, we were calculating the SHA256 hash and ignoring the result, to then proceed and calculate the `Hkdf<Sha256>`.

This PR removes the unnecessary hash.