### PR TITLE
[PM-9499] fix passkey-rs and sdk not returning cbor encoded attestation object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "hmac",
  "log",
  "p256",
- "passkey 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey",
  "rand",
  "rand_chacha",
  "reqwest",
@@ -522,7 +522,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "p256",
- "passkey 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey",
  "reqwest",
  "schemars",
  "serde",
@@ -2596,21 +2596,10 @@ name = "passkey"
 version = "0.3.1"
 source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
 dependencies = [
- "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "passkey-client 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "passkey-transports 0.1.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
-]
-
-[[package]]
-name = "passkey"
-version = "0.3.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
-dependencies = [
- "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "passkey-client 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "passkey-transports 0.1.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-authenticator",
+ "passkey-client",
+ "passkey-transports",
+ "passkey-types",
 ]
 
 [[package]]
@@ -2622,20 +2611,7 @@ dependencies = [
  "coset",
  "log",
  "p256",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "rand",
-]
-
-[[package]]
-name = "passkey-authenticator"
-version = "0.3.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
-dependencies = [
- "async-trait",
- "coset",
- "log",
- "p256",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-types",
  "rand",
 ]
 
@@ -2647,28 +2623,11 @@ dependencies = [
  "ciborium",
  "coset",
  "idna",
- "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
- "public-suffix 0.1.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey-authenticator",
+ "passkey-types",
+ "public-suffix",
  "serde",
  "serde_json",
- "url",
-]
-
-[[package]]
-name = "passkey-client"
-version = "0.3.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
-dependencies = [
- "ciborium",
- "coset",
- "idna",
- "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "public-suffix 0.1.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
- "serde",
- "serde_json",
- "typeshare",
  "url",
 ]
 
@@ -2676,11 +2635,6 @@ dependencies = [
 name = "passkey-transports"
 version = "0.1.0"
 source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
-
-[[package]]
-name = "passkey-transports"
-version = "0.1.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
 
 [[package]]
 name = "passkey-types"
@@ -2698,25 +2652,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "strum 0.25.0",
-]
-
-[[package]]
-name = "passkey-types"
-version = "0.2.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
-dependencies = [
- "bitflags 2.6.0",
- "ciborium",
- "coset",
- "data-encoding",
- "getrandom",
- "indexmap 2.2.6",
- "rand",
- "serde",
- "serde_json",
- "sha2",
- "strum 0.25.0",
- "typeshare",
 ]
 
 [[package]]
@@ -2916,11 +2851,6 @@ dependencies = [
 name = "public-suffix"
 version = "0.1.1"
 source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
-
-[[package]]
-name = "public-suffix"
-version = "0.1.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
 
 [[package]]
 name = "pyo3"
@@ -4195,28 +4125,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "typeshare"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f17399b76c2e743d58eac0635d7686e9c00f48cd4776f00695d9882a7d3187"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "typeshare-annotation",
-]
-
-[[package]]
-name = "typeshare-annotation"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "hmac",
  "log",
  "p256",
- "passkey",
+ "passkey 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
  "rand",
  "rand_chacha",
  "reqwest",
@@ -522,7 +522,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "p256",
- "passkey",
+ "passkey 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
  "reqwest",
  "schemars",
  "serde",
@@ -2594,12 +2594,36 @@ dependencies = [
 [[package]]
 name = "passkey"
 version = "0.3.1"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
+dependencies = [
+ "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey-client 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey-transports 0.1.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+]
+
+[[package]]
+name = "passkey"
+version = "0.3.1"
 source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
 dependencies = [
- "passkey-authenticator",
- "passkey-client",
- "passkey-transports",
- "passkey-types",
+ "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-client 0.3.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-transports 0.1.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+]
+
+[[package]]
+name = "passkey-authenticator"
+version = "0.3.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
+dependencies = [
+ "async-trait",
+ "coset",
+ "log",
+ "p256",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "rand",
 ]
 
 [[package]]
@@ -2611,8 +2635,24 @@ dependencies = [
  "coset",
  "log",
  "p256",
- "passkey-types",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
  "rand",
+]
+
+[[package]]
+name = "passkey-client"
+version = "0.3.1"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
+dependencies = [
+ "ciborium",
+ "coset",
+ "idna",
+ "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "public-suffix 0.1.1 (git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27)",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -2623,9 +2663,9 @@ dependencies = [
  "ciborium",
  "coset",
  "idna",
- "passkey-authenticator",
- "passkey-types",
- "public-suffix",
+ "passkey-authenticator 0.3.0 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "passkey-types 0.2.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
+ "public-suffix 0.1.1 (git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a)",
  "serde",
  "serde_json",
  "typeshare",
@@ -2635,7 +2675,30 @@ dependencies = [
 [[package]]
 name = "passkey-transports"
 version = "0.1.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
+
+[[package]]
+name = "passkey-transports"
+version = "0.1.0"
 source = "git+https://github.com/bitwarden/passkey-rs?rev=c48c2ddfd6b884b2d754432576c66cb2b1985a3a#c48c2ddfd6b884b2d754432576c66cb2b1985a3a"
+
+[[package]]
+name = "passkey-types"
+version = "0.2.1"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
+dependencies = [
+ "bitflags 2.6.0",
+ "ciborium",
+ "coset",
+ "data-encoding",
+ "getrandom",
+ "indexmap 2.2.6",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "strum 0.25.0",
+]
 
 [[package]]
 name = "passkey-types"
@@ -2848,6 +2911,11 @@ checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "public-suffix"
+version = "0.1.1"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=ae08e2cb7dd3d44d915caed395c0cdc56b50fa27#ae08e2cb7dd3d44d915caed395c0cdc56b50fa27"
 
 [[package]]
 name = "public-suffix"

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -44,7 +44,7 @@ getrandom = { version = ">=0.2.9, <0.3", features = ["js"] }
 hmac = ">=0.12.1, <0.13"
 log = ">=0.4.18, <0.5"
 p256 = { version = ">=0.13.2, <0.14", optional = true }
-passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "c48c2ddfd6b884b2d754432576c66cb2b1985a3a", optional = true }
+passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "ae08e2cb7dd3d44d915caed395c0cdc56b50fa27", optional = true }
 rand = ">=0.8.5, <0.9"
 reqwest = { version = ">=0.12.5, <0.13", features = [
     "http2",

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -30,7 +30,7 @@ coset = { version = "0.3.7" }
 itertools = "0.13.0"
 log = ">=0.4.18, <0.5"
 p256 = { version = ">=0.13.2, <0.14" }
-passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "c48c2ddfd6b884b2d754432576c66cb2b1985a3a" }
+passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "ae08e2cb7dd3d44d915caed395c0cdc56b50fa27" }
 reqwest = { version = ">=0.12.5, <0.13", default-features = false }
 schemars = { version = "0.8.21", features = ["uuid1", "chrono"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -170,6 +170,7 @@ impl<'a> Fido2Authenticator<'a> {
             Err(e) => return Err(MakeCredentialError::Other(format!("{e:?}"))),
         };
 
+        let attestation_object = response.as_bytes().to_vec();
         let authenticator_data = response.auth_data.to_vec();
         let attested_credential_data = response
             .auth_data
@@ -179,7 +180,7 @@ impl<'a> Fido2Authenticator<'a> {
 
         Ok(MakeCredentialResult {
             authenticator_data,
-            attested_credential_data: attested_credential_data.into_iter().collect(),
+            attestation_object,
             credential_id,
         })
     }

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -176,7 +176,7 @@ pub struct MakeCredentialRequest {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialResult {
     pub authenticator_data: Vec<u8>,
-    pub attested_credential_data: Vec<u8>,
+    pub attestation_object: Vec<u8>,
     pub credential_id: Vec<u8>,
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Updates to the latest passkey-rs version and now correctly returns `attestation_object`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
