### PR TITLE
Remove Mutex from bitwarden-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,17 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +514,6 @@ dependencies = [
 name = "bitwarden-json"
 version = "0.3.0"
 dependencies = [
- "async-lock",
  "bitwarden",
  "log",
  "schemars",
@@ -562,7 +550,6 @@ name = "bitwarden-uniffi"
 version = "0.1.0"
 dependencies = [
  "android_logger",
- "async-lock",
  "async-trait",
  "bitwarden",
  "bitwarden-core",
@@ -970,15 +957,6 @@ dependencies = [
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "unicode-width",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1531,27 +1509,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -2556,12 +2513,6 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"

--- a/crates/bitwarden-json/Cargo.toml
+++ b/crates/bitwarden-json/Cargo.toml
@@ -20,7 +20,6 @@ internal = ["bitwarden/internal"] # Internal testing methods
 secrets = ["bitwarden/secrets"]   # Secrets manager API
 
 [dependencies]
-async-lock = ">=3.3.0, <4.0"
 bitwarden = { workspace = true }
 log = ">=0.4.18, <0.5"
 schemars = ">=0.8.12, <0.9"

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -1,4 +1,3 @@
-use async_lock::Mutex;
 use bitwarden::client::client_settings::ClientSettings;
 
 #[cfg(feature = "secrets")]
@@ -8,12 +7,12 @@ use crate::{
     response::{Response, ResponseIntoString},
 };
 
-pub struct Client(Mutex<bitwarden::Client>);
+pub struct Client(bitwarden::Client);
 
 impl Client {
     pub fn new(settings_input: Option<String>) -> Self {
         let settings = Self::parse_settings(settings_input);
-        Self(Mutex::new(bitwarden::Client::new(settings)))
+        Self(bitwarden::Client::new(settings))
     }
 
     pub async fn run_command(&self, input_str: &str) -> String {
@@ -45,7 +44,7 @@ impl Client {
             }
         };
 
-        let mut client = self.0.lock().await;
+        let client = &self.0;
 
         match cmd {
             #[cfg(feature = "internal")]

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["lib", "staticlib", "cdylib"]
 bench = false
 
 [dependencies]
-async-lock = "3.3.0"
 async-trait = "0.1.80"
 bitwarden = { workspace = true, features = ["internal", "uniffi"] }
 bitwarden-core = { workspace = true, features = ["uniffi"] }

--- a/crates/bitwarden/src/auth/client_auth.rs
+++ b/crates/bitwarden/src/auth/client_auth.rs
@@ -180,7 +180,7 @@ mod tests {
         use crate::{auth::login::AccessTokenLoginRequest, secrets_manager::secrets::*};
 
         // Create the mock server with the necessary routes for this test
-        let (_server, mut client) = crate::util::start_mock(vec![
+        let (_server, client) = crate::util::start_mock(vec![
             Mock::given(matchers::path("/identity/connect/token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(
                 serde_json::json!({

--- a/crates/bitwarden/src/secrets_manager/client_projects.rs
+++ b/crates/bitwarden/src/secrets_manager/client_projects.rs
@@ -9,33 +9,33 @@ use crate::{
 };
 
 pub struct ClientProjects<'a> {
-    pub(crate) client: &'a mut crate::Client,
+    pub(crate) client: &'a crate::Client,
 }
 
 impl<'a> ClientProjects<'a> {
-    pub async fn get(&mut self, input: &ProjectGetRequest) -> Result<ProjectResponse> {
+    pub async fn get(&self, input: &ProjectGetRequest) -> Result<ProjectResponse> {
         get_project(self.client, input).await
     }
 
-    pub async fn create(&mut self, input: &ProjectCreateRequest) -> Result<ProjectResponse> {
+    pub async fn create(&self, input: &ProjectCreateRequest) -> Result<ProjectResponse> {
         create_project(self.client, input).await
     }
 
-    pub async fn list(&mut self, input: &ProjectsListRequest) -> Result<ProjectsResponse> {
+    pub async fn list(&self, input: &ProjectsListRequest) -> Result<ProjectsResponse> {
         list_projects(self.client, input).await
     }
 
-    pub async fn update(&mut self, input: &ProjectPutRequest) -> Result<ProjectResponse> {
+    pub async fn update(&self, input: &ProjectPutRequest) -> Result<ProjectResponse> {
         update_project(self.client, input).await
     }
 
-    pub async fn delete(&mut self, input: ProjectsDeleteRequest) -> Result<ProjectsDeleteResponse> {
+    pub async fn delete(&self, input: ProjectsDeleteRequest) -> Result<ProjectsDeleteResponse> {
         delete_projects(self.client, input).await
     }
 }
 
 impl<'a> Client {
-    pub fn projects(&'a mut self) -> ClientProjects<'a> {
+    pub fn projects(&'a self) -> ClientProjects<'a> {
         ClientProjects { client: self }
     }
 }

--- a/crates/bitwarden/src/secrets_manager/client_secrets.rs
+++ b/crates/bitwarden/src/secrets_manager/client_secrets.rs
@@ -12,51 +12,51 @@ use crate::{
 };
 
 pub struct ClientSecrets<'a> {
-    pub(crate) client: &'a mut crate::Client,
+    pub(crate) client: &'a crate::Client,
 }
 
 impl<'a> ClientSecrets<'a> {
-    pub async fn get(&mut self, input: &SecretGetRequest) -> Result<SecretResponse> {
+    pub async fn get(&self, input: &SecretGetRequest) -> Result<SecretResponse> {
         get_secret(self.client, input).await
     }
 
-    pub async fn get_by_ids(&mut self, input: SecretsGetRequest) -> Result<SecretsResponse> {
+    pub async fn get_by_ids(&self, input: SecretsGetRequest) -> Result<SecretsResponse> {
         get_secrets_by_ids(self.client, input).await
     }
 
-    pub async fn create(&mut self, input: &SecretCreateRequest) -> Result<SecretResponse> {
+    pub async fn create(&self, input: &SecretCreateRequest) -> Result<SecretResponse> {
         create_secret(self.client, input).await
     }
 
     pub async fn list(
-        &mut self,
+        &self,
         input: &SecretIdentifiersRequest,
     ) -> Result<SecretIdentifiersResponse> {
         list_secrets(self.client, input).await
     }
 
     pub async fn list_by_project(
-        &mut self,
+        &self,
         input: &SecretIdentifiersByProjectRequest,
     ) -> Result<SecretIdentifiersResponse> {
         list_secrets_by_project(self.client, input).await
     }
 
-    pub async fn update(&mut self, input: &SecretPutRequest) -> Result<SecretResponse> {
+    pub async fn update(&self, input: &SecretPutRequest) -> Result<SecretResponse> {
         update_secret(self.client, input).await
     }
 
-    pub async fn delete(&mut self, input: SecretsDeleteRequest) -> Result<SecretsDeleteResponse> {
+    pub async fn delete(&self, input: SecretsDeleteRequest) -> Result<SecretsDeleteResponse> {
         delete_secrets(self.client, input).await
     }
 
-    pub async fn sync(&mut self, input: &SecretsSyncRequest) -> Result<SecretsSyncResponse> {
+    pub async fn sync(&self, input: &SecretsSyncRequest) -> Result<SecretsSyncResponse> {
         sync_secrets(self.client, input).await
     }
 }
 
 impl<'a> Client {
-    pub fn secrets(&'a mut self) -> ClientSecrets<'a> {
+    pub fn secrets(&'a self) -> ClientSecrets<'a> {
         ClientSecrets { client: self }
     }
 }

--- a/crates/bitwarden/src/secrets_manager/projects/create.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/create.rs
@@ -18,7 +18,7 @@ pub struct ProjectCreateRequest {
 }
 
 pub(crate) async fn create_project(
-    client: &mut Client,
+    client: &Client,
     input: &ProjectCreateRequest,
 ) -> Result<ProjectResponse> {
     let enc = client.get_encryption_settings()?;

--- a/crates/bitwarden/src/secrets_manager/projects/delete.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/delete.rs
@@ -16,7 +16,7 @@ pub struct ProjectsDeleteRequest {
 }
 
 pub(crate) async fn delete_projects(
-    client: &mut Client,
+    client: &Client,
     input: ProjectsDeleteRequest,
 ) -> Result<ProjectsDeleteResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/projects/get.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/get.rs
@@ -13,7 +13,7 @@ pub struct ProjectGetRequest {
 }
 
 pub(crate) async fn get_project(
-    client: &mut Client,
+    client: &Client,
     input: &ProjectGetRequest,
 ) -> Result<ProjectResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/projects/list.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/list.rs
@@ -17,7 +17,7 @@ pub struct ProjectsListRequest {
 }
 
 pub(crate) async fn list_projects(
-    client: &mut Client,
+    client: &Client,
     input: &ProjectsListRequest,
 ) -> Result<ProjectsResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/projects/update.rs
+++ b/crates/bitwarden/src/secrets_manager/projects/update.rs
@@ -20,7 +20,7 @@ pub struct ProjectPutRequest {
 }
 
 pub(crate) async fn update_project(
-    client: &mut Client,
+    client: &Client,
     input: &ProjectPutRequest,
 ) -> Result<ProjectResponse> {
     let enc = client.get_encryption_settings()?;

--- a/crates/bitwarden/src/secrets_manager/secrets/create.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/create.rs
@@ -23,7 +23,7 @@ pub struct SecretCreateRequest {
 }
 
 pub(crate) async fn create_secret(
-    client: &mut Client,
+    client: &Client,
     input: &SecretCreateRequest,
 ) -> Result<SecretResponse> {
     let enc = client.get_encryption_settings()?;

--- a/crates/bitwarden/src/secrets_manager/secrets/delete.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/delete.rs
@@ -16,7 +16,7 @@ pub struct SecretsDeleteRequest {
 }
 
 pub(crate) async fn delete_secrets(
-    client: &mut Client,
+    client: &Client,
     input: SecretsDeleteRequest,
 ) -> Result<SecretsDeleteResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/secrets/get.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/get.rs
@@ -13,7 +13,7 @@ pub struct SecretGetRequest {
 }
 
 pub(crate) async fn get_secret(
-    client: &mut Client,
+    client: &Client,
     input: &SecretGetRequest,
 ) -> Result<SecretResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/secrets/get_by_ids.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/get_by_ids.rs
@@ -14,7 +14,7 @@ pub struct SecretsGetRequest {
 }
 
 pub(crate) async fn get_secrets_by_ids(
-    client: &mut Client,
+    client: &Client,
     input: SecretsGetRequest,
 ) -> Result<SecretsResponse> {
     let request = Some(GetSecretsRequestModel { ids: input.ids });

--- a/crates/bitwarden/src/secrets_manager/secrets/list.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/list.rs
@@ -20,7 +20,7 @@ pub struct SecretIdentifiersRequest {
 }
 
 pub(crate) async fn list_secrets(
-    client: &mut Client,
+    client: &Client,
     input: &SecretIdentifiersRequest,
 ) -> Result<SecretIdentifiersResponse> {
     let config = client.get_api_configurations().await;
@@ -43,7 +43,7 @@ pub struct SecretIdentifiersByProjectRequest {
 }
 
 pub(crate) async fn list_secrets_by_project(
-    client: &mut Client,
+    client: &Client,
     input: &SecretIdentifiersByProjectRequest,
 ) -> Result<SecretIdentifiersResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/secrets/sync.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/sync.rs
@@ -18,7 +18,7 @@ pub struct SecretsSyncRequest {
 }
 
 pub(crate) async fn sync_secrets(
-    client: &mut Client,
+    client: &Client,
     input: &SecretsSyncRequest,
 ) -> Result<SecretsSyncResponse> {
     let config = client.get_api_configurations().await;

--- a/crates/bitwarden/src/secrets_manager/secrets/update.rs
+++ b/crates/bitwarden/src/secrets_manager/secrets/update.rs
@@ -23,7 +23,7 @@ pub struct SecretPutRequest {
 }
 
 pub(crate) async fn update_secret(
-    client: &mut Client,
+    client: &Client,
     input: &SecretPutRequest,
 ) -> Result<SecretResponse> {
     let enc = client.get_encryption_settings()?;

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -125,7 +125,7 @@ async fn process_commands() -> Result<()> {
         access_token_obj.access_token_id.to_string(),
     )?;
 
-    let mut client = bitwarden::Client::new(settings);
+    let client = bitwarden::Client::new(settings);
 
     // Load session or return if no session exists
     let _ = client


### PR DESCRIPTION
## 🎟️ Tracking

With the mutability changes to the client, we don't need a Mutex in `bitwarden-json` anymore either, which means we can remove the `async-lock` dependency as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
