### PR TITLE
Use non-root in bws scratch Docker image

### DIFF
--- a/crates/bws/Dockerfile
+++ b/crates/bws/Dockerfile
@@ -24,8 +24,8 @@ RUN mkdir /lib64-bws
 RUN ldd /app/target/release/bws | tr -s '[:blank:]' '\n' | grep '^/lib' | xargs -I % cp % /lib-bws
 RUN ldd /app/target/release/bws | tr -s '[:blank:]' '\n' | grep '^/lib64' | xargs -I % cp % /lib64-bws
 
-# Make a HOME directory for the app stage
-RUN mkdir -p /home/app
+# Make a user and HOME directory for the app stage
+RUN useradd -m app
 
 ###############################################
 #                  App stage                  #
@@ -35,10 +35,14 @@ FROM scratch
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"
 
-# Set a HOME directory
+# Set a HOME directory and copy the user file
 COPY --from=build /home/app /home/app
+COPY --from=build /etc/passwd /etc/passwd
 ENV HOME=/home/app
 WORKDIR /home/app
+
+# Switch to the app user
+USER app
 
 # Copy built project from the build stage
 COPY --from=build /app/target/release/bws /bin/bws


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

After the `bws` Docker image got moved to use `scratch` as a base image, non-root support got removed. This PR introduces it again, which should also remedy the SonarCloud scanner CI failure.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
