### PR TITLE
Move sends to tools

### DIFF
--- a/crates/bitwarden-uniffi/src/docs.rs
+++ b/crates/bitwarden-uniffi/src/docs.rs
@@ -3,11 +3,8 @@ use bitwarden::{
     generators::{PassphraseGeneratorRequest, PasswordGeneratorRequest},
     mobile::crypto::{InitOrgCryptoRequest, InitUserCryptoRequest},
     platform::FingerprintRequest,
-    tool::ExportFormat,
-    vault::{
-        Cipher, CipherView, Collection, Folder, FolderView, Send, SendListView, SendView,
-        TotpResponse,
-    },
+    tool::{ExportFormat, Send, SendListView, SendView},
+    vault::{Cipher, CipherView, Collection, Folder, FolderView, TotpResponse},
 };
 use bitwarden_crypto::{HashPurpose, Kdf};
 use schemars::JsonSchema;

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -20,7 +20,7 @@ pub mod docs;
 use crypto::ClientCrypto;
 use error::Result;
 use platform::ClientPlatform;
-use tool::{ClientExporters, ClientGenerators};
+use tool::{ClientExporters, ClientGenerators, ClientSends};
 use vault::ClientVault;
 
 #[derive(uniffi::Object)]
@@ -57,6 +57,11 @@ impl Client {
     /// Exporters
     pub fn exporters(self: Arc<Self>) -> Arc<ClientExporters> {
         Arc::new(ClientExporters(self))
+    }
+
+    /// Sends operations
+    pub fn sends(self: Arc<Self>) -> Arc<ClientSends> {
+        Arc::new(ClientSends(self))
     }
 
     /// Auth operations

--- a/crates/bitwarden-uniffi/src/tool/mod.rs
+++ b/crates/bitwarden-uniffi/src/tool/mod.rs
@@ -8,6 +8,9 @@ use bitwarden::{
 
 use crate::{error::Result, Client};
 
+mod sends;
+pub use sends::ClientSends;
+
 #[derive(uniffi::Object)]
 pub struct ClientGenerators(pub(crate) Arc<Client>);
 

--- a/crates/bitwarden-uniffi/src/tool/sends.rs
+++ b/crates/bitwarden-uniffi/src/tool/sends.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::Arc};
 
-use bitwarden::vault::{Send, SendListView, SendView};
+use bitwarden::tool::{Send, SendListView, SendView};
 
 use crate::{Client, Result};
 
@@ -11,15 +11,7 @@ pub struct ClientSends(pub Arc<Client>);
 impl ClientSends {
     /// Encrypt send
     pub async fn encrypt(&self, send: SendView) -> Result<Send> {
-        Ok(self
-            .0
-             .0
-            .write()
-            .await
-            .vault()
-            .sends()
-            .encrypt(send)
-            .await?)
+        Ok(self.0 .0.write().await.sends().encrypt(send).await?)
     }
 
     /// Encrypt a send file in memory
@@ -29,7 +21,6 @@ impl ClientSends {
              .0
             .write()
             .await
-            .vault()
             .sends()
             .encrypt_buffer(send, &buffer)
             .await?)
@@ -47,7 +38,6 @@ impl ClientSends {
              .0
             .write()
             .await
-            .vault()
             .sends()
             .encrypt_file(
                 send,
@@ -59,28 +49,12 @@ impl ClientSends {
 
     /// Decrypt send
     pub async fn decrypt(&self, send: Send) -> Result<SendView> {
-        Ok(self
-            .0
-             .0
-            .write()
-            .await
-            .vault()
-            .sends()
-            .decrypt(send)
-            .await?)
+        Ok(self.0 .0.write().await.sends().decrypt(send).await?)
     }
 
     /// Decrypt send list
     pub async fn decrypt_list(&self, sends: Vec<Send>) -> Result<Vec<SendListView>> {
-        Ok(self
-            .0
-             .0
-            .write()
-            .await
-            .vault()
-            .sends()
-            .decrypt_list(sends)
-            .await?)
+        Ok(self.0 .0.write().await.sends().decrypt_list(sends).await?)
     }
 
     /// Decrypt a send file in memory
@@ -90,7 +64,6 @@ impl ClientSends {
              .0
             .write()
             .await
-            .vault()
             .sends()
             .decrypt_buffer(send, &buffer)
             .await?)
@@ -108,7 +81,6 @@ impl ClientSends {
              .0
             .write()
             .await
-            .vault()
             .sends()
             .decrypt_file(
                 send,

--- a/crates/bitwarden-uniffi/src/vault/mod.rs
+++ b/crates/bitwarden-uniffi/src/vault/mod.rs
@@ -10,7 +10,6 @@ pub mod ciphers;
 pub mod collections;
 pub mod folders;
 pub mod password_history;
-pub mod sends;
 
 #[derive(uniffi::Object)]
 pub struct ClientVault(pub(crate) Arc<Client>);
@@ -35,11 +34,6 @@ impl ClientVault {
     /// Password history operations
     pub fn password_history(self: Arc<Self>) -> Arc<password_history::ClientPasswordHistory> {
         Arc::new(password_history::ClientPasswordHistory(self.0.clone()))
-    }
-
-    /// Sends operations
-    pub fn sends(self: Arc<Self>) -> Arc<sends::ClientSends> {
-        Arc::new(sends::ClientSends(self.0.clone()))
     }
 
     /// Attachment file operations

--- a/crates/bitwarden/src/mobile/mod.rs
+++ b/crates/bitwarden/src/mobile/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "internal")]
 pub mod crypto;
 pub mod kdf;
+pub mod tool;
 pub mod vault;
 
 mod client_crypto;

--- a/crates/bitwarden/src/mobile/tool/client_sends.rs
+++ b/crates/bitwarden/src/mobile/tool/client_sends.rs
@@ -4,7 +4,7 @@ use bitwarden_crypto::{DecryptedVec, EncString, KeyDecryptable, KeyEncryptable};
 
 use crate::{
     error::{Error, Result},
-    vault::{ClientVault, Send, SendListView, SendView},
+    tool::{Send, SendListView, SendView},
     Client,
 };
 
@@ -87,10 +87,8 @@ impl<'a> ClientSends<'a> {
     }
 }
 
-impl<'a> ClientVault<'a> {
-    pub fn sends(&'a self) -> ClientSends<'a> {
-        ClientSends {
-            client: self.client,
-        }
+impl<'a> Client {
+    pub fn sends(&'a mut self) -> ClientSends<'a> {
+        ClientSends { client: self }
     }
 }

--- a/crates/bitwarden/src/mobile/tool/mod.rs
+++ b/crates/bitwarden/src/mobile/tool/mod.rs
@@ -1,0 +1,2 @@
+mod client_sends;
+pub use client_sends::ClientSends;

--- a/crates/bitwarden/src/mobile/vault/mod.rs
+++ b/crates/bitwarden/src/mobile/vault/mod.rs
@@ -3,7 +3,6 @@ mod client_ciphers;
 mod client_collection;
 mod client_folders;
 mod client_password_history;
-mod client_sends;
 mod client_totp;
 
 pub use client_attachments::ClientAttachments;
@@ -11,4 +10,3 @@ pub use client_ciphers::ClientCiphers;
 pub use client_collection::ClientCollections;
 pub use client_folders::ClientFolders;
 pub use client_password_history::ClientPasswordHistory;
-pub use client_sends::ClientSends;

--- a/crates/bitwarden/src/tool/mod.rs
+++ b/crates/bitwarden/src/tool/mod.rs
@@ -2,3 +2,6 @@ mod exporters;
 pub use exporters::{ClientExporters, ExportFormat};
 mod client_generator;
 pub use client_generator::ClientGenerator;
+
+mod send;
+pub use send::{Send, SendListView, SendView};

--- a/crates/bitwarden/src/tool/send.rs
+++ b/crates/bitwarden/src/tool/send.rs
@@ -367,7 +367,7 @@ mod tests {
     use super::{Send, SendText, SendTextView, SendType};
     use crate::{
         client::{encryption_settings::EncryptionSettings, Kdf},
-        vault::SendView,
+        tool::SendView,
     };
 
     #[test]

--- a/crates/bitwarden/src/vault/mod.rs
+++ b/crates/bitwarden/src/vault/mod.rs
@@ -15,9 +15,6 @@ pub use folder::{Folder, FolderView};
 mod password_history;
 pub use password_history::{PasswordHistory, PasswordHistoryView};
 
-mod send;
-pub use send::{Send, SendListView, SendView};
-
 #[cfg(feature = "internal")]
 mod sync;
 #[cfg(feature = "internal")]

--- a/crates/bitwarden/src/vault/sync.rs
+++ b/crates/bitwarden/src/vault/sync.rs
@@ -75,7 +75,7 @@ pub struct SyncResponse {
     pub ciphers: Vec<Cipher>,
     pub domains: Option<DomainResponse>,
     pub policies: Vec<Policy>,
-    pub sends: Vec<crate::vault::Send>,
+    pub sends: Vec<crate::tool::Send>,
 }
 
 impl SyncResponse {


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The Sends feature is currently owned by the tools team, however in the SDK it's under Vault. Refactoring the code and extracting Sends as a top level client, and moving the code to the appropriate folder.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
