### PR TITLE
Fix memory testing permissions

### DIFF
--- a/crates/memory-testing/Dockerfile
+++ b/crates/memory-testing/Dockerfile
@@ -46,4 +46,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends gdb=13.1-3 && a
 COPY --from=build /app/target/release/memory-testing /app/target/release/capture-dumps ./
 COPY crates/memory-testing/cases.json .
 
-CMD [ "/capture-dumps", "./memory-testing", "/output" ]
+CMD [ "/capture-dumps", "./memory-testing", "/" ]

--- a/crates/memory-testing/run_test.sh
+++ b/crates/memory-testing/run_test.sh
@@ -16,7 +16,7 @@ if [ "$1" = "no-docker" ]; then
     sudo ./target/release/capture-dumps ./target/release/memory-testing $BASE_DIR
 else
     docker build -f crates/memory-testing/Dockerfile -t bitwarden/memory-testing .
-    docker run --rm -it -v $BASE_DIR:/output bitwarden/memory-testing 
+    docker run --rm -it --privileged --cap-add=SYS_PTRACE -v $BASE_DIR/output:/output bitwarden/memory-testing 
 fi
 
 ./target/release/analyze-dumps $BASE_DIR

--- a/crates/memory-testing/src/bin/capture-dumps.rs
+++ b/crates/memory-testing/src/bin/capture-dumps.rs
@@ -6,9 +6,16 @@ use std::{
 };
 
 fn dump_process_to_bytearray(pid: u32, output_dir: &Path, output_name: &Path) -> io::Result<u64> {
-    Command::new("gcore")
+    let output = Command::new("gcore")
         .args(["-a", &pid.to_string()])
         .output()?;
+
+    if !output.status.success() {
+        return io::Result::Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Failed to dump process: {:?}", output),
+        ));
+    }
 
     let core_path = format!("core.{}", pid);
     let output_path = output_dir.join(output_name);


### PR DESCRIPTION
## 📔 Objective

Today my memory testing started to fail, looking into it I discovered that the `gcore` program was failing with an operation not permitted error:
```
Error: Custom { kind: Other, error: "Failed to dump process: Output { status: ExitStatus(unix_wait_status(256)), stdout: \"gcore: failed to create core.7\\n\", stderr: \"ptrace: Operation not permitted.\\nYou can't do that without a process to debug.\\nThe program is not being run.\\n\" }" }
```

I'm not fully sure if this is caused by a docker engine update or from one of the base images, but  setting `--privileged --cap-add=SYS_PTRACE` in the docker command seems to fix it. I've added some checks in case the command fails again in the future so it's easier to find the cause.

Also I realized we were mounting the whole `memory-testing` directory instead of the `output` folder, so I've changed that as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
