### PR TITLE
Use Fido2Credential instead of view in CipherView

### DIFF
--- a/crates/bitwarden/src/platform/fido2/authenticator.rs
+++ b/crates/bitwarden/src/platform/fido2/authenticator.rs
@@ -15,7 +15,7 @@ use super::{
     Fido2UserInterface, SelectedCredential, AAGUID,
 };
 use crate::{
-    error::{require, Error, Result},
+    error::{Error, Result},
     platform::fido2::string_to_guid_bytes,
     vault::{
         login::Fido2CredentialView, CipherView, Fido2CredentialFullView, Fido2CredentialNewView,
@@ -163,10 +163,12 @@ impl<'a> Fido2Authenticator<'a> {
         &mut self,
         rp_id: String,
     ) -> Result<Vec<Fido2CredentialView>> {
+        let enc = self.client.get_encryption_settings()?;
         let result = self.credential_store.find_credentials(None, rp_id).await?;
+
         Ok(result
             .into_iter()
-            .filter_map(|c| c.login?.fido2_credentials)
+            .flat_map(|c| c.decrypt_fido2_credentials(enc))
             .flatten()
             .collect())
     }
@@ -198,6 +200,8 @@ impl<'a> Fido2Authenticator<'a> {
     }
 
     pub(super) fn get_selected_credential(&self) -> Result<SelectedCredential> {
+        let enc = self.client.get_encryption_settings()?;
+
         let cipher = self
             .selected_credential
             .lock()
@@ -205,8 +209,7 @@ impl<'a> Fido2Authenticator<'a> {
             .clone()
             .ok_or("No selected credential available")?;
 
-        let login = require!(cipher.login.as_ref());
-        let creds = require!(login.fido2_credentials.as_ref());
+        let creds = cipher.decrypt_fido2_credentials(enc)?;
 
         let credential = creds.first().ok_or("No Fido2 credentials found")?.clone();
 

--- a/crates/bitwarden/src/vault/cipher/cipher.rs
+++ b/crates/bitwarden/src/vault/cipher/cipher.rs
@@ -14,13 +14,12 @@ use super::{
     local_data::{LocalData, LocalDataView},
     login, secure_note,
 };
+#[cfg(feature = "uniffi")]
+use crate::{client::encryption_settings::EncryptionSettings, vault::Fido2CredentialView};
 use crate::{
     error::{require, Error, Result},
     vault::{password_history, Fido2CredentialFullView},
 };
-
-#[cfg(feature = "uniffi")]
-use crate::{client::encryption_settings::EncryptionSettings, vault::Fido2CredentialView};
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]

--- a/crates/bitwarden/src/vault/cipher/cipher.rs
+++ b/crates/bitwarden/src/vault/cipher/cipher.rs
@@ -14,13 +14,13 @@ use super::{
     local_data::{LocalData, LocalDataView},
     login, secure_note,
 };
-#[cfg(feature = "uniffi")]
-use crate::vault::Fido2CredentialFullView;
 use crate::{
-    client::encryption_settings::EncryptionSettings,
     error::{require, Error, Result},
-    vault::{password_history, Fido2CredentialView},
+    vault::{password_history, Fido2CredentialFullView},
 };
+
+#[cfg(feature = "uniffi")]
+use crate::{client::encryption_settings::EncryptionSettings, vault::Fido2CredentialView};
 
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
 #[repr(u8)]
@@ -385,6 +385,7 @@ impl CipherView {
         Ok(())
     }
 
+    #[cfg(feature = "uniffi")]
     pub(crate) fn decrypt_fido2_credentials(
         &self,
         enc: &EncryptionSettings,

--- a/crates/bitwarden/src/vault/cipher/cipher.rs
+++ b/crates/bitwarden/src/vault/cipher/cipher.rs
@@ -349,6 +349,7 @@ impl CipherView {
         let new_key = SymmetricCryptoKey::generate(rand::thread_rng());
 
         self.reencrypt_attachment_keys(old_key, &new_key)?;
+        self.reencrypt_fido2_credentials(old_key, &new_key)?;
 
         self.key = Some(new_key.to_vec().encrypt_with_key(key)?);
         Ok(())

--- a/crates/bitwarden/src/vault/cipher/login.rs
+++ b/crates/bitwarden/src/vault/cipher/login.rs
@@ -312,7 +312,7 @@ impl KeyDecryptable<SymmetricCryptoKey, LoginView> for Login {
             uris: self.uris.decrypt_with_key(key).ok().flatten(),
             totp: self.totp.decrypt_with_key(key).ok().flatten(),
             autofill_on_page_load: self.autofill_on_page_load,
-            fido2_credentials: self.fido2_credentials,
+            fido2_credentials: self.fido2_credentials.clone(),
         })
     }
 }

--- a/crates/bitwarden/src/vault/cipher/login.rs
+++ b/crates/bitwarden/src/vault/cipher/login.rs
@@ -169,24 +169,24 @@ impl From<Fido2CredentialFullView> for Fido2CredentialNewView {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Fido2CredentialView> for Fido2CredentialFullView {
-    fn encrypt_with_key(
-        self,
-        key: &SymmetricCryptoKey,
-    ) -> Result<Fido2CredentialView, CryptoError> {
-        Ok(Fido2CredentialView {
-            credential_id: self.credential_id,
-            key_type: self.key_type,
-            key_algorithm: self.key_algorithm,
-            key_curve: self.key_curve,
+impl KeyEncryptable<SymmetricCryptoKey, Fido2Credential> for Fido2CredentialFullView {
+    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Fido2Credential, CryptoError> {
+        Ok(Fido2Credential {
+            credential_id: self.credential_id.encrypt_with_key(key)?,
+            key_type: self.key_type.encrypt_with_key(key)?,
+            key_algorithm: self.key_algorithm.encrypt_with_key(key)?,
+            key_curve: self.key_curve.encrypt_with_key(key)?,
             key_value: self.key_value.encrypt_with_key(key)?,
-            rp_id: self.rp_id,
-            user_handle: self.user_handle,
-            user_name: self.user_name,
-            counter: self.counter,
-            rp_name: self.rp_name,
-            user_display_name: self.user_display_name,
-            discoverable: self.discoverable,
+            rp_id: self.rp_id.encrypt_with_key(key)?,
+            user_handle: self
+                .user_handle
+                .map(|h| h.encrypt_with_key(key))
+                .transpose()?,
+            user_name: self.user_name.encrypt_with_key(key)?,
+            counter: self.counter.encrypt_with_key(key)?,
+            rp_name: self.rp_name.encrypt_with_key(key)?,
+            user_display_name: self.user_display_name.encrypt_with_key(key)?,
+            discoverable: self.discoverable.encrypt_with_key(key)?,
             creation_date: self.creation_date,
         })
     }
@@ -266,7 +266,7 @@ pub struct LoginView {
     pub autofill_on_page_load: Option<bool>,
 
     // TODO: Remove this once the SDK supports state
-    pub fido2_credentials: Option<Vec<Fido2CredentialView>>,
+    pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
 impl KeyEncryptable<SymmetricCryptoKey, LoginUri> for LoginUriView {
@@ -288,7 +288,7 @@ impl KeyEncryptable<SymmetricCryptoKey, Login> for LoginView {
             uris: self.uris.encrypt_with_key(key)?,
             totp: self.totp.encrypt_with_key(key)?,
             autofill_on_page_load: self.autofill_on_page_load,
-            fido2_credentials: self.fido2_credentials.encrypt_with_key(key)?,
+            fido2_credentials: self.fido2_credentials,
         })
     }
 }
@@ -312,7 +312,7 @@ impl KeyDecryptable<SymmetricCryptoKey, LoginView> for Login {
             uris: self.uris.decrypt_with_key(key).ok().flatten(),
             totp: self.totp.decrypt_with_key(key).ok().flatten(),
             autofill_on_page_load: self.autofill_on_page_load,
-            fido2_credentials: self.fido2_credentials.decrypt_with_key(key).ok().flatten(),
+            fido2_credentials: self.fido2_credentials,
         })
     }
 }

--- a/crates/bitwarden/src/vault/cipher/mod.rs
+++ b/crates/bitwarden/src/vault/cipher/mod.rs
@@ -14,7 +14,7 @@ pub use attachment::{
 };
 pub use cipher::{Cipher, CipherListView, CipherRepromptType, CipherType, CipherView};
 pub use field::FieldView;
-#[cfg(feature = "uniffi")]
+
 pub(crate) use login::Fido2CredentialFullView;
 pub use login::{Fido2Credential, Fido2CredentialNewView, Fido2CredentialView};
 pub use secure_note::SecureNoteType;

--- a/crates/bitwarden/src/vault/cipher/mod.rs
+++ b/crates/bitwarden/src/vault/cipher/mod.rs
@@ -14,7 +14,6 @@ pub use attachment::{
 };
 pub use cipher::{Cipher, CipherListView, CipherRepromptType, CipherType, CipherView};
 pub use field::FieldView;
-
 pub(crate) use login::Fido2CredentialFullView;
 pub use login::{Fido2Credential, Fido2CredentialNewView, Fido2CredentialView};
 pub use secure_note::SecureNoteType;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We don't need to expose the `Fido2CredentialView` for ciphers since the data isn't used by the UI. Instead we can expose the encrypted view and ensure it is re-encrypted on move.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
