### PR TITLE
[PM-8874] Set attachment size when encrypting

### DIFF
--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -160,11 +160,11 @@ impl TryFrom<bitwarden_api_api::models::AttachmentResponseModel> for Attachment 
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use bitwarden_crypto::{EncString, KeyDecryptable, SymmetricCryptoKey};
+    use bitwarden_crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
 
     use crate::{
         cipher::cipher::{CipherRepromptType, CipherType},
-        Attachment, AttachmentFile, Cipher,
+        Attachment, AttachmentFile, AttachmentFileView, AttachmentView, Cipher,
     };
 
     #[test]
@@ -177,6 +177,59 @@ mod tests {
         assert_eq!(super::size_name(1024 * 18999), "18.6 MB");
         assert_eq!(super::size_name(1024 * 1024 * 1024), "1 GB");
         assert_eq!(super::size_name(1024 * 1024 * 1024 * 1024), "1 TB");
+    }
+
+    #[test]
+    fn test_encrypt_attachment() {
+        let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+
+        let attachment = AttachmentView {
+            id: None,
+            url: None,
+            size: Some("100".into()),
+            size_name: Some("100 Bytes".into()),
+            file_name: Some("Test.txt".into()),
+            key: None,
+        };
+
+        let contents = b"This is a test file that we will encrypt. It's 100 bytes long, the encrypted version will be longer!";
+
+        let attachment_file = AttachmentFileView {
+            cipher: Cipher {
+                id: None,
+                organization_id: None,
+                folder_id: None,
+                collection_ids: Vec::new(),
+                key: Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap()),
+                name: "2.d24xECyEdMZ3MG9s6SrGNw==|XvJlTeu5KJ22M3jKosy6iw==|8xGiQty4X61cDMx6PVqkJfSQ0ZTdA/5L9TpG7QfovoM=".parse().unwrap(),
+                notes: None,
+                r#type: CipherType::Login,
+                login: None,
+                identity: None,
+                card: None,
+                secure_note: None,
+                favorite: false,
+                reprompt: CipherRepromptType::None,
+                organization_use_totp: false,
+                edit: true,
+                view_password: true,
+                local_data: None,
+                attachments: None,
+                fields: None,
+                password_history: None,
+                creation_date: "2023-07-24T12:05:09.466666700Z".parse().unwrap(),
+                deleted_date: None,
+                revision_date: "2023-07-27T19:28:05.240Z".parse().unwrap(),
+            },
+            attachment,
+            contents: contents.as_slice(),
+        };
+
+        let result = attachment_file.encrypt_with_key(&user_key).unwrap();
+
+        assert_eq!(result.contents.len(), 161);
+        assert_eq!(result.attachment.size, Some("161".into()));
+        assert_eq!(result.attachment.size_name, Some("161 Bytes".into()));
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8874

## 📔 Objective

Set the attachment size after we encrypt the contents

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
