### PR TITLE
Pin security-framework to fix iOS build issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "reqwest",
  "rustls-platform-verifier",
  "schemars",
+ "security-framework",
  "serde",
  "serde_json",
  "serde_qs",
@@ -3353,11 +3354,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",

--- a/crates/bitwarden/Cargo.toml
+++ b/crates/bitwarden/Cargo.toml
@@ -84,6 +84,11 @@ reqwest = { version = ">=0.12, <0.13", features = [
     "rustls-tls-webpki-roots",
 ], default-features = false }
 
+# This is a workaround to fix a bug with version 2.11.0 that added some symbols that are not available on iOS
+# The bug is fixed already but the fix is not released yet. https://github.com/kornelski/rust-security-framework/pull/204
+[target.'cfg(target_os = "ios")'.dependencies]
+security-framework = { version = "=2.10" }
+
 [dev-dependencies]
 bitwarden-crypto = { workspace = true, features = ["test"] }
 rand_chacha = "0.3.1"


### PR DESCRIPTION
## 📔 Objective

I'm having compile errors running the iOS build, caused by the latest version of the `security-framework` crate including some MacOS symbols into the iOS binary.

The bug is [fixed upstream](https://github.com/kornelski/rust-security-framework/pull/204) but there haven't been any releases since then, so for now the best course of action is to pin the crate to the previous working version.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
