### PR TITLE
Rename selected_credential to selected_cipher

### DIFF
--- a/crates/bitwarden/src/platform/fido2/authenticator.rs
+++ b/crates/bitwarden/src/platform/fido2/authenticator.rs
@@ -27,7 +27,7 @@ pub struct Fido2Authenticator<'a> {
     pub(crate) user_interface: &'a dyn Fido2UserInterface,
     pub(crate) credential_store: &'a dyn Fido2CredentialStore,
 
-    pub(crate) selected_credential: Mutex<Option<CipherView>>,
+    pub(crate) selected_cipher: Mutex<Option<CipherView>>,
     pub(crate) requested_uv: Mutex<Option<UV>>,
 }
 
@@ -202,7 +202,7 @@ impl<'a> Fido2Authenticator<'a> {
         let enc = self.client.get_encryption_settings()?;
 
         let cipher = self
-            .selected_credential
+            .selected_cipher
             .lock()
             .expect("Mutex is not poisoned")
             .clone()
@@ -275,7 +275,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
 
                 // Store the selected credential for later use
                 this.authenticator
-                    .selected_credential
+                    .selected_cipher
                     .lock()
                     .expect("Mutex is not poisoned")
                     .replace(picked.clone());
@@ -313,7 +313,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
             // Get the previously selected cipher and add the new credential to it
             let mut selected: CipherView = this
                 .authenticator
-                .selected_credential
+                .selected_cipher
                 .lock()
                 .expect("Mutex is not poisoned")
                 .clone()
@@ -323,7 +323,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
 
             // Store the updated credential for later use
             this.authenticator
-                .selected_credential
+                .selected_cipher
                 .lock()
                 .expect("Mutex is not poisoned")
                 .replace(selected.clone());
@@ -370,7 +370,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
 
             // Store the updated credential for later use
             this.authenticator
-                .selected_credential
+                .selected_cipher
                 .lock()
                 .expect("Mutex is not poisoned")
                 .replace(selected.clone());
@@ -437,7 +437,7 @@ impl passkey::authenticator::UserValidationMethod for UserValidationMethodImpl<'
                     .map_err(|_| Ctap2Error::OperationDenied)?;
 
                 self.authenticator
-                    .selected_credential
+                    .selected_cipher
                     .lock()
                     .expect("Mutex is not poisoned")
                     .replace(cipher_view);

--- a/crates/bitwarden/src/platform/fido2/mod.rs
+++ b/crates/bitwarden/src/platform/fido2/mod.rs
@@ -56,7 +56,7 @@ impl<'a> ClientFido2<'a> {
             client: self.client,
             user_interface,
             credential_store,
-            selected_credential: Mutex::new(None),
+            selected_cipher: Mutex::new(None),
             requested_uv: Mutex::new(None),
         })
     }


### PR DESCRIPTION
## 📔 Objective

`selected_credential` is a misleading name as the selected value doesn't have to contain credentials, for example when creating a new passkey a cipher will usually not contain any credentials. Renaming it to `selected_cipher` should help clear the confusion a bit.

I've left the `get_selected_credential` function with the same name, as in this case we are actually getting the credential inside the cipher.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
