### PR TITLE
Always deploy all rust packages

### DIFF
--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -14,61 +14,11 @@ on:
           - Initial Release
           - Redeploy
           - Dry Run
-      publish_bitwarden:
-        description: "Publish bitwarden crate"
+      packages:
+        description: "Which packages to publish"
         required: true
-        default: true
-        type: boolean
-      publish_bitwarden-api-api:
-        description: "Publish bitwarden-api-api crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-api-identity:
-        description: "Publish bitwarden-api-identity crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-core:
-        description: "Publish bitwarden-core crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-crypto:
-        description: "Publish bitwarden-crypto crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-cli:
-        description: "Publish bitwarden-cli crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-exporters:
-        description: "Publish bitwarden-exporters crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-fido:
-        description: "Publish bitwarden-fido crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-generators:
-        description: "Publish bitwarden-generators crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-send:
-        description: "Publish bitwarden-send crate"
-        required: true
-        default: true
-        type: boolean
-      publish_bitwarden-vault:
-        description: "Publish bitwarden-valt crate"
-        required: true
-        default: true
-        type: boolean
+        default: "bitwarden bitwarden-api-api bitwarden-api-identity bitwarden-cli bitwarden-core bitwarden-crypto bitwarden-exporters bitwarden-fido bitwarden-generators bitwarden-send bitwarden-vault"
+        type: string
 
 defaults:
   run:
@@ -78,9 +28,6 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
-    outputs:
-      packages_list: ${{ steps.packages-list.outputs.packages_list }}
-      packages_command: ${{ steps.packages-list.outputs.packages_command }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -95,94 +42,8 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare packages list
-        id: packages-list
-        env:
-          PUBLISH_BITWARDEN: ${{ github.event.inputs.publish_bitwarden }}
-          PUBLISH_BITWARDEN_API_API: ${{ github.event.inputs.publish_bitwarden-api-api }}
-          PUBLISH_BITWARDEN_API_IDENTITY: ${{ github.event.inputs.publish_bitwarden-api-identity }}
-          PUBLISH_BITWARDEN_CORE: ${{ github.event.inputs.publish_bitwarden-core }}
-          PUBLISH_BITWARDEN_CRYPTO: ${{ github.event.inputs.publish_bitwarden-crypto }}
-          PUBLISH_BITWARDEN_CLI: ${{ github.event.inputs.publish_bitwarden-cli }}
-          PUBLISH_BITWARDEN_EXPORTERS: ${{ github.event.inputs.publish_bitwarden-exporters }}
-          PUBLISH_BITWARDEN_FIDO: ${{ github.event.inputs.publish_bitwarden-fido }}
-          PUBLISH_BITWARDEN_GENERATORS: ${{ github.event.inputs.publish_bitwarden-generators }}
-          PUBLISH_BITWARDEN_SEND: ${{ github.event.inputs.publish_bitwarden-send }}
-          PUBLISH_BITWARDEN_VAULT: ${{ github.event.inputs.publish_bitwarden-vault }}
-        run: |
-          if [[ "$PUBLISH_BITWARDEN" == "false" ]] && [[ "$PUBLISH_BITWARDEN_API_API" == "false" ]] && [[ "$PUBLISH_BITWARDEN_API_IDENTITY" == "false" ]]; then
-            echo "==================================="
-            echo "[!] You need to specify at least one crate for release!"
-            echo "==================================="
-            exit 1
-          fi
-
-          PACKAGES_COMMAND=""
-          PACKAGES_LIST=""
-
-          if [[ "$PUBLISH_BITWARDEN" == "true" ]] ; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_API_API" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-api-api"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-api-api"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_API_IDENTITY" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-api-identity"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-api-identity"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_CORE" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-core"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-core"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_CRYPTO" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-crypto"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-crypto"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_CLI" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-cli"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-cli"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_EXPORTERS" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-exporters"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-exporters"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_FIDO" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-fido"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-fido"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_GENERATORS" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-generators"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-generators"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_SEND" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-send"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-send"
-          fi
-
-          if [[ "$PUBLISH_BITWARDEN_VAULT" == "true" ]]; then
-            PACKAGES_COMMAND="$PACKAGES_COMMAND -p bitwarden-vault"
-            PACKAGES_LIST="$PACKAGES_LIST bitwarden-vault"
-          fi
-
-          echo "Packages command: " $PACKAGES_COMMAND
-          echo "Packages list: " $PACKAGES_LIST
-
-          echo "packages_list=$PACKAGES_LIST" >> $GITHUB_OUTPUT
-          echo "packages_command=$PACKAGES_COMMAND" >> $GITHUB_OUTPUT
-
   publish:
-    name: Publish ${{ needs.setup.outputs.packages_list }}
+    name: Publish ${{ github.event.inputs.packages }}
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -220,7 +81,7 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           initial-status: "in_progress"
-          environment: "Bitwarden SDK to crates.io: ${{ needs.setup.outputs.packages_list }}"
+          environment: "Bitwarden SDK to crates.io: ${{ github.event.inputs.packages }}"
           description: "Deployment from branch ${{ github.ref_name }}"
           task: release
 
@@ -228,9 +89,11 @@ jobs:
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           PUBLISH_GRACE_SLEEP: 10
-          PACKAGES_PUBLISH: ${{ needs.setup.outputs.packages_command }}
+          PACKAGES_PUBLISH: ${{ github.event.inputs.release_type }}
           CARGO_REGISTRY_TOKEN: ${{ steps.retrieve-secrets.outputs.cratesio-api-token }}
-        run: cargo-release release publish $PACKAGES_PUBLISH --execute --no-confirm
+        run: |
+          PACKAGES="-p ${PACKAGES_PUBLISH// / -p }"
+          cargo-release release publish $PACKAGES --execute --no-confirm
 
       - name: Update deployment status to Success
         if: ${{ github.event.inputs.release_type != 'Dry Run' && success() }}

--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -14,11 +14,6 @@ on:
           - Initial Release
           - Redeploy
           - Dry Run
-      packages:
-        description: "Which packages to publish"
-        required: true
-        default: "bitwarden bitwarden-api-api bitwarden-api-identity bitwarden-cli bitwarden-core bitwarden-crypto bitwarden-exporters bitwarden-fido bitwarden-generators bitwarden-send bitwarden-vault"
-        type: string
 
 defaults:
   run:
@@ -43,7 +38,7 @@ jobs:
           fi
 
   publish:
-    name: Publish ${{ github.event.inputs.packages }}
+    name: Publish
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -81,7 +76,7 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           initial-status: "in_progress"
-          environment: "Bitwarden SDK to crates.io: ${{ github.event.inputs.packages }}"
+          environment: "Bitwarden SDK"
           description: "Deployment from branch ${{ github.ref_name }}"
           task: release
 
@@ -91,9 +86,7 @@ jobs:
           PUBLISH_GRACE_SLEEP: 10
           PACKAGES_PUBLISH: ${{ github.event.inputs.release_type }}
           CARGO_REGISTRY_TOKEN: ${{ steps.retrieve-secrets.outputs.cratesio-api-token }}
-        run: |
-          PACKAGES="-p ${PACKAGES_PUBLISH// / -p }"
-          cargo-release release publish $PACKAGES --execute --no-confirm
+        run: cargo-release release publish --exclude bw --exclude bws --execute --no-confirm
 
       - name: Update deployment status to Success
         if: ${{ github.event.inputs.release_type != 'Dry Run' && success() }}

--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -84,7 +84,6 @@ jobs:
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           PUBLISH_GRACE_SLEEP: 10
-          PACKAGES_PUBLISH: ${{ github.event.inputs.release_type }}
           CARGO_REGISTRY_TOKEN: ${{ steps.retrieve-secrets.outputs.cratesio-api-token }}
         run: cargo-release release publish --exclude bw --exclude bws --execute --no-confirm
 


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

GitHub actions only supports 10 inputs to a workflow_dispatch. As we keep adding packages we've exceeded this limit. Since we no longer need the functionality to release individual packages this PR removes the option all together and instead will always release all packages.

In case a package with the same version already exists in crates.io, cargo release won't attempt to publish it and continue on with the other packages.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
