### PR TITLE
Return a more detailed MissingKey error from get_key()

### DIFF
--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -6,7 +6,7 @@ use bitwarden_crypto::{
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{EncString, KeyDecryptable, SymmetricCryptoKey};
 
-use crate::{error::Error, Client, VaultLocked};
+use crate::{error::Error, Client};
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthRequestResponse {
@@ -82,7 +82,7 @@ pub(crate) fn approve_auth_request(
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(public_key)?)?;
 
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let key = enc.get_key(&None)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),

--- a/crates/bitwarden-core/src/auth/client_auth.rs
+++ b/crates/bitwarden-core/src/auth/client_auth.rs
@@ -150,11 +150,9 @@ impl<'a> ClientAuth<'a> {
 
 #[cfg(feature = "internal")]
 fn trust_device(client: &Client) -> Result<TrustDeviceResponse> {
-    use crate::VaultLocked;
-
     let enc = client.internal.get_encryption_settings()?;
 
-    let user_key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let user_key = enc.get_key(&None)?;
 
     Ok(DeviceKey::trust_device(user_key)?)
 }

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -44,8 +44,6 @@ pub(crate) fn validate_password_user_key(
     password: String,
     encrypted_user_key: String,
 ) -> Result<String> {
-    use crate::VaultLocked;
-
     let login_method = client
         .internal
         .get_login_method()
@@ -61,12 +59,9 @@ pub(crate) fn validate_password_user_key(
                     .decrypt_user_key(encrypted_user_key.parse()?)
                     .map_err(|_| "wrong password")?;
 
-                let enc = client
-                    .internal
-                    .get_encryption_settings()
-                    .map_err(|_| VaultLocked)?;
+                let enc = client.internal.get_encryption_settings()?;
 
-                let existing_key = enc.get_key(&None).ok_or(VaultLocked)?;
+                let existing_key = enc.get_key(&None)?;
 
                 if user_key.to_vec() != existing_key.to_vec() {
                     return Err("wrong user key".into());

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -73,7 +73,7 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
                     if let (IdentityTokenResponse::Payload(r), Some(state_file), Ok(enc_settings)) =
                         (&result, state_file, client.get_encryption_settings())
                     {
-                        if let Some(enc_key) = enc_settings.get_key(&None) {
+                        if let Ok(enc_key) = enc_settings.get_key(&None) {
                             let state =
                                 ClientState::new(r.access_token.clone(), enc_key.to_base64());
                             _ = state::set(state_file, access_token, state);

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::client::{LoginMethod, UserLoginMethod};
 use crate::{
     error::{Error, Result},
-    Client, VaultLocked,
+    Client,
 };
 
 #[cfg(feature = "internal")]
@@ -185,7 +185,7 @@ pub async fn initialize_org_crypto(client: &Client, req: InitOrgCryptoRequest) -
 #[cfg(feature = "internal")]
 pub async fn get_user_encryption_key(client: &Client) -> Result<String> {
     let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let user_key = enc.get_key(&None)?;
 
     Ok(user_key.to_base64())
 }
@@ -203,7 +203,7 @@ pub struct UpdatePasswordResponse {
 
 pub fn update_password(client: &Client, new_password: String) -> Result<UpdatePasswordResponse> {
     let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let user_key = enc.get_key(&None)?;
 
     let login_method = client
         .internal
@@ -247,7 +247,7 @@ pub struct DerivePinKeyResponse {
 #[cfg(feature = "internal")]
 pub fn derive_pin_key(client: &Client, pin: String) -> Result<DerivePinKeyResponse> {
     let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let user_key = enc.get_key(&None)?;
 
     let login_method = client
         .internal
@@ -265,7 +265,7 @@ pub fn derive_pin_key(client: &Client, pin: String) -> Result<DerivePinKeyRespon
 #[cfg(feature = "internal")]
 pub fn derive_pin_user_key(client: &Client, encrypted_pin: EncString) -> Result<EncString> {
     let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let user_key = enc.get_key(&None)?;
 
     let pin: String = encrypted_pin.decrypt_with_key(user_key)?;
     let login_method = client
@@ -306,7 +306,7 @@ pub(super) fn enroll_admin_password_reset(
 
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(public_key)?)?;
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let key = enc.get_key(&None)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use thiserror::Error;
+use uuid::Uuid;
 
 use crate::fingerprint::FingerprintError;
 
@@ -16,8 +17,8 @@ pub enum CryptoError {
     InvalidKeyLen,
     #[error("The value is not a valid UTF8 String")]
     InvalidUtf8String,
-    #[error("Missing Key")]
-    MissingKey,
+    #[error("Missing Key for organization with ID {0}")]
+    MissingKey(Uuid),
 
     #[error("EncString error, {0}")]
     EncString(#[from] EncStringParseError),

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -3,14 +3,14 @@ use std::{collections::HashMap, hash::Hash, sync::Arc};
 use rayon::prelude::*;
 use uuid::Uuid;
 
-use crate::{error::Result, SymmetricCryptoKey};
+use crate::{error::Result, CryptoError, SymmetricCryptoKey};
 
 pub trait KeyContainer: Send + Sync {
-    fn get_key(&self, org_id: &Option<Uuid>) -> Option<&SymmetricCryptoKey>;
+    fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError>;
 }
 
 impl<T: KeyContainer> KeyContainer for Arc<T> {
-    fn get_key(&self, org_id: &Option<Uuid>) -> Option<&SymmetricCryptoKey> {
+    fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError> {
         self.as_ref().get_key(org_id)
     }
 }
@@ -20,7 +20,7 @@ pub trait LocateKey {
         &self,
         enc: &'a dyn KeyContainer,
         org_id: &Option<Uuid>,
-    ) -> Option<&'a SymmetricCryptoKey> {
+    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
         enc.get_key(org_id)
     }
 }

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -1,4 +1,4 @@
-use bitwarden_core::{Client, VaultLocked};
+use bitwarden_core::Client;
 use bitwarden_crypto::KeyDecryptable;
 use bitwarden_vault::{Cipher, CipherView, Collection, Folder, FolderView};
 
@@ -14,7 +14,7 @@ pub(crate) fn export_vault(
     format: ExportFormat,
 ) -> Result<String, ExportError> {
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None).ok_or(VaultLocked)?;
+    let key = enc.get_key(&None)?;
 
     let folders: Vec<FolderView> = folders.decrypt_with_key(key)?;
     let folders: Vec<crate::Folder> = folders.into_iter().flat_map(|f| f.try_into()).collect();

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -483,7 +483,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .replace(selected.clone());
 
             // Encrypt the updated cipher before sending it to the clients to be stored
-            let key = enc.get_key(&selected.organization_id).ok_or(VaultLocked)?;
+            let key = enc.get_key(&selected.organization_id)?;
             let encrypted = selected.encrypt_with_key(key)?;
 
             this.authenticator
@@ -557,7 +557,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .replace(selected.clone());
 
             // Encrypt the updated cipher before sending it to the clients to be stored
-            let key = enc.get_key(&selected.organization_id).ok_or(VaultLocked)?;
+            let key = enc.get_key(&selected.organization_id)?;
             let encrypted = selected.encrypt_with_key(key)?;
 
             this.authenticator

--- a/crates/bitwarden-send/src/client_sends.rs
+++ b/crates/bitwarden-send/src/client_sends.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use bitwarden_core::{Client, Error, VaultLocked};
+use bitwarden_core::{Client, Error};
 use bitwarden_crypto::{EncString, KeyDecryptable, KeyEncryptable};
 
 use crate::{Send, SendListView, SendView};
@@ -16,7 +16,7 @@ impl<'a> ClientSends<'a> {
 
     pub fn decrypt(&self, send: Send) -> Result<SendView, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(VaultLocked)?;
+        let key = enc.get_key(&None)?;
 
         let send_view = send.decrypt_with_key(key)?;
 
@@ -25,7 +25,7 @@ impl<'a> ClientSends<'a> {
 
     pub fn decrypt_list(&self, sends: Vec<Send>) -> Result<Vec<SendListView>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(VaultLocked)?;
+        let key = enc.get_key(&None)?;
 
         let send_views = sends.decrypt_with_key(key)?;
 
@@ -46,7 +46,7 @@ impl<'a> ClientSends<'a> {
 
     pub fn decrypt_buffer(&self, send: Send, encrypted_buffer: &[u8]) -> Result<Vec<u8>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(VaultLocked)?;
+        let key = enc.get_key(&None)?;
         let key = Send::get_key(&send.key, key)?;
 
         let buf = EncString::from_buffer(encrypted_buffer)?;
@@ -55,7 +55,7 @@ impl<'a> ClientSends<'a> {
 
     pub fn encrypt(&self, send_view: SendView) -> Result<Send, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(VaultLocked)?;
+        let key = enc.get_key(&None)?;
 
         let send = send_view.encrypt_with_key(key)?;
 
@@ -76,7 +76,7 @@ impl<'a> ClientSends<'a> {
 
     pub fn encrypt_buffer(&self, send: Send, buffer: &[u8]) -> Result<Vec<u8>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(VaultLocked)?;
+        let key = enc.get_key(&None)?;
         let key = Send::get_key(&send.key, key)?;
 
         let encrypted = buffer.encrypt_with_key(&key)?;

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -375,8 +375,13 @@ mod tests {
         }
     }
     impl KeyContainer for MockKeyContainer {
-        fn get_key<'a>(&'a self, org_id: &Option<Uuid>) -> Option<&'a SymmetricCryptoKey> {
-            self.0.get(org_id)
+        fn get_key<'a>(
+            &'a self,
+            org_id: &Option<Uuid>,
+        ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
+            self.0
+                .get(org_id)
+                .ok_or(CryptoError::MissingKey(org_id.unwrap_or_default()))
         }
     }
 

--- a/crates/bitwarden-sm/src/projects/create.rs
+++ b/crates/bitwarden-sm/src/projects/create.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::ProjectCreateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error, VaultLocked};
+use bitwarden_core::{validate_only_whitespaces, Client, Error};
 use bitwarden_crypto::KeyEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,9 +24,7 @@ pub(crate) async fn create_project(
     input.validate()?;
 
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc
-        .get_key(&Some(input.organization_id))
-        .ok_or(VaultLocked)?;
+    let key = enc.get_key(&Some(input.organization_id))?;
 
     let project = Some(ProjectCreateRequestModel {
         name: input.name.clone().trim().encrypt_with_key(key)?.to_string(),

--- a/crates/bitwarden-sm/src/projects/project_response.rs
+++ b/crates/bitwarden-sm/src/projects/project_response.rs
@@ -1,6 +1,6 @@
 use bitwarden_api_api::models::ProjectResponseModel;
 use bitwarden_core::{client::encryption_settings::EncryptionSettings, require, Error};
-use bitwarden_crypto::{CryptoError, EncString, KeyDecryptable};
+use bitwarden_crypto::{EncString, KeyDecryptable};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -22,9 +22,7 @@ impl ProjectResponse {
         enc: &EncryptionSettings,
     ) -> Result<Self, Error> {
         let organization_id = require!(response.organization_id);
-        let enc_key = enc
-            .get_key(&Some(organization_id))
-            .ok_or(CryptoError::MissingKey)?;
+        let enc_key = enc.get_key(&Some(organization_id))?;
 
         let name = require!(response.name)
             .parse::<EncString>()?

--- a/crates/bitwarden-sm/src/projects/update.rs
+++ b/crates/bitwarden-sm/src/projects/update.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::ProjectUpdateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error, VaultLocked};
+use bitwarden_core::{validate_only_whitespaces, Client, Error};
 use bitwarden_crypto::KeyEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -26,9 +26,7 @@ pub(crate) async fn update_project(
     input.validate()?;
 
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc
-        .get_key(&Some(input.organization_id))
-        .ok_or(VaultLocked)?;
+    let key = enc.get_key(&Some(input.organization_id))?;
 
     let project = Some(ProjectUpdateRequestModel {
         name: input.name.clone().trim().encrypt_with_key(key)?.to_string(),

--- a/crates/bitwarden-sm/src/secrets/create.rs
+++ b/crates/bitwarden-sm/src/secrets/create.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::SecretCreateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error, VaultLocked};
+use bitwarden_core::{validate_only_whitespaces, Client, Error};
 use bitwarden_crypto::KeyEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -32,9 +32,7 @@ pub(crate) async fn create_secret(
     input.validate()?;
 
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc
-        .get_key(&Some(input.organization_id))
-        .ok_or(VaultLocked)?;
+    let key = enc.get_key(&Some(input.organization_id))?;
 
     let secret = Some(SecretCreateRequestModel {
         key: input.key.clone().trim().encrypt_with_key(key)?.to_string(),

--- a/crates/bitwarden-sm/src/secrets/list.rs
+++ b/crates/bitwarden-sm/src/secrets/list.rs
@@ -5,7 +5,7 @@ use bitwarden_core::{
     client::{encryption_settings::EncryptionSettings, Client},
     require, Error,
 };
-use bitwarden_crypto::{CryptoError, EncString, KeyDecryptable};
+use bitwarden_crypto::{EncString, KeyDecryptable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -93,9 +93,7 @@ impl SecretIdentifierResponse {
         enc: &EncryptionSettings,
     ) -> Result<SecretIdentifierResponse, Error> {
         let organization_id = require!(response.organization_id);
-        let enc_key = enc
-            .get_key(&Some(organization_id))
-            .ok_or(CryptoError::MissingKey)?;
+        let enc_key = enc.get_key(&Some(organization_id))?;
 
         let key = require!(response.key)
             .parse::<EncString>()?

--- a/crates/bitwarden-sm/src/secrets/secret_response.rs
+++ b/crates/bitwarden-sm/src/secrets/secret_response.rs
@@ -2,7 +2,7 @@ use bitwarden_api_api::models::{
     BaseSecretResponseModel, BaseSecretResponseModelListResponseModel, SecretResponseModel,
 };
 use bitwarden_core::{client::encryption_settings::EncryptionSettings, require, Error};
-use bitwarden_crypto::{CryptoError, EncString, KeyDecryptable};
+use bitwarden_crypto::{EncString, KeyDecryptable};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -46,7 +46,7 @@ impl SecretResponse {
         enc: &EncryptionSettings,
     ) -> Result<SecretResponse, Error> {
         let org_id = response.organization_id;
-        let enc_key = enc.get_key(&org_id).ok_or(CryptoError::MissingKey)?;
+        let enc_key = enc.get_key(&org_id)?;
 
         let key = require!(response.key)
             .parse::<EncString>()?

--- a/crates/bitwarden-sm/src/secrets/update.rs
+++ b/crates/bitwarden-sm/src/secrets/update.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::SecretUpdateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error, VaultLocked};
+use bitwarden_core::{validate_only_whitespaces, Client, Error};
 use bitwarden_crypto::KeyEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -31,9 +31,7 @@ pub(crate) async fn update_secret(
     input.validate()?;
 
     let enc = client.internal.get_encryption_settings()?;
-    let key = enc
-        .get_key(&Some(input.organization_id))
-        .ok_or(VaultLocked)?;
+    let key = enc.get_key(&Some(input.organization_id))?;
 
     let secret = Some(SecretUpdateRequestModel {
         key: input.key.clone().trim().encrypt_with_key(key)?.to_string(),

--- a/crates/bitwarden-vault/src/collection.rs
+++ b/crates/bitwarden-vault/src/collection.rs
@@ -42,7 +42,7 @@ impl LocateKey for Collection {
         &self,
         enc: &'a dyn KeyContainer,
         _: &Option<Uuid>,
-    ) -> Option<&'a SymmetricCryptoKey> {
+    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
         enc.get_key(&Some(self.organization_id))
     }
 }

--- a/crates/bitwarden-vault/src/mobile/client_attachments.rs
+++ b/crates/bitwarden-vault/src/mobile/client_attachments.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use bitwarden_core::{Client, Error, VaultLocked};
+use bitwarden_core::{Client, Error};
 use bitwarden_crypto::{EncString, KeyDecryptable, KeyEncryptable, LocateKey};
 
 use crate::{
@@ -20,7 +20,7 @@ impl<'a> ClientAttachments<'a> {
         buffer: &[u8],
     ) -> Result<AttachmentEncryptResult, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = cipher.locate_key(&enc, &None).ok_or(VaultLocked)?;
+        let key = cipher.locate_key(&enc, &None)?;
 
         Ok(AttachmentFileView {
             cipher,
@@ -52,7 +52,7 @@ impl<'a> ClientAttachments<'a> {
         encrypted_buffer: &[u8],
     ) -> Result<Vec<u8>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = cipher.locate_key(&enc, &None).ok_or(VaultLocked)?;
+        let key = cipher.locate_key(&enc, &None)?;
 
         AttachmentFile {
             cipher,

--- a/crates/bitwarden-vault/src/mobile/client_collection.rs
+++ b/crates/bitwarden-vault/src/mobile/client_collection.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{CryptoError, KeyDecryptable, LocateKey};
+use bitwarden_crypto::{KeyDecryptable, LocateKey};
 
 use crate::{ClientVault, Collection, CollectionView};
 
@@ -10,9 +10,7 @@ pub struct ClientCollections<'a> {
 impl<'a> ClientCollections<'a> {
     pub fn decrypt(&self, collection: Collection) -> Result<CollectionView, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = collection
-            .locate_key(&enc, &None)
-            .ok_or(CryptoError::MissingKey)?;
+        let key = collection.locate_key(&enc, &None)?;
 
         let view = collection.decrypt_with_key(key)?;
 
@@ -25,7 +23,7 @@ impl<'a> ClientCollections<'a> {
         let views: Result<Vec<CollectionView>, _> = collections
             .iter()
             .map(|c| -> Result<CollectionView, _> {
-                let key = c.locate_key(&enc, &None).ok_or(CryptoError::MissingKey)?;
+                let key = c.locate_key(&enc, &None)?;
                 Ok(c.decrypt_with_key(key)?)
             })
             .collect();

--- a/crates/bitwarden-vault/src/mobile/client_folders.rs
+++ b/crates/bitwarden-vault/src/mobile/client_folders.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable};
+use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{ClientVault, Folder, FolderView};
 
@@ -10,7 +10,7 @@ pub struct ClientFolders<'a> {
 impl<'a> ClientFolders<'a> {
     pub fn encrypt(&self, folder_view: FolderView) -> Result<Folder, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(CryptoError::MissingKey)?;
+        let key = enc.get_key(&None)?;
 
         let folder = folder_view.encrypt_with_key(key)?;
 
@@ -19,7 +19,7 @@ impl<'a> ClientFolders<'a> {
 
     pub fn decrypt(&self, folder: Folder) -> Result<FolderView, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(CryptoError::MissingKey)?;
+        let key = enc.get_key(&None)?;
 
         let folder_view = folder.decrypt_with_key(key)?;
 
@@ -28,7 +28,7 @@ impl<'a> ClientFolders<'a> {
 
     pub fn decrypt_list(&self, folders: Vec<Folder>) -> Result<Vec<FolderView>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(CryptoError::MissingKey)?;
+        let key = enc.get_key(&None)?;
 
         let views = folders.decrypt_with_key(key)?;
 

--- a/crates/bitwarden-vault/src/mobile/client_password_history.rs
+++ b/crates/bitwarden-vault/src/mobile/client_password_history.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable};
+use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{ClientVault, PasswordHistory, PasswordHistoryView};
 
@@ -10,7 +10,7 @@ pub struct ClientPasswordHistory<'a> {
 impl<'a> ClientPasswordHistory<'a> {
     pub fn encrypt(&self, history_view: PasswordHistoryView) -> Result<PasswordHistory, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(CryptoError::MissingKey)?;
+        let key = enc.get_key(&None)?;
 
         let history = history_view.encrypt_with_key(key)?;
 
@@ -22,7 +22,7 @@ impl<'a> ClientPasswordHistory<'a> {
         history: Vec<PasswordHistory>,
     ) -> Result<Vec<PasswordHistoryView>, Error> {
         let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None).ok_or(CryptoError::MissingKey)?;
+        let key = enc.get_key(&None)?;
 
         let history_view = history.decrypt_with_key(key)?;
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This change adds the organization UUID to the `MissingKey` error type, and changes the `get_key` function to return a Result instead of an Option to avoid having to add the error all over the place.

Note that some of the `encryption_settings.get_key()` calls were being mapped to `VaultLocked`, that wasn't correct as having the `EncryptionSettings` means the vault is unlocked. Those were changed to `MissingKey(id)` as well.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
