### PR TITLE
Remove unnecessary into()

### DIFF
--- a/crates/bitwarden-vault/src/cipher/linked_id.rs
+++ b/crates/bitwarden-vault/src/cipher/linked_id.rs
@@ -112,7 +112,7 @@ impl TryFrom<u32> for LinkedIdType {
             416 => Ok(LinkedIdType::Identity(IdentityLinkedIdType::FirstName)),
             417 => Ok(LinkedIdType::Identity(IdentityLinkedIdType::LastName)),
             418 => Ok(LinkedIdType::Identity(IdentityLinkedIdType::FullName)),
-            _ => Err(MissingFieldError("LinkedIdType").into()),
+            _ => Err(MissingFieldError("LinkedIdType")),
         }
     }
 }


### PR DESCRIPTION
## 📔 Objective

Clippy was complaining in my local build that this into was unnecessary, and for some reason this wasn't caught by CI

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
