### PR TITLE
Clear stack after argon2

### DIFF
--- a/crates/bitwarden-crypto/src/keys/utils.rs
+++ b/crates/bitwarden-crypto/src/keys/utils.rs
@@ -32,6 +32,15 @@ pub(super) fn derive_kdf_key(secret: &[u8], salt: &[u8], kdf: &Kdf) -> Result<Sy
 
             let mut hash = [0u8; 32];
             argon.hash_password_into(secret, &salt_sha, &mut hash)?;
+
+            // Argon2 is using some stack memory that is not zeroed. Eventually some function will
+            // overwrite the stack, but we use this trick to force the used stack to be zeroed.
+            #[inline(never)]
+            fn clear_stack() {
+                std::hint::black_box([0u8; 4096]);
+            }
+            clear_stack();
+
             hash
         }
     };

--- a/crates/memory-testing/cases.json
+++ b/crates/memory-testing/cases.json
@@ -80,8 +80,7 @@
       "memory_lookups": [
         {
           "name": "Key",
-          "hex": "3bc0520a0abff0097d521ce0ee5e5b1cee301939a84742623c0c1697d7a4bd46",
-          "allowed_count": 3
+          "hex": "3bc0520a0abff0097d521ce0ee5e5b1cee301939a84742623c0c1697d7a4bd46"
         },
         {
           "name": "Hash B64",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The argon2 library doesn't seem to clear the stack after doing a hash, but we can overwrite the stack by calling a function that creates a big stack allocated array right after the hash operation.

I've tried changing the parameters to the argon2 function and tweaking the array size to see where the limit should be, and in most of my tests clearing around 3700 bytes is enough. I've decided to round it up to the page size to be safe.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
