### PR TITLE
Add fido2 credential autofill view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ name = "bitwarden"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitwarden-api-api",
  "bitwarden-api-identity",
  "bitwarden-core",
@@ -497,16 +497,18 @@ name = "bitwarden-fido"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitwarden-core",
  "bitwarden-crypto",
  "bitwarden-vault",
  "chrono",
  "coset",
+ "itertools 0.13.0",
  "log",
  "p256",
  "passkey",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -570,7 +572,7 @@ dependencies = [
 name = "bitwarden-send"
 version = "0.5.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitwarden-api-api",
  "bitwarden-core",
  "bitwarden-crypto",
@@ -610,7 +612,7 @@ dependencies = [
 name = "bitwarden-vault"
 version = "0.5.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitwarden-api-api",
  "bitwarden-core",
  "bitwarden-crypto",
@@ -2150,6 +2152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,7 +2217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -27,12 +27,12 @@ chrono = { version = ">=0.4.26, <0.5", features = [
     "serde",
 ], default-features = false }
 coset = { version = "0.3.7" }
-schemars = { version = ">=0.8.9, <0.9", features = ["uuid1", "chrono"] }
 itertools = "0.13.0"
 log = ">=0.4.18, <0.5"
 p256 = { version = ">=0.13.2, <0.14" }
 passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "c48c2ddfd6b884b2d754432576c66cb2b1985a3a" }
 reqwest = { version = ">=0.12, <0.13", default-features = false }
+schemars = { version = "0.8.21", features = ["uuid1", "chrono"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
 serde_json = ">=1.0.96, <2.0"
 thiserror = ">=1.0.40, <2.0"

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -27,6 +27,8 @@ chrono = { version = ">=0.4.26, <0.5", features = [
     "serde",
 ], default-features = false }
 coset = { version = "0.3.7" }
+schemars = { version = ">=0.8.9, <0.9", features = ["uuid1", "chrono"] }
+itertools = "0.13.0"
 log = ">=0.4.18, <0.5"
 p256 = { version = ">=0.13.2, <0.14" }
 passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "c48c2ddfd6b884b2d754432576c66cb2b1985a3a" }

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -270,14 +270,15 @@ impl<'a> Fido2Authenticator<'a> {
 
         all_credentials
             .into_iter()
-            .flat_map(|cipher| {
-                cipher.get_fido2_credentials(&*enc).map(|credentials| {
+            .map(
+                |cipher| -> Result<Vec<Fido2CredentialAutofillView>, CredentialsForAutofillError> {
+                    let credentials = cipher.get_fido2_credentials(&*enc)?;
                     Fido2CredentialAutofillView::from_full_view(&cipher, &credentials)
-                })
-            })
+                        .map_err(Into::into)
+                },
+            )
             .flatten_ok()
-            .collect::<Result<_, _>>()
-            .map_err(|e| e.into())
+            .collect()
     }
 
     pub(super) fn get_authenticator(

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use bitwarden_core::VaultLocked;
 use bitwarden_crypto::{CryptoError, KeyContainer, KeyEncryptable};
-use bitwarden_vault::{CipherError, CipherView, Fido2CredentialView};
+use bitwarden_vault::{CipherError, CipherView};
 use itertools::Itertools;
 use log::error;
 use passkey::{
@@ -72,6 +72,8 @@ pub enum SilentlyDiscoverCredentialsError {
     CipherError(#[from] CipherError),
     #[error(transparent)]
     VaultLocked(#[from] VaultLocked),
+    #[error(transparent)]
+    InvalidGuid(#[from] InvalidGuid),
     #[error(transparent)]
     Fido2CallbackError(#[from] Fido2CallbackError),
 }
@@ -251,16 +253,21 @@ impl<'a> Fido2Authenticator<'a> {
     pub async fn silently_discover_credentials(
         &mut self,
         rp_id: String,
-    ) -> Result<Vec<Fido2CredentialView>, SilentlyDiscoverCredentialsError> {
+    ) -> Result<Vec<Fido2CredentialAutofillView>, SilentlyDiscoverCredentialsError> {
         let enc = self.client.get_encryption_settings()?;
         let result = self.credential_store.find_credentials(None, rp_id).await?;
 
         result
             .into_iter()
-            .map(|c| c.decrypt_fido2_credentials(&*enc))
+            .map(
+                |cipher| -> Result<Vec<Fido2CredentialAutofillView>, SilentlyDiscoverCredentialsError> {
+                    let credentials = cipher.decrypt_fido2_credentials(&*enc)?;
+                    Fido2CredentialAutofillView::from_view(&cipher, &credentials)
+                        .map_err(Into::into)
+                },
+            )
             .flatten_ok()
-            .collect::<Result<_, _>>()
-            .map_err(Into::into)
+            .collect()
     }
 
     /// Returns all Fido2 credentials that can be used for autofill, in a view
@@ -275,8 +282,8 @@ impl<'a> Fido2Authenticator<'a> {
             .into_iter()
             .map(
                 |cipher| -> Result<Vec<Fido2CredentialAutofillView>, CredentialsForAutofillError> {
-                    let credentials = cipher.get_fido2_credentials(&*enc)?;
-                    Fido2CredentialAutofillView::from_full_view(&cipher, &credentials)
+                    let credentials = cipher.decrypt_fido2_credentials(&*enc)?;
+                    Fido2CredentialAutofillView::from_view(&cipher, &credentials)
                         .map_err(Into::into)
                 },
             )

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -69,6 +69,8 @@ pub enum GetAssertionError {
 #[derive(Debug, Error)]
 pub enum SilentlyDiscoverCredentialsError {
     #[error(transparent)]
+    CipherError(#[from] CipherError),
+    #[error(transparent)]
     VaultLocked(#[from] VaultLocked),
     #[error(transparent)]
     Fido2CallbackError(#[from] Fido2CallbackError),
@@ -253,11 +255,12 @@ impl<'a> Fido2Authenticator<'a> {
         let enc = self.client.get_encryption_settings()?;
         let result = self.credential_store.find_credentials(None, rp_id).await?;
 
-        Ok(result
+        result
             .into_iter()
-            .flat_map(|c| c.decrypt_fido2_credentials(&*enc))
-            .flatten()
-            .collect())
+            .map(|c| c.decrypt_fido2_credentials(&*enc))
+            .flatten_ok()
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)
     }
 
     /// Returns all Fido2 credentials that can be used for autofill, in a view

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use bitwarden_core::VaultLocked;
 use bitwarden_crypto::{CryptoError, KeyContainer, KeyEncryptable};
 use bitwarden_vault::{CipherError, CipherView, Fido2CredentialView};
+use itertools::Itertools;
 use log::error;
 use passkey::{
     authenticator::{Authenticator, DiscoverabilitySupport, StoreInfo, UIHint, UserCheck},
@@ -69,6 +70,18 @@ pub enum GetAssertionError {
 pub enum SilentlyDiscoverCredentialsError {
     #[error(transparent)]
     VaultLocked(#[from] VaultLocked),
+    #[error(transparent)]
+    Fido2CallbackError(#[from] Fido2CallbackError),
+}
+
+#[derive(Debug, Error)]
+pub enum CredentialsForAutofillError {
+    #[error(transparent)]
+    CipherError(#[from] CipherError),
+    #[error(transparent)]
+    VaultLocked(#[from] VaultLocked),
+    #[error(transparent)]
+    InvalidGuid(#[from] InvalidGuid),
     #[error(transparent)]
     Fido2CallbackError(#[from] Fido2CallbackError),
 }
@@ -245,6 +258,26 @@ impl<'a> Fido2Authenticator<'a> {
             .flat_map(|c| c.decrypt_fido2_credentials(&*enc))
             .flatten()
             .collect())
+    }
+
+    /// Returns all Fido2 credentials that can be used for autofill, in a view
+    /// tailored for integration with OS autofill systems.
+    pub async fn credentials_for_autofill(
+        &mut self,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, CredentialsForAutofillError> {
+        let enc = self.client.get_encryption_settings()?;
+        let all_credentials = self.credential_store.all_credentials().await?;
+
+        all_credentials
+            .into_iter()
+            .flat_map(|cipher| {
+                cipher.get_fido2_credentials(&*enc).map(|credentials| {
+                    Fido2CredentialAutofillView::from_full_view(&cipher, &credentials)
+                })
+            })
+            .flatten_ok()
+            .collect::<Result<_, _>>()
+            .map_err(|e| e.into())
     }
 
     pub(super) fn get_authenticator(

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -8,6 +8,8 @@ use passkey::types::{ctap2::Aaguid, Passkey};
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
+#[cfg(feature = "uniffi")]
+mod uniffi_support;
 
 mod authenticator;
 mod client;

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -29,8 +29,8 @@ pub use traits::{
 };
 pub use types::{
     AuthenticatorAssertionResponse, AuthenticatorAttestationResponse, ClientData,
-    GetAssertionRequest, GetAssertionResult, MakeCredentialRequest, MakeCredentialResult, Options,
-    PublicKeyCredentialAuthenticatorAssertionResponse,
+    Fido2CredentialAutofillView, GetAssertionRequest, GetAssertionResult, MakeCredentialRequest,
+    MakeCredentialResult, Options, PublicKeyCredentialAuthenticatorAssertionResponse,
     PublicKeyCredentialAuthenticatorAttestationResponse, PublicKeyCredentialRpEntity,
     PublicKeyCredentialUserEntity,
 };

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -17,8 +17,8 @@ mod crypto;
 mod traits;
 mod types;
 pub use authenticator::{
-    Fido2Authenticator, FidoEncryptionSettingStore, GetAssertionError, MakeCredentialError,
-    SilentlyDiscoverCredentialsError,
+    CredentialsForAutofillError, Fido2Authenticator, FidoEncryptionSettingStore, GetAssertionError,
+    MakeCredentialError, SilentlyDiscoverCredentialsError,
 };
 pub use client::{Fido2Client, Fido2ClientError};
 pub use passkey::authenticator::UIHint;
@@ -29,8 +29,9 @@ pub use traits::{
 };
 pub use types::{
     AuthenticatorAssertionResponse, AuthenticatorAttestationResponse, ClientData,
-    Fido2CredentialAutofillView, GetAssertionRequest, GetAssertionResult, MakeCredentialRequest,
-    MakeCredentialResult, Options, PublicKeyCredentialAuthenticatorAssertionResponse,
+    Fido2CredentialAutofillView, Fido2CredentialAutofillViewError, GetAssertionRequest,
+    GetAssertionResult, MakeCredentialRequest, MakeCredentialResult, Options,
+    PublicKeyCredentialAuthenticatorAssertionResponse,
     PublicKeyCredentialAuthenticatorAttestationResponse, PublicKeyCredentialRpEntity,
     PublicKeyCredentialUserEntity,
 };

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -41,6 +41,8 @@ pub trait Fido2CredentialStore: Send + Sync {
         rip_id: String,
     ) -> Result<Vec<CipherView>, Fido2CallbackError>;
 
+    async fn all_credentials(&self) -> Result<Vec<CipherView>, Fido2CallbackError>;
+
     async fn save_credential(&self, cred: Cipher) -> Result<(), Fido2CallbackError>;
 }
 

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -29,7 +29,7 @@ trait NoneWhitespace {
 impl NoneWhitespace for String {
     fn none_whitespace(&self) -> Option<String> {
         match self.trim() {
-            s if s.is_empty() => None,
+            "" => None,
             s => Some(s.to_owned()),
         }
     }

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -16,7 +16,7 @@ pub struct Fido2CredentialAutofillView {
     pub credential_id: Vec<u8>,
     pub cipher_id: uuid::Uuid,
     pub rp_id: String,
-    pub user_name: Option<String>,
+    pub user_name_for_ui: Option<String>,
     pub user_handle: Vec<u8>,
 }
 
@@ -56,7 +56,7 @@ impl Fido2CredentialAutofillView {
                         .expect("cipher must be saved to server for autofill"),
                     rp_id: c.rp_id.clone(),
                     user_handle: c.user_handle.clone().unwrap(),
-                    user_name: c
+                    user_name_for_ui: c
                         .user_name
                         .none_whitespace()
                         .or(c.user_display_name.none_whitespace())

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -59,20 +59,21 @@ impl Fido2CredentialAutofillView {
 
         credentials
             .into_iter()
-            .filter(|c| c.user_handle.is_some())
-            .map(|c| -> Result<_, Fido2CredentialAutofillViewError> {
-                Ok(Fido2CredentialAutofillView {
-                    credential_id: string_to_guid_bytes(&c.credential_id)?,
-                    cipher_id: cipher
-                        .id
-                        .expect("cipher must be saved to server for autofill"),
-                    rp_id: c.rp_id.clone(),
-                    user_handle: c.user_handle.clone().unwrap(),
-                    user_name_for_ui: c
-                        .user_name
-                        .none_whitespace()
-                        .or(c.user_display_name.none_whitespace())
-                        .or(cipher.name.none_whitespace()),
+            .filter_map(|c| -> Option<Result<_, Fido2CredentialAutofillViewError>> {
+                c.user_handle.map(|user_handle| {
+                    Ok(Fido2CredentialAutofillView {
+                        credential_id: string_to_guid_bytes(&c.credential_id)?,
+                        cipher_id: cipher
+                            .id
+                            .expect("cipher must be saved to server for autofill"),
+                        rp_id: c.rp_id.clone(),
+                        user_handle,
+                        user_name_for_ui: c
+                            .user_name
+                            .none_whitespace()
+                            .or(c.user_display_name.none_whitespace())
+                            .or(cipher.name.none_whitespace()),
+                    })
                 })
             })
             .collect()

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -43,6 +43,11 @@ impl NoneWhitespace for Option<String> {
 
 #[derive(Debug, Error)]
 pub enum Fido2CredentialAutofillViewError {
+    #[error(
+        "Autofill credentials can only be created from existing ciphers that have a cipher id"
+    )]
+    MissingCipherId,
+
     #[error(transparent)]
     InvalidGuid(#[from] InvalidGuid),
 
@@ -65,7 +70,7 @@ impl Fido2CredentialAutofillView {
                         credential_id: string_to_guid_bytes(&c.credential_id)?,
                         cipher_id: cipher
                             .id
-                            .expect("cipher must be saved to server for autofill"),
+                            .ok_or(Fido2CredentialAutofillViewError::MissingCipherId)?,
                         rp_id: c.rp_id.clone(),
                         user_handle,
                         user_name_for_ui: c

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,4 +1,5 @@
-use bitwarden_vault::{CipherView, Fido2CredentialView};
+use bitwarden_crypto::KeyContainer;
+use bitwarden_vault::{CipherError, CipherView};
 use passkey::types::webauthn::UserVerificationRequirement;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -40,15 +41,26 @@ impl NoneWhitespace for Option<String> {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum Fido2CredentialAutofillViewError {
+    #[error(transparent)]
+    InvalidGuid(#[from] InvalidGuid),
+
+    #[error(transparent)]
+    CipherError(#[from] CipherError),
+}
+
 impl Fido2CredentialAutofillView {
-    pub fn from_view(
+    pub fn from_cipher_view(
         cipher: &CipherView,
-        credentials: &Vec<Fido2CredentialView>,
-    ) -> Result<Vec<Fido2CredentialAutofillView>, InvalidGuid> {
+        enc: &dyn KeyContainer,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, Fido2CredentialAutofillViewError> {
+        let credentials = cipher.decrypt_fido2_credentials(enc)?;
+
         credentials
             .into_iter()
             .filter(|c| c.user_handle.is_some())
-            .map(|c| -> Result<_, InvalidGuid> {
+            .map(|c| -> Result<_, Fido2CredentialAutofillViewError> {
                 Ok(Fido2CredentialAutofillView {
                     credential_id: string_to_guid_bytes(&c.credential_id)?,
                     cipher_id: cipher

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,4 +1,4 @@
-use bitwarden_vault::{CipherView, Fido2CredentialFullView};
+use bitwarden_vault::{CipherView, Fido2CredentialView};
 use passkey::types::webauthn::UserVerificationRequirement;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -41,9 +41,9 @@ impl NoneWhitespace for Option<String> {
 }
 
 impl Fido2CredentialAutofillView {
-    pub fn from_full_view(
+    pub fn from_view(
         cipher: &CipherView,
-        credentials: &Vec<Fido2CredentialFullView>,
+        credentials: &Vec<Fido2CredentialView>,
     ) -> Result<Vec<Fido2CredentialAutofillView>, InvalidGuid> {
         credentials
             .into_iter()

--- a/crates/bitwarden-fido/src/uniffi_support.rs
+++ b/crates/bitwarden-fido/src/uniffi_support.rs
@@ -1,0 +1,3 @@
+use uuid::Uuid;
+
+uniffi::ffi_converter_forward!(Uuid, bitwarden_core::UniFfiTag, crate::UniFfiTag);

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -54,7 +54,7 @@ impl ClientFido2 {
             .platform()
             .fido2()
             .decrypt_fido2_autofill_credentials(cipher_view)
-            .map_err(|e| Error::DecryptFido2AutofillCredentialsError(e))?;
+            .map_err(Error::DecryptFido2AutofillCredentialsError)?;
 
         Ok(result)
     }

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -216,6 +216,8 @@ pub trait Fido2CredentialStore: Send + Sync {
         rip_id: String,
     ) -> Result<Vec<CipherView>, Fido2CallbackError>;
 
+    async fn all_credentials(&self) -> Result<Vec<CipherView>, Fido2CallbackError>;
+
     async fn save_credential(&self, cred: Cipher) -> Result<(), Fido2CallbackError>;
 }
 
@@ -238,6 +240,10 @@ impl bitwarden::platform::fido2::Fido2CredentialStore
             .find_credentials(ids, rip_id)
             .await
             .map_err(Into::into)
+    }
+
+    async fn all_credentials(&self) -> Result<Vec<CipherView>, BitFido2CallbackError> {
+        self.0.all_credentials().await.map_err(Into::into)
     }
 
     async fn save_credential(&self, cred: Cipher) -> Result<(), BitFido2CallbackError> {

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -43,6 +43,21 @@ impl ClientFido2 {
             credential_store,
         )))
     }
+
+    pub fn decrypt_fido2_autofill_credentials(
+        self: Arc<Self>,
+        cipher_view: CipherView,
+    ) -> Result<Vec<Fido2CredentialAutofillView>> {
+        let result = self
+            .0
+             .0
+            .platform()
+            .fido2()
+            .decrypt_fido2_autofill_credentials(cipher_view)
+            .map_err(|e| Error::DecryptFido2AutofillCredentialsError(e))?;
+
+        Ok(result)
+    }
 }
 
 #[derive(uniffi::Object)]
@@ -99,6 +114,20 @@ impl ClientFido2Authenticator {
             .silently_discover_credentials(rp_id)
             .await
             .map_err(Error::SilentlyDiscoverCredentials)?;
+        Ok(result)
+    }
+
+    pub async fn credentials_for_autofill(&self) -> Result<Vec<Fido2CredentialAutofillView>> {
+        let platform = self.0 .0.platform();
+        let fido2 = platform.fido2();
+        let ui = UniffiTraitBridge(self.1.as_ref());
+        let cs = UniffiTraitBridge(self.2.as_ref());
+        let mut auth = fido2.create_authenticator(&ui, &cs);
+
+        let result = auth
+            .credentials_for_autofill()
+            .await
+            .map_err(Error::CredentialsForAutofillError)?;
         Ok(result)
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -4,12 +4,13 @@ use bitwarden::{
     error::Error,
     platform::fido2::{
         CheckUserOptions, ClientData, Fido2CallbackError as BitFido2CallbackError,
-        GetAssertionRequest, GetAssertionResult, MakeCredentialRequest, MakeCredentialResult,
+        Fido2CredentialAutofillView, GetAssertionRequest, GetAssertionResult,
+        MakeCredentialRequest, MakeCredentialResult,
         PublicKeyCredentialAuthenticatorAssertionResponse,
         PublicKeyCredentialAuthenticatorAttestationResponse, PublicKeyCredentialRpEntity,
         PublicKeyCredentialUserEntity,
     },
-    vault::{Cipher, CipherView, Fido2CredentialNewView, Fido2CredentialView},
+    vault::{Cipher, CipherView, Fido2CredentialNewView},
 };
 
 use crate::{error::Result, Client};
@@ -87,7 +88,7 @@ impl ClientFido2Authenticator {
     pub async fn silently_discover_credentials(
         &self,
         rp_id: String,
-    ) -> Result<Vec<Fido2CredentialView>> {
+    ) -> Result<Vec<Fido2CredentialAutofillView>> {
         let platform = self.0 .0.platform();
         let fido2 = platform.fido2();
         let ui = UniffiTraitBridge(self.1.as_ref());

--- a/crates/bitwarden/src/error.rs
+++ b/crates/bitwarden/src/error.rs
@@ -96,6 +96,14 @@ pub enum Error {
     SilentlyDiscoverCredentials(#[from] bitwarden_fido::SilentlyDiscoverCredentialsError),
     #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error(transparent)]
+    CredentialsForAutofillError(#[from] bitwarden_fido::CredentialsForAutofillError),
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
+    #[error(transparent)]
+    DecryptFido2AutofillCredentialsError(
+        #[from] crate::platform::fido2::DecryptFido2AutofillCredentialsError,
+    ),
+    #[cfg(all(feature = "uniffi", feature = "internal"))]
+    #[error(transparent)]
     Fido2Client(#[from] bitwarden_fido::Fido2ClientError),
     #[cfg(all(feature = "uniffi", feature = "internal"))]
     #[error("Fido2 Callback error: {0:?}")]

--- a/crates/bitwarden/src/platform/client_fido.rs
+++ b/crates/bitwarden/src/platform/client_fido.rs
@@ -1,15 +1,25 @@
 use std::sync::Arc;
 
 use bitwarden_fido::{
-    Fido2Authenticator, Fido2Client, Fido2CredentialStore, Fido2UserInterface,
-    FidoEncryptionSettingStore,
+    Fido2Authenticator, Fido2Client, Fido2CredentialAutofillView, Fido2CredentialStore,
+    Fido2UserInterface, FidoEncryptionSettingStore,
 };
+use bitwarden_vault::CipherView;
+use thiserror::Error;
 
 use crate::Client;
 
 pub struct ClientFido2<'a> {
     #[allow(dead_code)]
     pub(crate) client: &'a Client,
+}
+
+#[derive(Debug, Error)]
+pub enum DecryptFido2AutofillCredentialsError {
+    #[error(transparent)]
+    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    #[error(transparent)]
+    Fido2CredentialAutofillViewError(#[from] bitwarden_fido::Fido2CredentialAutofillViewError),
 }
 
 impl FidoEncryptionSettingStore for Client {
@@ -37,5 +47,17 @@ impl<'a> ClientFido2<'a> {
         Fido2Client {
             authenticator: self.create_authenticator(user_interface, credential_store),
         }
+    }
+
+    pub fn decrypt_fido2_autofill_credentials(
+        &'a self,
+        cipher_view: CipherView,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, DecryptFido2AutofillCredentialsError> {
+        let enc = self.client.get_encryption_settings()?;
+
+        Ok(Fido2CredentialAutofillView::from_cipher_view(
+            &cipher_view,
+            &*enc,
+        )?)
     }
 }

--- a/crates/bitwarden/src/platform/mod.rs
+++ b/crates/bitwarden/src/platform/mod.rs
@@ -12,6 +12,7 @@ pub use secret_verification_request::SecretVerificationRequest;
 
 #[cfg(feature = "uniffi")]
 pub mod fido2 {
-    pub use super::client_fido::DecryptFido2AutofillCredentialsError;
     pub use bitwarden_fido::*;
+
+    pub use super::client_fido::DecryptFido2AutofillCredentialsError;
 }

--- a/crates/bitwarden/src/platform/mod.rs
+++ b/crates/bitwarden/src/platform/mod.rs
@@ -12,5 +12,6 @@ pub use secret_verification_request::SecretVerificationRequest;
 
 #[cfg(feature = "uniffi")]
 pub mod fido2 {
+    pub use super::client_fido::DecryptFido2AutofillCredentialsError;
     pub use bitwarden_fido::*;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR adds a function on the Fido2 authenticator which returns all available credentials as a View tailored specifically for integrating with OS-level autofill APIs

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
