### PR TITLE
Export ClientSettings and DeviceType in the root namespace

### DIFF
--- a/crates/bitwarden/CHANGELOG.md
+++ b/crates/bitwarden/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Support for secrets sync (#678)
 
+### Changed
+
+- `ClientSettings` and `DeviceType` is now exported in the root module (#805)
+
 ## [0.5.0] - 2024-04-26
 
 ### Changed

--- a/crates/bitwarden/src/client/mod.rs
+++ b/crates/bitwarden/src/client/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod encryption_settings;
 mod flags;
 
 pub use client::Client;
+pub use client_settings::{ClientSettings, DeviceType};

--- a/crates/bitwarden/src/lib.rs
+++ b/crates/bitwarden/src/lib.rs
@@ -16,11 +16,8 @@
 //!
 //! ```rust
 //! use bitwarden::{
-//!     auth::login::AccessTokenLoginRequest,
-//!     client::client_settings::{ClientSettings, DeviceType},
-//!     error::Result,
-//!     secrets_manager::secrets::SecretIdentifiersRequest,
-//!     Client,
+//!     auth::login::AccessTokenLoginRequest, error::Result,
+//!     secrets_manager::secrets::SecretIdentifiersRequest, Client, ClientSettings, DeviceType,
 //! };
 //! use uuid::Uuid;
 //!
@@ -38,14 +35,26 @@
 //!     let mut client = Client::new(Some(settings));
 //!
 //!     // Before we operate, we need to authenticate with a token
-//!     let token = AccessTokenLoginRequest { access_token: String::from(""), state_file: None };
+//!     let token = AccessTokenLoginRequest {
+//!         access_token: String::from(""),
+//!         state_file: None,
+//!     };
 //!     client.auth().login_access_token(&token).await.unwrap();
 //!
-//!     let org_id = SecretIdentifiersRequest { organization_id: Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap() };
-//!     println!("Stored secrets: {:#?}", client.secrets().list(&org_id).await.unwrap());
+//!     let org_id = SecretIdentifiersRequest {
+//!         organization_id: Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap(),
+//!     };
+//!     println!(
+//!         "Stored secrets: {:#?}",
+//!         client.secrets().list(&org_id).await.unwrap()
+//!     );
 //!     Ok(())
 //! }
 //! ```
+
+// Ensure the readme docs compile
+#[doc = include_str!("../README.md")]
+mod readme {}
 
 #[cfg(feature = "mobile")]
 uniffi::setup_scaffolding!();
@@ -69,11 +78,7 @@ mod util;
 #[cfg(feature = "internal")]
 pub mod vault;
 
-pub use client::Client;
-
-// Ensure the readme docs compile
-#[doc = include_str!("../README.md")]
-mod readme {}
+pub use client::{Client, ClientSettings, DeviceType};
 
 #[cfg(feature = "internal")]
 pub mod generators {


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

It's a bit cumbersome to import `ClientSettings` and `DeviceType` from `client::client_settings` namespace. We can expose it in the root directly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
