### PR TITLE
[PM-9498] let user check and pick credential for creation return user check

### DIFF
--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -15,7 +15,7 @@ use passkey::{
 use thiserror::Error;
 
 use super::{
-    try_from_credential_new_view, types::*, CheckUserOptions, CheckUserResult, CipherViewContainer,
+    try_from_credential_new_view, types::*, CheckUserOptions, CipherViewContainer,
     Fido2CredentialStore, Fido2UserInterface, SelectedCredential, UnknownEnum, AAGUID,
 };
 use crate::{
@@ -613,7 +613,7 @@ impl passkey::authenticator::UserValidationMethod for UserValidationMethodImpl<'
                 let new_credential = try_from_credential_new_view(user, rp)
                     .map_err(|_| Ctap2Error::InvalidCredential)?;
 
-                let cipher_view = self
+                let (cipher_view, user_check) = self
                     .authenticator
                     .user_interface
                     .check_user_and_pick_credential_for_creation(options, new_credential)
@@ -626,10 +626,7 @@ impl passkey::authenticator::UserValidationMethod for UserValidationMethodImpl<'
                     .expect("Mutex is not poisoned")
                     .replace(cipher_view);
 
-                Ok(CheckUserResult {
-                    user_present: true,
-                    user_verified: verification != UV::Discouraged,
-                })
+                Ok(user_check)
             }
             _ => {
                 self.authenticator

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -29,7 +29,7 @@ pub trait Fido2UserInterface: Send + Sync {
         &self,
         options: CheckUserOptions,
         new_credential: Fido2CredentialNewView,
-    ) -> Result<CipherView, Fido2CallbackError>;
+    ) -> Result<(CipherView, CheckUserResult), Fido2CallbackError>;
     async fn is_verification_enabled(&self) -> bool;
 }
 

--- a/languages/swift/iOS/App/ContentView.swift
+++ b/languages/swift/iOS/App/ContentView.swift
@@ -400,7 +400,7 @@ class Fido2UserInterfaceImpl: Fido2UserInterface {
         abort()
     }
 
-    func checkUserAndPickCredentialForCreation(options: BitwardenSdk.CheckUserOptions, newCredential: BitwardenSdk.Fido2CredentialNewView) async throws -> BitwardenSdk.CipherViewWrapper {
+    func checkUserAndPickCredentialForCreation(options: BitwardenSdk.CheckUserOptions, newCredential: BitwardenSdk.Fido2CredentialNewView) async throws -> BitwardenSdk.CheckUserAndPickCredentialForCreationResult {
         abort()
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

`check_user_and_pick_credential_for_creation` needs to return the result of the `check_user` part of the function

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
