### PR TITLE
Migrate fido logic to use explicit errors

### DIFF
--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden::{
+    error::Error,
     platform::fido2::{
         CheckUserOptions, ClientData, Fido2CallbackError as BitFido2CallbackError,
         GetAssertionRequest, GetAssertionResult, MakeCredentialRequest, MakeCredentialResult,
@@ -62,9 +63,12 @@ impl ClientFido2Authenticator {
         let mut fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.1.as_ref());
         let cs = UniffiTraitBridge(self.2.as_ref());
-        let mut auth = fido2.create_authenticator(&ui, &cs)?;
+        let mut auth = fido2.create_authenticator(&ui, &cs);
 
-        let result = auth.make_credential(request).await?;
+        let result = auth
+            .make_credential(request)
+            .await
+            .map_err(Error::MakeCredential)?;
         Ok(result)
     }
 
@@ -75,9 +79,12 @@ impl ClientFido2Authenticator {
         let mut fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.1.as_ref());
         let cs = UniffiTraitBridge(self.2.as_ref());
-        let mut auth = fido2.create_authenticator(&ui, &cs)?;
+        let mut auth = fido2.create_authenticator(&ui, &cs);
 
-        let result = auth.get_assertion(request).await?;
+        let result = auth
+            .get_assertion(request)
+            .await
+            .map_err(Error::GetAssertion)?;
         Ok(result)
     }
 
@@ -91,9 +98,12 @@ impl ClientFido2Authenticator {
         let mut fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.1.as_ref());
         let cs = UniffiTraitBridge(self.2.as_ref());
-        let mut auth = fido2.create_authenticator(&ui, &cs)?;
+        let mut auth = fido2.create_authenticator(&ui, &cs);
 
-        let result = auth.silently_discover_credentials(rp_id).await?;
+        let result = auth
+            .silently_discover_credentials(rp_id)
+            .await
+            .map_err(Error::SilentlyDiscoverCredentials)?;
         Ok(result)
     }
 }
@@ -115,9 +125,12 @@ impl ClientFido2Client {
         let mut fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.0 .1.as_ref());
         let cs = UniffiTraitBridge(self.0 .2.as_ref());
-        let mut client = fido2.create_client(&ui, &cs)?;
+        let mut client = fido2.create_client(&ui, &cs);
 
-        let result = client.register(origin, request, client_data).await?;
+        let result = client
+            .register(origin, request, client_data)
+            .await
+            .map_err(Error::Fido2Client)?;
         Ok(result)
     }
 
@@ -133,9 +146,12 @@ impl ClientFido2Client {
         let mut fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.0 .1.as_ref());
         let cs = UniffiTraitBridge(self.0 .2.as_ref());
-        let mut client = fido2.create_client(&ui, &cs)?;
+        let mut client = fido2.create_client(&ui, &cs);
 
-        let result = client.authenticate(origin, request, client_data).await?;
+        let result = client
+            .authenticate(origin, request, client_data)
+            .await
+            .map_err(Error::Fido2Client)?;
         Ok(result)
     }
 }

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -188,8 +188,8 @@ impl Client {
         }
     }
 
-    pub(crate) fn get_encryption_settings(&self) -> Result<&EncryptionSettings> {
-        self.encryption_settings.as_ref().ok_or(VaultLocked.into())
+    pub(crate) fn get_encryption_settings(&self) -> Result<&EncryptionSettings, VaultLocked> {
+        self.encryption_settings.as_ref().ok_or(VaultLocked)
     }
 
     pub(crate) fn set_login_method(&mut self, login_method: LoginMethod) {

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -80,16 +80,16 @@ pub enum Error {
     ExportError(#[from] ExportError),
 
     // Fido
-    #[cfg(feature = "internal")]
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error(transparent)]
     MakeCredential(#[from] crate::platform::fido2::MakeCredentialError),
-    #[cfg(feature = "internal")]
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error(transparent)]
     GetAssertion(#[from] crate::platform::fido2::GetAssertionError),
-    #[cfg(feature = "internal")]
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error(transparent)]
     SilentlyDiscoverCredentials(#[from] crate::platform::fido2::SilentlyDiscoverCredentialsError),
-    #[cfg(feature = "internal")]
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error(transparent)]
     Fido2Client(#[from] crate::platform::fido2::Fido2ClientError),
 
@@ -97,7 +97,7 @@ pub enum Error {
     #[error("Uniffi callback error: {0}")]
     UniffiCallbackError(#[from] uniffi::UnexpectedUniFFICallbackError),
 
-    #[cfg(feature = "uniffi")]
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error("Fido2 Callback error: {0:?}")]
     Fido2CallbackError(#[from] crate::platform::fido2::Fido2CallbackError),
 

--- a/crates/bitwarden/src/platform/fido2/authenticator.rs
+++ b/crates/bitwarden/src/platform/fido2/authenticator.rs
@@ -1,8 +1,8 @@
 use std::sync::Mutex;
 
 use bitwarden_core::VaultLocked;
-use bitwarden_crypto::KeyEncryptable;
-use bitwarden_vault::{CipherView, Fido2CredentialView};
+use bitwarden_crypto::{CryptoError, KeyEncryptable};
+use bitwarden_vault::{CipherError, CipherView, Fido2CredentialView};
 use log::error;
 use passkey::{
     authenticator::{Authenticator, DiscoverabilitySupport, StoreInfo, UIHint, UserCheck},
@@ -11,16 +11,70 @@ use passkey::{
         Passkey,
     },
 };
+use thiserror::Error;
 
 use super::{
     try_from_credential_new_view, types::*, CheckUserOptions, CheckUserResult, CipherViewContainer,
     Fido2CredentialStore, Fido2UserInterface, SelectedCredential, UnknownEnum, AAGUID,
 };
 use crate::{
-    error::Result,
-    platform::fido2::{fill_with_credential, string_to_guid_bytes, try_from_credential_full},
+    platform::fido2::{
+        fill_with_credential, string_to_guid_bytes, try_from_credential_full, Fido2CallbackError,
+        FillCredentialError, InvalidGuid,
+    },
     Client,
 };
+
+#[derive(Debug, Error)]
+pub enum GetSelectedCredentialError {
+    #[error("No selected credential available")]
+    NoSelectedCredential,
+    #[error("No fido2 credentials found")]
+    NoCredentialFound,
+
+    #[error(transparent)]
+    VaultLocked(#[from] VaultLocked),
+    #[error(transparent)]
+    CipherError(#[from] CipherError),
+}
+
+#[derive(Debug, Error)]
+pub enum MakeCredentialError {
+    #[error(transparent)]
+    PublicKeyCredentialParametersError(#[from] PublicKeyCredentialParametersError),
+    #[error(transparent)]
+    UnknownEnum(#[from] UnknownEnum),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error("Missing attested_credential_data")]
+    MissingAttestedCredentialData,
+    #[error("make_credential error: {0}")]
+    Other(String),
+}
+
+#[derive(Debug, Error)]
+pub enum GetAssertionError {
+    #[error(transparent)]
+    UnknownEnum(#[from] UnknownEnum),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    GetSelectedCredentialError(#[from] GetSelectedCredentialError),
+    #[error("Missing attested_credential_data")]
+    MissingAttestedCredentialData,
+    #[error("missing user")]
+    MissingUser,
+    #[error("get_assertion error: {0}")]
+    Other(String),
+}
+
+#[derive(Debug, Error)]
+pub enum SilentlyDiscoverCredentialsError {
+    #[error(transparent)]
+    VaultLocked(#[from] VaultLocked),
+    #[error(transparent)]
+    Fido2CallbackError(#[from] Fido2CallbackError),
+}
 
 pub struct Fido2Authenticator<'a> {
     pub(crate) client: &'a mut Client,
@@ -35,7 +89,7 @@ impl<'a> Fido2Authenticator<'a> {
     pub async fn make_credential(
         &mut self,
         request: MakeCredentialRequest,
-    ) -> Result<MakeCredentialResult> {
+    ) -> Result<MakeCredentialResult, MakeCredentialError> {
         // Insert the received UV to be able to return it later in check_user
         self.requested_uv
             .get_mut()
@@ -60,13 +114,11 @@ impl<'a> Fido2Authenticator<'a> {
                     .pub_key_cred_params
                     .into_iter()
                     .map(TryInto::try_into)
-                    .collect::<Result<_, _>>()
-                    .map_err(|e: PublicKeyCredentialParametersError| e.to_string())?,
+                    .collect::<Result<_, _>>()?,
                 exclude_list: request
                     .exclude_list
                     .map(|x| x.into_iter().map(TryInto::try_into).collect())
-                    .transpose()
-                    .map_err(|e: UnknownEnum| e.to_string())?,
+                    .transpose()?,
                 extensions: request
                     .extensions
                     .map(|e| serde_json::from_str(&e))
@@ -83,14 +135,14 @@ impl<'a> Fido2Authenticator<'a> {
 
         let response = match response {
             Ok(x) => x,
-            Err(e) => return Err(format!("make_credential error: {e:?}").into()),
+            Err(e) => return Err(MakeCredentialError::Other(format!("{e:?}"))),
         };
 
         let authenticator_data = response.auth_data.to_vec();
         let attested_credential_data = response
             .auth_data
             .attested_credential_data
-            .ok_or("Missing attested_credential_data")?;
+            .ok_or(MakeCredentialError::MissingAttestedCredentialData)?;
         let credential_id = attested_credential_data.credential_id().to_vec();
 
         Ok(MakeCredentialResult {
@@ -103,7 +155,7 @@ impl<'a> Fido2Authenticator<'a> {
     pub async fn get_assertion(
         &mut self,
         request: GetAssertionRequest,
-    ) -> Result<GetAssertionResult> {
+    ) -> Result<GetAssertionResult, GetAssertionError> {
         // Insert the received UV to be able to return it later in check_user
         self.requested_uv
             .get_mut()
@@ -123,8 +175,7 @@ impl<'a> Fido2Authenticator<'a> {
                             .map(TryInto::try_into)
                             .collect::<Result<Vec<_>, _>>()
                     })
-                    .transpose()
-                    .map_err(|e: UnknownEnum| e.to_string())?,
+                    .transpose()?,
                 extensions: request
                     .extensions
                     .map(|e| serde_json::from_str(&e))
@@ -141,14 +192,14 @@ impl<'a> Fido2Authenticator<'a> {
 
         let response = match response {
             Ok(x) => x,
-            Err(e) => return Err(format!("get_assertion error: {e:?}").into()),
+            Err(e) => return Err(GetAssertionError::Other(format!("{e:?}"))),
         };
 
         let authenticator_data = response.auth_data.to_vec();
         let credential_id = response
             .auth_data
             .attested_credential_data
-            .ok_or("Missing attested_credential_data")?
+            .ok_or(GetAssertionError::MissingAttestedCredentialData)?
             .credential_id()
             .to_vec();
 
@@ -156,7 +207,11 @@ impl<'a> Fido2Authenticator<'a> {
             credential_id,
             authenticator_data,
             signature: response.signature.into(),
-            user_handle: response.user.ok_or("Missing user")?.id.into(),
+            user_handle: response
+                .user
+                .ok_or(GetAssertionError::MissingUser)?
+                .id
+                .into(),
             selected_credential: self.get_selected_credential()?,
         })
     }
@@ -164,7 +219,7 @@ impl<'a> Fido2Authenticator<'a> {
     pub async fn silently_discover_credentials(
         &mut self,
         rp_id: String,
-    ) -> Result<Vec<Fido2CredentialView>> {
+    ) -> Result<Vec<Fido2CredentialView>, SilentlyDiscoverCredentialsError> {
         let enc = self.client.get_encryption_settings()?;
         let result = self.credential_store.find_credentials(None, rp_id).await?;
 
@@ -201,7 +256,9 @@ impl<'a> Fido2Authenticator<'a> {
         }
     }
 
-    pub(super) fn get_selected_credential(&self) -> Result<SelectedCredential> {
+    pub(super) fn get_selected_credential(
+        &self,
+    ) -> Result<SelectedCredential, GetSelectedCredentialError> {
         let enc = self.client.get_encryption_settings()?;
 
         let cipher = self
@@ -209,11 +266,14 @@ impl<'a> Fido2Authenticator<'a> {
             .lock()
             .expect("Mutex is not poisoned")
             .clone()
-            .ok_or("No selected credential available")?;
+            .ok_or(GetSelectedCredentialError::NoSelectedCredential)?;
 
         let creds = cipher.decrypt_fido2_credentials(enc)?;
 
-        let credential = creds.first().ok_or("No Fido2 credentials found")?.clone();
+        let credential = creds
+            .first()
+            .ok_or(GetSelectedCredentialError::NoCredentialFound)?
+            .clone();
 
         Ok(SelectedCredential { cipher, credential })
     }
@@ -235,12 +295,24 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         ids: Option<&[passkey::types::webauthn::PublicKeyCredentialDescriptor]>,
         rp_id: &str,
     ) -> Result<Vec<Self::PasskeyItem>, StatusCode> {
+        #[derive(Debug, Error)]
+        enum InnerError {
+            #[error(transparent)]
+            VaultLocked(#[from] VaultLocked),
+            #[error(transparent)]
+            CipherError(#[from] CipherError),
+            #[error(transparent)]
+            CryptoError(#[from] CryptoError),
+            #[error(transparent)]
+            Fido2CallbackError(#[from] Fido2CallbackError),
+        }
+
         // This is just a wrapper around the actual implementation to allow for ? error handling
         async fn inner(
             this: &CredentialStoreImpl<'_>,
             ids: Option<&[passkey::types::webauthn::PublicKeyCredentialDescriptor]>,
             rp_id: &str,
-        ) -> Result<Vec<CipherViewContainer>> {
+        ) -> Result<Vec<CipherViewContainer>, InnerError> {
             let ids: Option<Vec<Vec<u8>>> =
                 ids.map(|ids| ids.iter().map(|id| id.id.clone().into()).collect());
 
@@ -265,10 +337,10 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
 
             // When using the credential for authentication we have to ask the user to pick one.
             if this.create_credential {
-                creds
+                Ok(creds
                     .into_iter()
                     .map(|c| CipherViewContainer::new(c, enc))
-                    .collect()
+                    .collect::<Result<_, _>>()?)
             } else {
                 let picked = this
                     .authenticator
@@ -302,13 +374,30 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         rp: passkey::types::ctap2::make_credential::PublicKeyCredentialRpEntity,
         _options: passkey::types::ctap2::get_assertion::Options,
     ) -> Result<(), StatusCode> {
+        #[derive(Debug, Error)]
+        enum InnerError {
+            #[error(transparent)]
+            VaultLocked(#[from] VaultLocked),
+            #[error(transparent)]
+            FillCredentialError(#[from] FillCredentialError),
+            #[error(transparent)]
+            CipherError(#[from] CipherError),
+            #[error(transparent)]
+            CryptoError(#[from] CryptoError),
+            #[error(transparent)]
+            Fido2CallbackError(#[from] Fido2CallbackError),
+
+            #[error("No selected credential available")]
+            NoSelectedCredential,
+        }
+
         // This is just a wrapper around the actual implementation to allow for ? error handling
         async fn inner(
             this: &mut CredentialStoreImpl<'_>,
             cred: Passkey,
             user: passkey::types::ctap2::make_credential::PublicKeyCredentialUserEntity,
             rp: passkey::types::ctap2::make_credential::PublicKeyCredentialRpEntity,
-        ) -> Result<()> {
+        ) -> Result<(), InnerError> {
             let enc = this.authenticator.client.get_encryption_settings()?;
 
             let cred = try_from_credential_full(cred, user, rp)?;
@@ -320,7 +409,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .lock()
                 .expect("Mutex is not poisoned")
                 .clone()
-                .ok_or("No selected cipher available")?;
+                .ok_or(InnerError::NoSelectedCredential)?;
 
             selected.set_new_fido2_credentials(enc, vec![cred])?;
 
@@ -352,8 +441,31 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
     }
 
     async fn update_credential(&mut self, cred: Passkey) -> Result<(), StatusCode> {
+        #[derive(Debug, Error)]
+        enum InnerError {
+            #[error(transparent)]
+            VaultLocked(#[from] VaultLocked),
+            #[error(transparent)]
+            InvalidGuid(#[from] InvalidGuid),
+            #[error("Credential ID does not match selected credential")]
+            CredentialIdMismatch,
+            #[error(transparent)]
+            FillCredentialError(#[from] FillCredentialError),
+            #[error(transparent)]
+            CipherError(#[from] CipherError),
+            #[error(transparent)]
+            CryptoError(#[from] CryptoError),
+            #[error(transparent)]
+            Fido2CallbackError(#[from] Fido2CallbackError),
+            #[error(transparent)]
+            GetSelectedCredentialError(#[from] GetSelectedCredentialError),
+        }
+
         // This is just a wrapper around the actual implementation to allow for ? error handling
-        async fn inner(this: &mut CredentialStoreImpl<'_>, cred: Passkey) -> Result<()> {
+        async fn inner(
+            this: &mut CredentialStoreImpl<'_>,
+            cred: Passkey,
+        ) -> Result<(), InnerError> {
             let enc = this.authenticator.client.get_encryption_settings()?;
 
             // Get the previously selected cipher and update the credential
@@ -361,10 +473,9 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
 
             // Check that the provided credential ID matches the selected credential
             let new_id: &Vec<u8> = &cred.credential_id;
-            let selected_id = string_to_guid_bytes(&selected.credential.credential_id)
-                .map_err(|e| e.to_string())?;
+            let selected_id = string_to_guid_bytes(&selected.credential.credential_id)?;
             if new_id != &selected_id {
-                return Err("Credential ID does not match selected credential".into());
+                return Err(InnerError::CredentialIdMismatch);
             }
 
             let cred = fill_with_credential(&selected.credential, cred)?;

--- a/crates/bitwarden/src/platform/fido2/crypto.rs
+++ b/crates/bitwarden/src/platform/fido2/crypto.rs
@@ -1,24 +1,28 @@
-use coset::{
-    iana::{self},
-    CoseKey,
-};
+use coset::{iana, CoseKey};
 use p256::{pkcs8::EncodePrivateKey, SecretKey};
 use passkey::authenticator::{private_key_from_cose_key, CoseKeyPair};
+use thiserror::Error;
 
-use crate::error::{Error, Result};
+#[derive(Debug, Error)]
+pub enum CodeKeyToPkcs8Error {
+    #[error("Failed to extract private key from cose_key")]
+    FailedToExtractPrivateKeyFromCoseKey,
+    #[error("Failed to convert P256 private key to PKC8")]
+    FailedToConvertP256PrivateKeyToPkcs8,
+}
 
-pub fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>> {
+pub fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>, CodeKeyToPkcs8Error> {
     // cose_key.
     let secret_key = private_key_from_cose_key(cose_key).map_err(|error| {
         log::error!("Failed to extract private key from cose_key: {:?}", error);
-        Error::Internal("Failed to extract private key from cose_key".into())
+        CodeKeyToPkcs8Error::FailedToExtractPrivateKeyFromCoseKey
     })?;
 
     let vec = secret_key
         .to_pkcs8_der()
         .map_err(|error| {
             log::error!("Failed to convert P256 private key to PKC8: {:?}", error);
-            Error::Internal("Failed to convert P256 private key to PKC8".into())
+            CodeKeyToPkcs8Error::FailedToConvertP256PrivateKeyToPkcs8
         })?
         .as_bytes()
         .to_vec();
@@ -26,10 +30,14 @@ pub fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>> {
     Ok(vec)
 }
 
-pub fn pkcs8_to_cose_key(secret_key: &[u8]) -> Result<CoseKey> {
+#[derive(Debug, Error)]
+#[error("Failed to extract private key from secret_key")]
+pub struct PrivateKeyFromSecretKeyError;
+
+pub fn pkcs8_to_cose_key(secret_key: &[u8]) -> Result<CoseKey, PrivateKeyFromSecretKeyError> {
     let secret_key = SecretKey::from_slice(secret_key).map_err(|error| {
         log::error!("Failed to extract private key from secret_key: {:?}", error);
-        Error::Internal("Failed to extract private key from secret_key".into())
+        PrivateKeyFromSecretKeyError
     })?;
 
     let cose_key_pair = CoseKeyPair::from_secret_key(&secret_key, iana::Algorithm::ES256);

--- a/crates/bitwarden/src/platform/fido2/crypto.rs
+++ b/crates/bitwarden/src/platform/fido2/crypto.rs
@@ -4,25 +4,25 @@ use passkey::authenticator::{private_key_from_cose_key, CoseKeyPair};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum CodeKeyToPkcs8Error {
+pub enum CoseKeyToPkcs8Error {
     #[error("Failed to extract private key from cose_key")]
     FailedToExtractPrivateKeyFromCoseKey,
     #[error("Failed to convert P256 private key to PKC8")]
     FailedToConvertP256PrivateKeyToPkcs8,
 }
 
-pub fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>, CodeKeyToPkcs8Error> {
+pub fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>, CoseKeyToPkcs8Error> {
     // cose_key.
     let secret_key = private_key_from_cose_key(cose_key).map_err(|error| {
         log::error!("Failed to extract private key from cose_key: {:?}", error);
-        CodeKeyToPkcs8Error::FailedToExtractPrivateKeyFromCoseKey
+        CoseKeyToPkcs8Error::FailedToExtractPrivateKeyFromCoseKey
     })?;
 
     let vec = secret_key
         .to_pkcs8_der()
         .map_err(|error| {
             log::error!("Failed to convert P256 private key to PKC8: {:?}", error);
-            CodeKeyToPkcs8Error::FailedToConvertP256PrivateKeyToPkcs8
+            CoseKeyToPkcs8Error::FailedToConvertP256PrivateKeyToPkcs8
         })?
         .as_bytes()
         .to_vec();

--- a/crates/bitwarden/src/platform/fido2/traits.rs
+++ b/crates/bitwarden/src/platform/fido2/traits.rs
@@ -2,8 +2,6 @@ use bitwarden_vault::{Cipher, CipherView, Fido2CredentialNewView};
 use passkey::authenticator::UIHint;
 use thiserror::Error;
 
-use crate::error::Result;
-
 #[derive(Debug, Error)]
 pub enum Fido2CallbackError {
     #[error("The operation requires user interaction")]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR establishes explicit error types for the fido logic.

In order to extract the fido logic into a separate `bitwarden-fido` crate, we need to remove the dependencies on the `bitwarden` logic. Most of this is either the `Client` struct which is currently difficult, or the `Error` and `Result` types which this PR focuses on.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
