### PR TITLE
Flip the dependency between exporters and vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,9 @@ name = "bitwarden-exporters"
 version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
+ "bitwarden-core",
  "bitwarden-crypto",
+ "bitwarden-vault",
  "chrono",
  "csv",
  "serde",
@@ -584,7 +586,6 @@ dependencies = [
  "bitwarden-api-api",
  "bitwarden-core",
  "bitwarden-crypto",
- "bitwarden-exporters",
  "chrono",
  "hmac",
  "rand",

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -16,7 +16,9 @@ keywords.workspace = true
 
 [dependencies]
 base64 = ">=0.21.2, <0.23"
+bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
+bitwarden-vault = { workspace = true }
 chrono = { version = ">=0.4.26, <0.5", features = [
     "clock",
     "serde",

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -10,8 +10,8 @@ use crate::csv::export_csv;
 mod json;
 use json::export_json;
 mod encrypted_json;
-
 use encrypted_json::export_encrypted_json;
+pub mod models;
 
 pub enum Format {
     Csv,

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -11,7 +11,7 @@ mod json;
 use json::export_json;
 mod encrypted_json;
 use encrypted_json::export_encrypted_json;
-pub mod models;
+mod models;
 
 pub enum Format {
     Csv,

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::{require, MissingFieldError};
-
 use bitwarden_vault::{
     CipherType, CipherView, FieldView, FolderView, LoginUriView, SecureNoteType,
 };
@@ -128,10 +127,10 @@ impl From<SecureNoteType> for crate::SecureNoteType {
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_vault::{CipherRepromptType, LoginView};
     use chrono::{DateTime, Utc};
 
     use super::*;
-    use bitwarden_vault::{CipherRepromptType, LoginView};
 
     #[test]
     fn test_try_from_folder_view() {

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -25,7 +25,6 @@ base64 = ">=0.21.2, <0.23"
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
-bitwarden-exporters = { workspace = true }
 chrono = { version = ">=0.4.26, <0.5", default-features = false }
 rand = ">=0.8.5, <0.9"
 hmac = ">=0.12.1, <0.13"

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -35,11 +35,11 @@ pub struct Field {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct FieldView {
-    pub(crate) name: Option<String>,
-    pub(crate) value: Option<String>,
-    pub(crate) r#type: FieldType,
+    pub name: Option<String>,
+    pub value: Option<String>,
+    pub r#type: FieldType,
 
-    pub(crate) linked_id: Option<LinkedIdType>,
+    pub linked_id: Option<LinkedIdType>,
 }
 
 impl KeyEncryptable<SymmetricCryptoKey, Field> for FieldView {

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -16,6 +16,6 @@ pub use cipher::{Cipher, CipherError, CipherListView, CipherRepromptType, Cipher
 pub use field::FieldView;
 pub use login::{
     Fido2Credential, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView, Login,
-    LoginView,
+    LoginUriView, LoginView,
 };
 pub use secure_note::SecureNoteType;

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -25,7 +25,7 @@ pub struct SecureNote {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SecureNoteView {
-    pub(crate) r#type: SecureNoteType,
+    pub r#type: SecureNoteType,
 }
 
 impl KeyEncryptable<SymmetricCryptoKey, SecureNote> for SecureNoteView {

--- a/crates/bitwarden-vault/src/lib.rs
+++ b/crates/bitwarden-vault/src/lib.rs
@@ -17,4 +17,3 @@ mod totp;
 pub use totp::{generate_totp, TotpError, TotpResponse};
 mod error;
 pub use error::VaultParseError;
-mod exporters;


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In preparation for #798 we need to flip the relationship between vault and exporters. Due to exporters in the future getting a `client_exporters` which means they need to be able to access the vault models to properly model it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
