### PR TITLE
Async callbacks test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ name = "bitwarden-uniffi"
 version = "0.1.0"
 dependencies = [
  "async-lock",
+ "async-trait",
  "bitwarden",
  "bitwarden-crypto",
  "bitwarden-generators",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -331,6 +331,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 name = "bitwarden"
 version = "0.5.0"
 dependencies = [
+ "async-trait",
  "base64",
  "bitwarden-api-api",
  "bitwarden-api-identity",
@@ -3615,9 +3616,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "uniffi"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
+checksum = "a5566fae48a5cb017005bf9cd622af5236b2a203a13fb548afde3506d3c68277"
 dependencies = [
  "anyhow",
  "camino",
@@ -3637,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
+checksum = "4a77bb514bcd4bf27c9bd404d7c3f2a6a8131b957eba9c22cfeb7751c4278e09"
 dependencies = [
  "anyhow",
  "askama",
@@ -3662,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
+checksum = "45cba427aeb7b3a8b54830c4c915079a7a3c62608dd03dddba1d867a8a023eb4"
 dependencies = [
  "anyhow",
  "camino",
@@ -3673,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
+checksum = "ae7e5a6c33b1dec3f255f57ec0b6af0f0b2bb3021868be1d5eec7a38e2905ebc"
 dependencies = [
  "quote",
  "syn 2.0.53",
@@ -3683,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
+checksum = "0ea3eb5474d50fc149b7e4d86b9c5bd4a61dcc167f0683902bf18ae7bbb3deef"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3700,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
+checksum = "18331d35003f46f0d04047fbe4227291815b83a937a8c32bc057f990962182c4"
 dependencies = [
  "bincode",
  "camino",
@@ -3713,15 +3714,14 @@ dependencies = [
  "serde",
  "syn 2.0.53",
  "toml 0.5.11",
- "uniffi_build",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
+checksum = "f7224422c4cfd181c7ca9fca2154abca4d21db962f926f270f996edd38b0c4b8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
+checksum = "f8ce878d0bdfc288b58797044eaaedf748526c56eef3575380bb4d4b19d69eee"
 dependencies = [
  "anyhow",
  "camino",
@@ -3744,9 +3744,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
+checksum = "8c43c9ed40a8d20a5c3eae2d23031092db6b96dc8e571beb449ba9757484cea0"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -41,7 +41,7 @@ sha1 = ">=0.10.5, <0.11"
 sha2 = ">=0.10.6, <0.11"
 subtle = ">=2.5.0, <3.0"
 thiserror = ">=1.0.40, <2.0"
-uniffi = { version = "=0.26.1", optional = true }
+uniffi = { version = "=0.27.1", optional = true }
 uuid = { version = ">=1.3.3, <2.0", features = ["serde"] }
 zeroize = { version = ">=1.7.0, <2.0", features = ["derive", "aarch64"] }
 

--- a/crates/bitwarden-generators/Cargo.toml
+++ b/crates/bitwarden-generators/Cargo.toml
@@ -27,7 +27,7 @@ schemars = { version = ">=0.8.9, <0.9", features = ["uuid1", "chrono"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 thiserror = ">=1.0.40, <2.0"
-uniffi = { version = "=0.26.1", optional = true }
+uniffi = { version = "=0.27.1", optional = true }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 
 [dependencies]
 async-lock = "3.3.0"
+async-trait = "0.1.80"
 bitwarden = { workspace = true, features = ["mobile", "internal"] }
 bitwarden-crypto = { workspace = true, features = ["mobile"] }
 bitwarden-generators = { workspace = true, features = ["mobile"] }

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -28,11 +28,11 @@ chrono = { version = ">=0.4.26, <0.5", features = [
 ], default-features = false }
 env_logger = "0.11.1"
 schemars = { version = ">=0.8, <0.9", optional = true }
-uniffi = "=0.26.1"
+uniffi = "=0.27.1"
 uuid = ">=1.3.3, <2"
 
 [build-dependencies]
-uniffi = { version = "=0.26.1", features = ["build"] }
+uniffi = { version = "=0.27.1", features = ["build"] }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -14,6 +14,14 @@ impl From<bitwarden::error::Error> for BitwardenError {
     }
 }
 
+// Need to implement this From<> impl in order to handle unexpected callback errors.  See the
+// Callback Interfaces section of the handbook for more info.
+impl From<uniffi::UnexpectedUniFFICallbackError> for BitwardenError {
+    fn from(e: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::E(bitwarden::error::Error::UniffiCallback(e))
+    }
+}
+
 impl Display for BitwardenError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -4,6 +4,8 @@ use bitwarden::platform::FingerprintRequest;
 
 use crate::{error::Result, Client};
 
+mod passkeys;
+
 #[derive(uniffi::Object)]
 pub struct ClientPlatform(pub(crate) Arc<Client>);
 
@@ -36,5 +38,10 @@ impl ClientPlatform {
     pub async fn load_flags(&self, flags: std::collections::HashMap<String, bool>) -> Result<()> {
         self.0 .0.write().await.load_flags(flags);
         Ok(())
+    }
+
+    /// Passkey operations
+    pub fn passkeys(self: Arc<Self>) -> Arc<passkeys::ClientPasskeys> {
+        Arc::new(passkeys::ClientPasskeys(self.0.clone()))
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/passkeys.rs
+++ b/crates/bitwarden-uniffi/src/platform/passkeys.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use crate::{error::Result, Client};
+
+#[derive(uniffi::Object)]
+pub struct ClientPasskeys(pub(crate) Arc<Client>);
+
+#[uniffi::export(async_runtime = "tokio")]
+impl ClientPasskeys {
+    pub async fn passkey_test_sync(&self, t: Arc<dyn TestTraitSync>) -> Result<String> {
+        Ok(self
+            .0
+             .0
+            .write()
+            .await
+            .platform()
+            .passkeys()
+            .passkey_test_sync(&UniffiTraitBridge(t.as_ref()))
+            .await?)
+    }
+
+    pub async fn passkey_test_async(&self, t: Arc<dyn TestTraitAsync>) -> Result<String> {
+        Ok(self
+            .0
+             .0
+            .write()
+            .await
+            .platform()
+            .passkeys()
+            .passkey_test_async(&UniffiTraitBridge(t.as_ref()))
+            .await?)
+    }
+}
+
+// Note that uniffi doesn't support external traits for now it seems, so we have to duplicate them here.
+
+#[uniffi::export(with_foreign)]
+pub trait TestTraitSync: Send + Sync {
+    fn give_me_a_name(&self) -> String;
+}
+
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait TestTraitAsync: Send + Sync {
+    async fn give_me_a_name(&self) -> String;
+}
+
+struct UniffiTraitBridge<T>(T);
+
+impl bitwarden::platform::TestTraitSync for UniffiTraitBridge<&dyn TestTraitSync> {
+    fn give_me_a_name(&self) -> String {
+        self.0.give_me_a_name()
+    }
+}
+
+#[async_trait::async_trait]
+impl bitwarden::platform::TestTraitAsync for UniffiTraitBridge<&dyn TestTraitAsync> {
+    async fn give_me_a_name(&self) -> String {
+        self.0.give_me_a_name().await
+    }
+}

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -59,7 +59,7 @@ serde_repr = ">=0.1.12, <0.2"
 sha1 = ">=0.10.5, <0.11"
 sha2 = ">=0.10.6, <0.11"
 thiserror = ">=1.0.40, <2.0"
-uniffi = { version = "=0.26.1", optional = true, features = ["tokio"] }
+uniffi = { version = "=0.27.1", optional = true, features = ["tokio"] }
 uuid = { version = ">=1.3.3, <2.0", features = ["serde"] }
 zxcvbn = ">= 2.2.2, <3.0"
 

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -31,6 +31,7 @@ mobile = [
 wasm-bindgen = ["chrono/wasmbind"]
 
 [dependencies]
+async-trait = ">=0.1.80, <0.2"
 base64 = ">=0.21.2, <0.22"
 bitwarden-api-api = { workspace = true }
 bitwarden-api-identity = { workspace = true }

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -68,6 +68,10 @@ pub enum Error {
     #[error(transparent)]
     ExportError(#[from] ExportError),
 
+    #[cfg(feature = "mobile")]
+    #[error("Uniffi callback error: {0}")]
+    UniffiCallback(#[from] uniffi::UnexpectedUniFFICallbackError),
+
     #[error("Internal error: {0}")]
     Internal(Cow<'static, str>),
 }

--- a/crates/bitwarden/src/platform/client_platform.rs
+++ b/crates/bitwarden/src/platform/client_platform.rs
@@ -1,6 +1,6 @@
 use super::{
     generate_fingerprint::{generate_fingerprint, generate_user_fingerprint},
-    FingerprintRequest, FingerprintResponse,
+    ClientPasskeys, FingerprintRequest, FingerprintResponse,
 };
 use crate::{error::Result, Client};
 
@@ -15,6 +15,12 @@ impl<'a> ClientPlatform<'a> {
 
     pub fn user_fingerprint(self, fingerprint_material: String) -> Result<String> {
         generate_user_fingerprint(self.client, fingerprint_material)
+    }
+
+    pub fn passkeys(&'a mut self) -> ClientPasskeys<'a> {
+        ClientPasskeys {
+            client: self.client,
+        }
     }
 }
 

--- a/crates/bitwarden/src/platform/mod.rs
+++ b/crates/bitwarden/src/platform/mod.rs
@@ -2,12 +2,14 @@ pub mod client_platform;
 mod domain;
 mod generate_fingerprint;
 mod get_user_api_key;
+mod passkeys;
 mod secret_verification_request;
 mod sync;
 
 pub use generate_fingerprint::{FingerprintRequest, FingerprintResponse};
 pub(crate) use get_user_api_key::get_user_api_key;
 pub use get_user_api_key::UserApiKeyResponse;
+pub use passkeys::{ClientPasskeys, TestTraitAsync, TestTraitSync};
 pub use secret_verification_request::SecretVerificationRequest;
 pub(crate) use sync::sync;
 pub use sync::{SyncRequest, SyncResponse};

--- a/crates/bitwarden/src/platform/passkeys.rs
+++ b/crates/bitwarden/src/platform/passkeys.rs
@@ -1,0 +1,30 @@
+use crate::{error::Result, Client};
+
+pub struct ClientPasskeys<'a> {
+    #[allow(dead_code)]
+    pub(crate) client: &'a mut Client,
+}
+
+impl<'a> ClientPasskeys<'a> {
+    pub async fn passkey_test_sync(&self, t: &dyn TestTraitSync) -> Result<String> {
+        Ok(format!("Hello {}!", t.give_me_a_name()))
+    }
+
+    pub async fn passkey_test_async(&self, t: &dyn TestTraitAsync) -> Result<String> {
+        Ok(format!(
+            "Hello {}, we're using async!",
+            t.give_me_a_name().await
+        ))
+    }
+}
+
+//#[cfg_attr(feature = "mobile", uniffi::export(with_foreign))]
+pub trait TestTraitSync: Send + Sync {
+    fn give_me_a_name(&self) -> String;
+}
+
+//#[cfg_attr(feature = "mobile", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait TestTraitAsync: Send + Sync {
+    async fn give_me_a_name(&self) -> String;
+}

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -17,4 +17,4 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-uniffi = { version = "=0.26.1", features = ["cli"] }
+uniffi = { version = "=0.27.1", features = ["cli"] }

--- a/languages/java/gradle/wrapper/gradle-wrapper.properties
+++ b/languages/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/languages/kotlin/app/build.gradle
+++ b/languages/kotlin/app/build.gradle
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace 'com.bitwarden.myapplication'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.bitwarden.myapplication"
         minSdk 28
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -38,7 +38,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.8'
+        kotlinCompilerExtensionVersion '1.5.12'
     }
     packagingOptions {
         resources {

--- a/languages/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
+++ b/languages/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
@@ -32,6 +32,9 @@ import com.bitwarden.crypto.HashPurpose
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.myapplication.ui.theme.MyApplicationTheme
 import com.bitwarden.sdk.Client
+import com.bitwarden.sdk.ClientPasskeysTestSync
+import com.bitwarden.sdk.TestTraitAsync
+import com.bitwarden.sdk.TestTraitSync
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -89,6 +92,30 @@ class MainActivity : FragmentActivity() {
         biometric = Biometric(this)
         client = Client(null)
         http = httpClient()
+
+        GlobalScope.launch {
+
+            class TestSyncImplementation : TestTraitSync {
+                override fun giveMeAName(): String {
+                    return "Kotlin!"
+                }
+            }
+
+            class TestAsyncImplementation : TestTraitAsync {
+                constructor(client: Client)
+                override suspend fun giveMeAName(): String {
+                    return client.echo("Kotlin-suspend!")
+                }
+            }
+
+            println("NAME: " + TestSyncImplementation().giveMeAName())
+
+            val result1 = client.platform().passkeys().passkeyTestSync(TestSyncImplementation())
+            val result2 = client.platform().passkeys().passkeyTestAsync(TestAsyncImplementation(client))
+
+            println("Result1: $result1")
+            println("Result2: $result2")
+        }
 
         setContent {
             MyApplicationTheme {

--- a/languages/kotlin/build.gradle
+++ b/languages/kotlin/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.0' apply false
-    id 'com.android.library' version '8.1.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.22' apply false
+    id 'com.android.application' version '8.4.0' apply false
+    id 'com.android.library' version '8.4.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23' apply false
 }

--- a/languages/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/languages/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jul 24 14:16:42 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/languages/kotlin/sdk/build.gradle
+++ b/languages/kotlin/sdk/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace 'com.bitwarden.sdk'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 28
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -84,11 +84,9 @@ publishing {
 }
 
 dependencies {
-    implementation 'net.java.dev.jna:jna:5.13.0@aar'
+    implementation 'net.java.dev.jna:jna:5.14.0@aar'
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.core:core-ktx:1.13.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     testImplementation 'junit:junit:4.13.2'

--- a/languages/swift/iOS/App/ContentView.swift
+++ b/languages/swift/iOS/App/ContentView.swift
@@ -39,6 +39,28 @@ struct ContentView: View {
             delegateQueue: nil)
         
         client = Client(settings: nil)
+        
+        Task {
+            class TestSyncImplementation: TestTraitSync {
+                func giveMeAName() -> String {
+                    "Swift!"
+                }
+            }
+            class TestAsyncImplementation: TestTraitAsync {
+                func giveMeAName() async -> String {
+                    "Swift async!"
+                }
+            }
+            do {
+                let result1 = try await Client(settings: nil).platform().passkeys().passkeyTestSync(t: TestSyncImplementation())
+                let result2 = try await Client(settings: nil).platform().passkeys().passkeyTestAsync(t: TestAsyncImplementation())
+                print("Result1 " + result1)
+                print("Result2 " + result2)
+            } catch {
+                print("ERROR:", error)
+            }
+        }
+            
     }
     
     @State var setupBiometrics: Bool = true


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Testing both sync and async callbacks with Uniffi, importantly this has a couple of restrictions:
- Uniffi needs to be updated to 0.27.x #756 
- The traits that we want to be implemented externally need to be defined in the bitwarden-uniffi crate, this is a limitation of uniffi for the moment. In the tests I've duplicated the trait definition and then created a bridge to add compatibility with the original trait definition.
