### PR TITLE
Fix individual crate compilation

### DIFF
--- a/crates/bitwarden-send/Cargo.toml
+++ b/crates/bitwarden-send/Cargo.toml
@@ -25,7 +25,10 @@ base64 = ">=0.21.2, <0.23"
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
-chrono = { version = ">=0.4.26, <0.5", default-features = false }
+chrono = { version = ">=0.4.26, <0.5", features = [
+    "clock",
+    "serde",
+], default-features = false }
 schemars = { version = ">=0.8.9, <0.9", features = ["uuid1", "chrono"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_repr = ">=0.1.12, <0.2"

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -25,7 +25,10 @@ base64 = ">=0.21.2, <0.23"
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
-chrono = { version = ">=0.4.26, <0.5", default-features = false }
+chrono = { version = ">=0.4.26, <0.5", features = [
+    "clock",
+    "serde",
+], default-features = false }
 rand = ">=0.8.5, <0.9"
 hmac = ">=0.12.1, <0.13"
 reqwest = { version = ">=0.12, <0.13", default-features = false }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -16,9 +16,7 @@ use super::{
     local_data::{LocalData, LocalDataView},
     login, secure_note,
 };
-#[cfg(feature = "uniffi")]
-use crate::Fido2CredentialView;
-use crate::{password_history, Fido2CredentialFullView, VaultParseError};
+use crate::{password_history, Fido2CredentialFullView, Fido2CredentialView, VaultParseError};
 
 #[derive(Debug, Error)]
 pub enum CipherError {
@@ -396,7 +394,6 @@ impl CipherView {
         Ok(())
     }
 
-    #[cfg(feature = "uniffi")]
     pub fn decrypt_fido2_credentials(
         &self,
         enc: &dyn KeyContainer,
@@ -458,7 +455,6 @@ impl CipherView {
         Ok(())
     }
 
-    #[cfg(feature = "uniffi")]
     pub fn set_new_fido2_credentials(
         &mut self,
         enc: &dyn KeyContainer,
@@ -475,7 +471,6 @@ impl CipherView {
         Ok(())
     }
 
-    #[cfg(feature = "uniffi")]
     pub fn get_fido2_credentials(
         &self,
         enc: &dyn KeyContainer,


### PR DESCRIPTION
## 📔 Objective

This PR fixes some compilation errors when compiling individual crates using `cargo c -p crate-name`:
- `send` and `vault` were missing some features of `chrono`, these features are available in other crates in the workspace so when compiling the entire workspace it works, but it returns an error when compiling the individual crates

- `fido` depended on some functions from `vault` that were behind a `uniffi` feature.

Rust-analyzer will try to compile the crate individually when manually running a test, which is how I notice that this problem was occurring.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
