### PR TITLE
Use Display impl instead of ToString

### DIFF
--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bitwarden_crypto::{DecryptedString, Kdf, SensitiveString};
 use chrono::{DateTime, Utc};
 use thiserror::Error;
@@ -8,6 +10,7 @@ use crate::csv::export_csv;
 mod json;
 use json::export_json;
 mod encrypted_json;
+
 use encrypted_json::export_encrypted_json;
 
 pub enum Format {
@@ -63,13 +66,13 @@ pub enum CipherType {
     Identity(Box<Identity>),
 }
 
-impl ToString for CipherType {
-    fn to_string(&self) -> String {
+impl fmt::Display for CipherType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CipherType::Login(_) => "login".to_string(),
-            CipherType::SecureNote(_) => "note".to_string(),
-            CipherType::Card(_) => "card".to_string(),
-            CipherType::Identity(_) => "identity".to_string(),
+            CipherType::Login(_) => write!(f, "login"),
+            CipherType::SecureNote(_) => write!(f, "note"),
+            CipherType::Card(_) => write!(f, "card"),
+            CipherType::Identity(_) => write!(f, "identity"),
         }
     }
 }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Latest Rust 1.78 includes a [clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_trait_impl) when implementing ToString directly instead of using Display, which would also derive `ToString` for free. Note that there are a few uses of `impl ToString` in the `bitwarden-api-*` packages but I haven't changed those here. I've opened a PR in openapi-generator https://github.com/OpenAPITools/openapi-generator/pull/18633