### PR TITLE
Rename mobile feature to uniffi for bindings

### DIFF
--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -16,7 +16,7 @@ keywords.workspace = true
 [features]
 default = []
 
-mobile = ["dep:uniffi"]  # Mobile-specific features
+uniffi = ["dep:uniffi"]  # Uniffi bindings
 no-memory-hardening = [] # Disable memory hardening features
 test = []                # Test methods
 

--- a/crates/bitwarden-crypto/src/keys/device_key.rs
+++ b/crates/bitwarden-crypto/src/keys/device_key.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct DeviceKey(SymmetricCryptoKey);
 
 #[derive(Debug)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct TrustDeviceResponse {
     /// Base64 encoded device key
     pub device_key: SensitiveString,

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -16,7 +16,7 @@ use crate::{
 /// Enum represents all the possible KDFs.
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum Kdf {
     PBKDF2 {
         iterations: NonZeroU32,
@@ -55,7 +55,7 @@ pub fn default_argon2_parallelism() -> NonZeroU32 {
 }
 
 #[derive(Copy, Clone, JsonSchema)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum HashPurpose {
     ServerAuthorization = 1,
     LocalAuthorization = 2,

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -87,8 +87,8 @@ pub use sensitive::*;
 mod allocator;
 pub use allocator::ZeroizingAllocator;
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 mod uniffi_support;

--- a/crates/bitwarden-crypto/src/rsa.rs
+++ b/crates/bitwarden-crypto/src/rsa.rs
@@ -13,7 +13,7 @@ use crate::{
 /// RSA Key Pair
 ///
 /// Consists of a public key and an encrypted private key.
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RsaKeyPair {
     /// Base64 encoded DER representation of the public key
     pub public: String,

--- a/crates/bitwarden-generators/Cargo.toml
+++ b/crates/bitwarden-generators/Cargo.toml
@@ -14,7 +14,7 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-mobile = ["dep:uniffi"] # Mobile-specific features
+uniffi = ["dep:uniffi"] # Uniffi bindings
 
 [dependencies]
 bitwarden-crypto = { workspace = true }

--- a/crates/bitwarden-generators/src/lib.rs
+++ b/crates/bitwarden-generators/src/lib.rs
@@ -7,5 +7,5 @@ mod username;
 pub use username::{username, ForwarderServiceType, UsernameError, UsernameGeneratorRequest};
 mod username_forwarders;
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();

--- a/crates/bitwarden-generators/src/passphrase.rs
+++ b/crates/bitwarden-generators/src/passphrase.rs
@@ -15,7 +15,7 @@ pub enum PassphraseError {
 /// Passphrase generator request options.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PassphraseGeneratorRequest {
     /// Number of words in the generated passphrase.
     /// This value must be between 3 and 20.

--- a/crates/bitwarden-generators/src/password.rs
+++ b/crates/bitwarden-generators/src/password.rs
@@ -16,7 +16,7 @@ pub enum PasswordError {
 /// Password generator request options.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PasswordGeneratorRequest {
     /// Include lowercase characters (a-z).
     pub lowercase: bool,

--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -23,7 +23,7 @@ pub enum UsernameError {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum AppendType {
     /// Generates a random string of 8 lowercase characters as part of your username
     Random,
@@ -33,7 +33,7 @@ pub enum AppendType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 /// Configures the email forwarding service to use.
 /// For instructions on how to configure each service, see the documentation:
 /// <https://bitwarden.com/help/generator/#username-types>
@@ -64,7 +64,7 @@ pub enum ForwarderServiceType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum UsernameGeneratorRequest {
     /// Generates a single word username
     Word {

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 [dependencies]
 async-lock = "3.3.0"
 async-trait = "0.1.80"
-bitwarden = { workspace = true, features = ["mobile", "internal"] }
+bitwarden = { workspace = true, features = ["internal", "uniffi"] }
 bitwarden-crypto = { workspace = true, features = ["uniffi"] }
 bitwarden-generators = { workspace = true, features = ["uniffi"] }
 chrono = { version = ">=0.4.26, <0.5", features = [

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -21,8 +21,8 @@ bench = false
 async-lock = "3.3.0"
 async-trait = "0.1.80"
 bitwarden = { workspace = true, features = ["mobile", "internal"] }
-bitwarden-crypto = { workspace = true, features = ["mobile"] }
-bitwarden-generators = { workspace = true, features = ["mobile"] }
+bitwarden-crypto = { workspace = true, features = ["uniffi"] }
+bitwarden-generators = { workspace = true, features = ["uniffi"] }
 chrono = { version = ">=0.4.26, <0.5", features = [
     "serde",
     "std",

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -23,12 +23,12 @@ internal = [
 no-memory-hardening = [
     "bitwarden-crypto/no-memory-hardening",
 ] # Disable memory hardening features
-mobile = [
-    "internal",
+uniffi = [
+    "bitwarden-crypto/uniffi",
+    "bitwarden-generators/uniffi",
     "dep:uniffi",
-    "bitwarden-crypto/mobile",
-    "bitwarden-generators/mobile",
-] # Mobile-specific features
+] # Uniffi bindings
+mobile = ["internal", "uniffi"] # Mobile-specific features
 secrets = [] # Secrets manager API
 wasm-bindgen = ["chrono/wasmbind"]
 

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -28,7 +28,6 @@ uniffi = [
     "bitwarden-generators/uniffi",
     "dep:uniffi",
 ] # Uniffi bindings
-mobile = ["internal", "uniffi"] # Mobile-specific features
 secrets = [] # Secrets manager API
 wasm-bindgen = ["chrono/wasmbind"]
 

--- a/crates/bitwarden/src/auth/api/request/mod.rs
+++ b/crates/bitwarden/src/auth/api/request/mod.rs
@@ -15,9 +15,9 @@ pub(crate) use password_token_request::*;
 #[cfg(feature = "internal")]
 pub(crate) use renew_token_request::*;
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 mod auth_request_token_request;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) use auth_request_token_request::*;
 
 use crate::{

--- a/crates/bitwarden/src/auth/auth_request.rs
+++ b/crates/bitwarden/src/auth/auth_request.rs
@@ -9,7 +9,7 @@ use bitwarden_generators::{password, PasswordGeneratorRequest};
 
 use crate::{error::Error, Client};
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthRequestResponse {
     /// Base64 encoded private key
     /// This key is temporarily passed back and will most likely not be available in the future

--- a/crates/bitwarden/src/auth/auth_request.rs
+++ b/crates/bitwarden/src/auth/auth_request.rs
@@ -3,7 +3,7 @@ use bitwarden_crypto::{
     fingerprint, AsymmetricCryptoKey, AsymmetricEncString, AsymmetricPublicCryptoKey,
     SensitiveString,
 };
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 use bitwarden_crypto::{EncString, KeyDecryptable, SymmetricCryptoKey};
 use bitwarden_generators::{password, PasswordGeneratorRequest};
 
@@ -53,7 +53,7 @@ pub(crate) fn new_auth_request(email: &str) -> Result<AuthRequestResponse, Error
 }
 
 /// Decrypt the user key using the private key generated previously.
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) fn auth_request_decrypt_user_key(
     private_key: SensitiveString,
     user_key: AsymmetricEncString,
@@ -67,7 +67,7 @@ pub(crate) fn auth_request_decrypt_user_key(
 }
 
 /// Decrypt the user key using the private key generated previously.
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) fn auth_request_decrypt_master_key(
     private_key: SensitiveString,
     master_key: AsymmetricEncString,

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{AsymmetricEncString, DeviceKey, SensitiveString, TrustDeviceResponse};
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 use crate::auth::login::NewAuthRequestResponse;
 #[cfg(feature = "secrets")]
 use crate::auth::login::{login_access_token, AccessTokenLoginRequest, AccessTokenLoginResponse};
@@ -141,7 +141,7 @@ impl<'a> ClientAuth<'a> {
     }
 }
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 impl<'a> ClientAuth<'a> {
     pub async fn login_device(
         &mut self,

--- a/crates/bitwarden/src/auth/login/mod.rs
+++ b/crates/bitwarden/src/auth/login/mod.rs
@@ -29,11 +29,11 @@ pub(crate) use api_key::login_api_key;
 #[cfg(feature = "internal")]
 pub use api_key::{ApiKeyLoginRequest, ApiKeyLoginResponse};
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 mod auth_request;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub use auth_request::NewAuthRequestResponse;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) use auth_request::{complete_auth_request, send_new_auth_request};
 
 #[cfg(feature = "secrets")]

--- a/crates/bitwarden/src/auth/mod.rs
+++ b/crates/bitwarden/src/auth/mod.rs
@@ -18,7 +18,7 @@ pub use register::{RegisterKeyResponse, RegisterRequest};
 mod auth_request;
 #[cfg(feature = "internal")]
 pub use auth_request::AuthRequestResponse;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) use auth_request::{auth_request_decrypt_master_key, auth_request_decrypt_user_key};
 #[cfg(feature = "internal")]
 mod tde;

--- a/crates/bitwarden/src/auth/password/policy.rs
+++ b/crates/bitwarden/src/auth/password/policy.rs
@@ -35,7 +35,7 @@ pub(crate) fn satisfies_policy(
 }
 
 #[derive(Debug, JsonSchema)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[allow(dead_code)]
 pub struct MasterPasswordPolicyOptions {
     min_complexity: u8,

--- a/crates/bitwarden/src/auth/register.rs
+++ b/crates/bitwarden/src/auth/register.rs
@@ -73,7 +73,7 @@ pub(super) fn make_register_keys(
     })
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RegisterKeyResponse {
     pub master_password_hash: SensitiveString,
     pub encrypted_user_key: String,

--- a/crates/bitwarden/src/auth/tde.rs
+++ b/crates/bitwarden/src/auth/tde.rs
@@ -49,7 +49,7 @@ pub(super) fn make_register_tde_keys(
     })
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RegisterTdeKeyResponse {
     pub private_key: EncString,
     pub public_key: String,

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -163,7 +163,7 @@ impl Client {
         self.flags = Flags::load_from_map(flags);
     }
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "internal")]
     pub(crate) fn get_flags(&self) -> &Flags {
         &self.flags
     }
@@ -175,7 +175,7 @@ impl Client {
         &self.__api_configurations
     }
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "internal")]
     pub(crate) fn get_http_client(&self) -> &reqwest::Client {
         &self.__api_configurations.external_client
     }
@@ -274,7 +274,7 @@ impl Client {
             )?))
     }
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "internal")]
     pub(crate) fn initialize_user_crypto_pin(
         &mut self,
         pin_key: MasterKey,

--- a/crates/bitwarden/src/client/client_settings.rs
+++ b/crates/bitwarden/src/client/client_settings.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ClientSettings {
     /// The identity url of the targeted Bitwarden instance. Defaults to `https://identity.bitwarden.com`
     pub identity_url: String,
@@ -43,7 +43,7 @@ impl Default for ClientSettings {
 
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, JsonSchema)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum DeviceType {
     Android = 0,
     iOS = 1,

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -72,7 +72,7 @@ pub enum Error {
     #[error("Webauthn error: {0:?}")]
     WebauthnError(passkey::client::WebauthnError),
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "uniffi")]
     #[error("Uniffi callback error: {0}")]
     UniffiCallback(#[from] uniffi::UnexpectedUniFFICallbackError),
 

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -55,13 +55,13 @@ pub mod admin_console;
 pub mod auth;
 pub mod client;
 pub mod error;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub mod mobile;
 #[cfg(feature = "internal")]
 pub mod platform;
 #[cfg(feature = "secrets")]
 pub mod secrets_manager;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub mod tool;
 #[cfg(feature = "uniffi")]
 pub(crate) mod uniffi_support;

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -47,7 +47,7 @@
 //! }
 //! ```
 
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
 #[cfg(feature = "internal")]
@@ -63,7 +63,7 @@ pub mod platform;
 pub mod secrets_manager;
 #[cfg(feature = "mobile")]
 pub mod tool;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 pub(crate) mod uniffi_support;
 mod util;
 #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/mobile/crypto.rs
+++ b/crates/bitwarden/src/mobile/crypto.rs
@@ -19,7 +19,7 @@ use crate::{
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct InitUserCryptoRequest {
     /// The user's KDF parameters, as received from the prelogin request
     pub kdf_params: Kdf,
@@ -34,7 +34,7 @@ pub struct InitUserCryptoRequest {
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum InitUserCryptoMethod {
     Password {
         /// The user's master password
@@ -72,7 +72,7 @@ pub enum InitUserCryptoMethod {
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum AuthRequestMethod {
     UserKey {
         /// User Key protected by the private key provided in `AuthRequestResponse`.
@@ -159,7 +159,7 @@ pub async fn initialize_user_crypto(client: &mut Client, req: InitUserCryptoRequ
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct InitOrgCryptoRequest {
     /// The encryption keys for all the organizations the user is a part of
     pub organization_keys: HashMap<uuid::Uuid, AsymmetricEncString>,
@@ -185,7 +185,7 @@ pub async fn get_user_encryption_key(client: &mut Client) -> Result<SensitiveStr
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct UpdatePasswordResponse {
     /// Hash of the new password
     password_hash: SensitiveString,
@@ -234,7 +234,7 @@ pub fn update_password(
 #[cfg(feature = "internal")]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct DerivePinKeyResponse {
     /// [UserKey](bitwarden_crypto::UserKey) protected by PIN
     pin_protected_user_key: EncString,

--- a/crates/bitwarden/src/platform/fido2/authenticator.rs
+++ b/crates/bitwarden/src/platform/fido2/authenticator.rs
@@ -253,32 +253,32 @@ impl passkey::authenticator::UserValidationMethod for UserInterfaceImpl<'_> {
 // What type do we need this to be? We probably can't use Serialize over the FFI boundary
 pub type Extensions = Option<std::collections::HashMap<String, String>>;
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialRpEntity {
     pub id: String,
     pub name: Option<String>,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialUserEntity {
     pub id: Vec<u8>,
     pub display_name: String,
     pub name: String,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialParameters {
     pub ty: String,
     pub alg: i64,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialDescriptor {
     pub ty: i64,
     pub id: Vec<u8>,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialRequest {
     client_data_hash: Vec<u8>,
     rp: PublicKeyCredentialRpEntity,
@@ -289,7 +289,7 @@ pub struct MakeCredentialRequest {
     extensions: Extensions,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialResult {
     // TODO
     // authenticator_data: Vec<u8>,
@@ -297,7 +297,7 @@ pub struct MakeCredentialResult {
     credential_id: Vec<u8>,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetAssertionRequest {
     rp_id: String,
     client_data_hash: Vec<u8>,
@@ -306,20 +306,20 @@ pub struct GetAssertionRequest {
     extensions: Extensions,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Options {
     rk: bool,
     uv: UV,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum UV {
     Discouraged,
     Preferred,
     Required,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetAssertionResult {
     credential_id: Vec<u8>,
     authenticator_data: Vec<u8>,

--- a/crates/bitwarden/src/platform/fido2/client.rs
+++ b/crates/bitwarden/src/platform/fido2/client.rs
@@ -240,7 +240,7 @@ impl<'a> Fido2Client<'a> {
     }
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ClientData {
     DefaultWithExtraData { android_package_name: String },
     DefaultWithCustomHash { hash: Vec<u8> },
@@ -274,7 +274,7 @@ impl passkey::client::ClientData<Option<AndroidClientData>> for ClientData {
     }
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
     id: String,
     raw_id: Vec<u8>,
@@ -285,7 +285,7 @@ pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
     selected_credential: SelectedCredential,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthenticatorAttestationResponse {
     client_data_json: Vec<u8>,
     authenticator_data: Vec<u8>,
@@ -295,7 +295,7 @@ pub struct AuthenticatorAttestationResponse {
     transports: Option<Vec<String>>,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
     id: String,
     raw_id: Vec<u8>,
@@ -306,7 +306,7 @@ pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
     selected_credential: SelectedCredential,
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthenticatorAssertionResponse {
     client_data_json: Vec<u8>,
     authenticator_data: Vec<u8>,

--- a/crates/bitwarden/src/platform/fido2/mod.rs
+++ b/crates/bitwarden/src/platform/fido2/mod.rs
@@ -52,7 +52,7 @@ impl<'a> ClientFido2<'a> {
 }
 
 #[allow(dead_code)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SelectedCredential {
     cipher: CipherView,
     credential: Fido2Credential,

--- a/crates/bitwarden/src/platform/fido2/traits.rs
+++ b/crates/bitwarden/src/platform/fido2/traits.rs
@@ -32,12 +32,12 @@ pub trait CredentialStore: Send + Sync {
     async fn save_credential(&self, cred: Cipher) -> Result<()>;
 }
 
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CheckUserOptions {
     RequirePresence(bool),
     RequireVerification(Verification),
 }
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum Verification {
     Discouraged,
     Preferred,

--- a/crates/bitwarden/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden/src/platform/generate_fingerprint.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct FingerprintRequest {
     /// The input material, used in the fingerprint generation process.
     pub fingerprint_material: String,

--- a/crates/bitwarden/src/tool/exporters/mod.rs
+++ b/crates/bitwarden/src/tool/exporters/mod.rs
@@ -16,7 +16,7 @@ mod client_exporter;
 pub use client_exporter::ClientExporters;
 
 #[derive(JsonSchema)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ExportFormat {
     Csv,
     Json,

--- a/crates/bitwarden/src/vault/cipher/attachment.rs
+++ b/crates/bitwarden/src/vault/cipher/attachment.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Attachment {
     pub id: Option<String>,
     pub url: Option<String>,
@@ -23,7 +23,7 @@ pub struct Attachment {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AttachmentView {
     pub id: Option<String>,
     pub url: Option<String>,
@@ -35,7 +35,7 @@ pub struct AttachmentView {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AttachmentEncryptResult {
     pub attachment: Attachment,
     pub contents: Vec<u8>,

--- a/crates/bitwarden/src/vault/cipher/card.rs
+++ b/crates/bitwarden/src/vault/cipher/card.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Card {
     pub cardholder_name: Option<EncString>,
     pub exp_month: Option<EncString>,
@@ -21,7 +21,7 @@ pub struct Card {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CardView {
     pub cardholder_name: Option<DecryptedString>,
     pub exp_month: Option<DecryptedString>,

--- a/crates/bitwarden/src/vault/cipher/cipher.rs
+++ b/crates/bitwarden/src/vault/cipher/cipher.rs
@@ -21,7 +21,7 @@ use crate::{
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CipherType {
     Login = 1,
     SecureNote = 2,
@@ -31,7 +31,7 @@ pub enum CipherType {
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CipherRepromptType {
     None = 0,
     Password = 1,
@@ -39,7 +39,7 @@ pub enum CipherRepromptType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Cipher {
     pub id: Option<Uuid>,
     pub organization_id: Option<Uuid>,
@@ -77,7 +77,7 @@ pub struct Cipher {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CipherView {
     pub id: Option<Uuid>,
     pub organization_id: Option<Uuid>,
@@ -113,7 +113,7 @@ pub struct CipherView {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CipherListView {
     pub id: Option<Uuid>,
     pub organization_id: Option<Uuid>,

--- a/crates/bitwarden/src/vault/cipher/field.rs
+++ b/crates/bitwarden/src/vault/cipher/field.rs
@@ -11,7 +11,7 @@ use crate::error::{require, Error, Result};
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum FieldType {
     Text = 0,
     Hidden = 1,
@@ -21,7 +21,7 @@ pub enum FieldType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Field {
     name: Option<EncString>,
     value: Option<EncString>,
@@ -32,7 +32,7 @@ pub struct Field {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct FieldView {
     pub(crate) name: Option<DecryptedString>,
     pub(crate) value: Option<DecryptedString>,

--- a/crates/bitwarden/src/vault/cipher/identity.rs
+++ b/crates/bitwarden/src/vault/cipher/identity.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Identity {
     pub title: Option<EncString>,
     pub first_name: Option<EncString>,
@@ -33,7 +33,7 @@ pub struct Identity {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct IdentityView {
     pub title: Option<DecryptedString>,
     pub first_name: Option<DecryptedString>,

--- a/crates/bitwarden/src/vault/cipher/linked_id.rs
+++ b/crates/bitwarden/src/vault/cipher/linked_id.rs
@@ -11,11 +11,11 @@ pub enum LinkedIdType {
 }
 
 use crate::error::{Error, Result};
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 use crate::UniffiCustomTypeConverter;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 uniffi::custom_type!(LinkedIdType, u32);
-#[cfg(feature = "mobile")]
+#[cfg(feature = "uniffi")]
 impl UniffiCustomTypeConverter for LinkedIdType {
     type Builtin = u32;
 
@@ -138,7 +138,7 @@ mod tests {
         assert_eq!(serialized, json);
     }
 
-    #[cfg(feature = "mobile")]
+    #[cfg(feature = "uniffi")]
     #[test]
     fn test_linked_id_serialization_uniffi() {
         use super::{CardLinkedIdType, LinkedIdType, LoginLinkedIdType};

--- a/crates/bitwarden/src/vault/cipher/local_data.rs
+++ b/crates/bitwarden/src/vault/cipher/local_data.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LocalData {
     last_used_date: Option<u32>,
     last_launched: Option<u32>,
@@ -12,7 +12,7 @@ pub struct LocalData {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LocalDataView {
     last_used_date: Option<u32>,
     last_launched: Option<u32>,

--- a/crates/bitwarden/src/vault/cipher/login.rs
+++ b/crates/bitwarden/src/vault/cipher/login.rs
@@ -16,7 +16,7 @@ use crate::error::{require, Error, Result};
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum UriMatchType {
     Domain = 0,
     Host = 1,
@@ -28,7 +28,7 @@ pub enum UriMatchType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LoginUri {
     pub uri: Option<EncString>,
     pub r#match: Option<UriMatchType>,
@@ -37,7 +37,7 @@ pub struct LoginUri {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LoginUriView {
     pub uri: Option<DecryptedString>,
     pub r#match: Option<UriMatchType>,
@@ -80,7 +80,7 @@ impl LoginUriView {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Fido2Credential {
     pub credential_id: EncString,
     pub key_type: EncString,
@@ -99,7 +99,7 @@ pub struct Fido2Credential {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Fido2CredentialView {
     pub credential_id: SensitiveString,
     pub key_type: SensitiveString,
@@ -118,7 +118,7 @@ pub struct Fido2CredentialView {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Login {
     pub username: Option<EncString>,
     pub password: Option<EncString>,
@@ -133,7 +133,7 @@ pub struct Login {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LoginView {
     pub username: Option<DecryptedString>,
     pub password: Option<DecryptedString>,

--- a/crates/bitwarden/src/vault/cipher/secure_note.rs
+++ b/crates/bitwarden/src/vault/cipher/secure_note.rs
@@ -8,21 +8,21 @@ use crate::error::{require, Error, Result};
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum SecureNoteType {
     Generic = 0,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SecureNote {
     r#type: SecureNoteType,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SecureNoteView {
     pub(crate) r#type: SecureNoteType,
 }

--- a/crates/bitwarden/src/vault/collection.rs
+++ b/crates/bitwarden/src/vault/collection.rs
@@ -11,7 +11,7 @@ use crate::error::{require, Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Collection {
     id: Option<Uuid>,
     organization_id: Uuid,
@@ -25,7 +25,7 @@ pub struct Collection {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CollectionView {
     id: Option<Uuid>,
     organization_id: Uuid,

--- a/crates/bitwarden/src/vault/folder.rs
+++ b/crates/bitwarden/src/vault/folder.rs
@@ -12,7 +12,7 @@ use crate::error::{require, Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Folder {
     id: Option<Uuid>,
     name: EncString,
@@ -21,7 +21,7 @@ pub struct Folder {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct FolderView {
     pub id: Option<Uuid>,
     pub name: DecryptedString,

--- a/crates/bitwarden/src/vault/mod.rs
+++ b/crates/bitwarden/src/vault/mod.rs
@@ -3,7 +3,7 @@ mod collection;
 mod folder;
 mod password_history;
 mod send;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 mod totp;
 
 pub use cipher::*;
@@ -11,7 +11,7 @@ pub use collection::{Collection, CollectionView};
 pub use folder::{Folder, FolderView};
 pub use password_history::{PasswordHistory, PasswordHistoryView};
 pub use send::{Send, SendListView, SendView};
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub(crate) use totp::generate_totp;
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 pub use totp::TotpResponse;

--- a/crates/bitwarden/src/vault/password_history.rs
+++ b/crates/bitwarden/src/vault/password_history.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, Result};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PasswordHistory {
     password: EncString,
     last_used_date: DateTime<Utc>,
@@ -19,7 +19,7 @@ pub struct PasswordHistory {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PasswordHistoryView {
     password: DecryptedString,
     last_used_date: DateTime<Utc>,

--- a/crates/bitwarden/src/vault/send.rs
+++ b/crates/bitwarden/src/vault/send.rs
@@ -17,7 +17,7 @@ const SEND_ITERATIONS: u32 = 100_000;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendFile {
     pub id: Option<String>,
     pub file_name: EncString,
@@ -28,7 +28,7 @@ pub struct SendFile {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendFileView {
     pub id: Option<String>,
     pub file_name: DecryptedString,
@@ -39,7 +39,7 @@ pub struct SendFileView {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendText {
     pub text: Option<EncString>,
     pub hidden: bool,
@@ -47,7 +47,7 @@ pub struct SendText {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendTextView {
     pub text: Option<DecryptedString>,
     pub hidden: bool,
@@ -55,7 +55,7 @@ pub struct SendTextView {
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema, PartialEq)]
 #[repr(u8)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Enum))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum SendType {
     Text = 0,
     File = 1,
@@ -63,7 +63,7 @@ pub enum SendType {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Send {
     pub id: Option<Uuid>,
     pub access_id: Option<String>,
@@ -89,7 +89,7 @@ pub struct Send {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendView {
     pub id: Option<Uuid>,
     pub access_id: Option<String>,
@@ -122,7 +122,7 @@ pub struct SendView {
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendListView {
     pub id: Option<Uuid>,
     pub access_id: Option<String>,

--- a/crates/bitwarden/src/vault/totp.rs
+++ b/crates/bitwarden/src/vault/totp.rs
@@ -21,7 +21,7 @@ const DEFAULT_PERIOD: u32 = 30;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct TotpResponse {
     /// Generated TOTP code
     pub code: String,

--- a/crates/bitwarden/tests/register.rs
+++ b/crates/bitwarden/tests/register.rs
@@ -1,5 +1,5 @@
 /// Integration test for registering a new user and unlocking the vault
-#[cfg(feature = "mobile")]
+#[cfg(feature = "internal")]
 #[tokio::test]
 async fn test_register_initialize_crypto() {
     use std::num::NonZeroU32;

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-bitwarden = { workspace = true, features = ["internal", "mobile"] }
+bitwarden = { workspace = true, features = ["internal"] }
 bitwarden-cli = { workspace = true }
 bitwarden-crypto = { workspace = true }
 clap = { version = "4.5.4", features = ["derive", "env"] }


### PR DESCRIPTION
## Objective

Create a new feature `uniffi` for the uniffi bindings, and replace the remaining `mobile` feature usages with `internal` which is our primary flag for the internal features.
