### PR TITLE
[SM-1236] - Add new targets for Go wrapper

### DIFF
--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -19,18 +19,19 @@ jobs:
       matrix:
         settings:
           - os: macos-12
-            target:
-              - x86_64-apple-darwin
-              - aarch64-apple-darwin
+            target: x86_64-apple-darwin
+          - os: macos-12
+            target: arch64-apple-darwin
           - os: windows-2022
-            target:
-              - x86_64-pc-windows-msvc
-              - x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-msvc
+          - os: windows-2022
+            target: x86_64-pc-windows-gnu
           - os: ubuntu-22.04
-            target:
-              - x86_64-unknown-linux-gnu
-              - x86_64-unknown-linux-musl
-              - aarch64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -46,19 +46,28 @@ jobs:
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2.2.0
+        if: ${{ contains(matrix.settings.target, 'musl') }}
         with:
           version: 0.12.0
 
       - name: Install Zigbuild
+        if: ${{ contains(matrix.settings.target, 'musl') }}
         run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 6f7e1336c9cd13cf1b3704f93c40fcf84caaed6b # 0.18.4
 
       - name: Add build architecture
         run: rustup target add ${{ matrix.settings.target }}
 
-      - name: Build Rust
+      - name: Build Rust for - ${{ matrix.settings.target }}
+        if: ${{ contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
         run: cargo zigbuild -p bitwarden-c --target ${{ matrix.settings.target }} --release
+
+      - name: Build Rust for - ${{ matrix.settings.target }}
+        if: ${{ !contains(matrix.settings.target, 'musl') }}
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -19,13 +19,18 @@ jobs:
       matrix:
         settings:
           - os: macos-12
-            target: x86_64-apple-darwin
-          - os: macos-12
-            target: aarch64-apple-darwin
+            target:
+              - x86_64-apple-darwin
+              - aarch64-apple-darwin
           - os: windows-2022
-            target: x86_64-pc-windows-msvc
+            target:
+              - x86_64-pc-windows-msvc
+              - x86_64-pc-windows-gnu
           - os: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
+            target:
+              - x86_64-unknown-linux-gnu
+              - x86_64-unknown-linux-musl
+              - aarch64-unknown-linux-musl
 
     steps:
       - name: Checkout
@@ -39,13 +44,20 @@ jobs:
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
+      - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2.2.0
+        with:
+          version: 0.12.0
+
+      - name: Install Zigbuild
+        run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 6f7e1336c9cd13cf1b3704f93c40fcf84caaed6b # 0.18.4
+
       - name: Add build architecture
         run: rustup target add ${{ matrix.settings.target }}
 
       - name: Build Rust
         env:
           RUSTFLAGS: "-D warnings"
-        run: cargo build --target ${{ matrix.settings.target }} --release
+        run: cargo zigbuild --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Build Rust
         env:
           RUSTFLAGS: "-D warnings"
-        run: cargo zigbuild --target ${{ matrix.settings.target }} --release
+        run: cargo zigbuild -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
## Tracking

[SM-1236](https://bitwarden.atlassian.net/browse/SM-1236)

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add the following targets to the build workflow:
- x86_64-pc-windows-gnu
- x86_64-unknown-linux-musl
- aarch64-unknown-linux-musl

These are needed to produced statically-linked binaries with our Go language wrapper.

## Code changes

- Cross-compile the MUSL targets with Zig and add the Windows GNU target. 
- Adjusted the workflow to _just_ build the `bitwarden-c` crate. Previously, it was building every crate in the workspace.

## Before you submit

- Please add **unit tests** where it makes sense to do so


[SM-1236]: https://bitwarden.atlassian.net/browse/SM-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ