### PR TITLE
Remove deprecated access_token_login

### DIFF
--- a/crates/bitwarden/CHANGELOG.md
+++ b/crates/bitwarden/CHANGELOG.md
@@ -15,6 +15,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `ClientSettings` and `DeviceType` is now exported in the root module (#805)
 
+### Removed
+
+- The deprecated `client.access_token_login()` is now removed. Please use
+  `client.auth().login_access_token()` instead. (#806)
+
 ## [0.5.0] - 2024-04-26
 
 ### Changed

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -9,8 +9,6 @@ use chrono::Utc;
 use reqwest::header::{self, HeaderValue};
 use uuid::Uuid;
 
-#[cfg(feature = "secrets")]
-use crate::auth::login::{AccessTokenLoginRequest, AccessTokenLoginResponse};
 use crate::{
     auth::AccessToken,
     client::{
@@ -178,15 +176,6 @@ impl Client {
     #[cfg(feature = "mobile")]
     pub(crate) fn get_http_client(&self) -> &reqwest::Client {
         &self.__api_configurations.external_client
-    }
-
-    #[cfg(feature = "secrets")]
-    #[deprecated(note = "Use auth().login_access_token() instead")]
-    pub async fn access_token_login(
-        &mut self,
-        input: &AccessTokenLoginRequest,
-    ) -> Result<AccessTokenLoginResponse> {
-        self.auth().login_access_token(input).await
     }
 
     #[cfg(feature = "internal")]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Remove deprecated `access_token_login`. We want to do this before releasing a stable SDK for secrets manager.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
