### PR TITLE
Remove calls to client_settings namespace

### DIFF
--- a/crates/bitwarden-cli/README.md
+++ b/crates/bitwarden-cli/README.md
@@ -1,0 +1,6 @@
+# Bitwarden Cli
+
+This is an internal crate for the Bitwarden SDK do not depend on this directly and use the
+[`bitwarden`](https://crates.io/crates/bitwarden) crate instead.
+
+This crate does not follow semantic versioning and the public interface may change at any time.

--- a/crates/bitwarden-core/README.md
+++ b/crates/bitwarden-core/README.md
@@ -1,0 +1,6 @@
+# Bitwarden Crypto
+
+This is an internal crate for the Bitwarden SDK do not depend on this directly and use the
+[`bitwarden`](https://crates.io/crates/bitwarden) crate instead.
+
+This crate does not follow semantic versioning and the public interface may change at any time.

--- a/crates/bitwarden-fido/README.md
+++ b/crates/bitwarden-fido/README.md
@@ -1,0 +1,6 @@
+# Bitwarden Fido
+
+This is an internal crate for the Bitwarden SDK do not depend on this directly and use the
+[`bitwarden`](https://crates.io/crates/bitwarden) crate instead.
+
+This crate does not follow semantic versioning and the public interface may change at any time.

--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -1,4 +1,4 @@
-use bitwarden::client::client_settings::ClientSettings;
+use bitwarden::ClientSettings;
 
 #[cfg(feature = "secrets")]
 use crate::command::{ProjectsCommand, SecretsCommand};

--- a/crates/bitwarden-send/README.md
+++ b/crates/bitwarden-send/README.md
@@ -1,0 +1,6 @@
+# Bitwarden Send
+
+This is an internal crate for the Bitwarden SDK do not depend on this directly and use the
+[`bitwarden`](https://crates.io/crates/bitwarden) crate instead.
+
+This crate does not follow semantic versioning and the public interface may change at any time.

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -3,7 +3,7 @@ uniffi::setup_scaffolding!();
 use std::sync::Arc;
 
 use auth::ClientAuth;
-use bitwarden::client::client_settings::ClientSettings;
+use bitwarden::ClientSettings;
 
 pub mod auth;
 pub mod crypto;

--- a/crates/bitwarden-vault/README.md
+++ b/crates/bitwarden-vault/README.md
@@ -1,0 +1,6 @@
+# Bitwarden Vault
+
+This is an internal crate for the Bitwarden SDK do not depend on this directly and use the
+[`bitwarden`](https://crates.io/crates/bitwarden) crate instead.
+
+This crate does not follow semantic versioning and the public interface may change at any time.

--- a/crates/bitwarden/README.md
+++ b/crates/bitwarden/README.md
@@ -19,11 +19,8 @@ Rust **1.71** or higher.
 
 ```rust
 use bitwarden::{
-    auth::login::AccessTokenLoginRequest,
-    client::client_settings::{ClientSettings, DeviceType},
-    error::Result,
-    secrets_manager::secrets::SecretIdentifiersRequest,
-    Client,
+    auth::login::AccessTokenLoginRequest, error::Result,
+    secrets_manager::secrets::SecretIdentifiersRequest, Client, ClientSettings, DeviceType,
 };
 use uuid::Uuid;
 

--- a/crates/bitwarden/src/auth/api/request/auth_request_token_request.rs
+++ b/crates/bitwarden/src/auth/api/request/auth_request_token_request.rs
@@ -3,9 +3,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    auth::api::response::IdentityTokenResponse,
-    client::{client_settings::DeviceType, ApiConfigurations},
-    error::Result,
+    auth::api::response::IdentityTokenResponse, client::ApiConfigurations, error::Result,
+    DeviceType,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/bitwarden/src/auth/api/request/password_token_request.rs
+++ b/crates/bitwarden/src/auth/api/request/password_token_request.rs
@@ -6,8 +6,9 @@ use crate::{
         api::response::IdentityTokenResponse,
         login::{TwoFactorProvider, TwoFactorRequest},
     },
-    client::{client_settings::DeviceType, ApiConfigurations},
+    client::ApiConfigurations,
     error::Result,
+    DeviceType,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/bitwarden/src/auth/login/password.rs
+++ b/crates/bitwarden/src/auth/login/password.rs
@@ -66,7 +66,7 @@ async fn request_identity_tokens(
     input: &PasswordLoginRequest,
     password_hash: &str,
 ) -> Result<IdentityTokenResponse> {
-    use crate::client::client_settings::DeviceType;
+    use crate::DeviceType;
 
     let config = client.get_api_configurations().await;
     PasswordTokenRequest::new(

--- a/crates/bitwarden/src/client/client.rs
+++ b/crates/bitwarden/src/client/client.rs
@@ -16,12 +16,8 @@ use uuid::Uuid;
 #[cfg(feature = "internal")]
 use crate::client::flags::Flags;
 use crate::{
-    auth::AccessToken,
-    client::{
-        client_settings::{ClientSettings, DeviceType},
-        encryption_settings::EncryptionSettings,
-    },
-    error::Result,
+    auth::AccessToken, client::encryption_settings::EncryptionSettings, error::Result,
+    ClientSettings, DeviceType,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/bitwarden/src/client/client_settings.rs
+++ b/crates/bitwarden/src/client/client_settings.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Defaults to
 ///
 /// ```
-/// # use bitwarden::client::client_settings::{ClientSettings, DeviceType};
+/// # use bitwarden::{ClientSettings, DeviceType};
 /// let settings = ClientSettings {
 ///     identity_url: "https://identity.bitwarden.com".to_string(),
 ///     api_url: "https://api.bitwarden.com".to_string(),

--- a/crates/bitwarden/src/util.rs
+++ b/crates/bitwarden/src/util.rs
@@ -17,11 +17,11 @@ pub async fn start_mock(mocks: Vec<wiremock::Mock>) -> (wiremock::MockServer, cr
         server.register(mock).await;
     }
 
-    let settings = crate::client::client_settings::ClientSettings {
+    let settings = crate::ClientSettings {
         identity_url: format!("http://{}/identity", server.address()),
         api_url: format!("http://{}/api", server.address()),
         user_agent: "Bitwarden Rust-SDK [TEST]".into(),
-        device_type: crate::client::client_settings::DeviceType::SDK,
+        device_type: crate::DeviceType::SDK,
     };
 
     (server, crate::Client::new(Some(settings)))

--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -1,7 +1,7 @@
 use bitwarden::{
     auth::RegisterRequest,
-    client::client_settings::ClientSettings,
     generators::{PassphraseGeneratorRequest, PasswordGeneratorRequest},
+    ClientSettings,
 };
 use bitwarden_cli::{install_color_eyre, text_prompt_when_none, Color};
 use clap::{command, Args, CommandFactory, Parser, Subcommand};

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -2,7 +2,6 @@ use std::{path::PathBuf, process, str::FromStr};
 
 use bitwarden::{
     auth::{login::AccessTokenLoginRequest, AccessToken},
-    client::client_settings::ClientSettings,
     secrets_manager::{
         projects::{
             ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsDeleteRequest,
@@ -13,6 +12,7 @@ use bitwarden::{
             SecretIdentifiersRequest, SecretPutRequest, SecretsDeleteRequest, SecretsGetRequest,
         },
     },
+    ClientSettings,
 };
 use bitwarden_cli::install_color_eyre;
 use clap::{CommandFactory, Parser};

--- a/crates/sdk-schemas/src/main.rs
+++ b/crates/sdk-schemas/src/main.rs
@@ -91,7 +91,7 @@ use bitwarden_json::response::Response;
 #[derive(JsonSchema)]
 struct SchemaTypes {
     // Input types for new Client
-    client_settings: bitwarden::client::client_settings::ClientSettings,
+    client_settings: bitwarden::ClientSettings,
 
     // Input types for Client::run_command
     input_command: bitwarden_json::command::Command,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Now that we expose `ClientSettings` and `DeviceType` directly in the root `bitwarden` crate we can make the `client_settings` module private. I also added `README` files to the newly created crates that missed them.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
