### PR TITLE
fix: `discoverable` should not be hard coded

### DIFF
--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -430,7 +430,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         cred: Passkey,
         user: passkey::types::ctap2::make_credential::PublicKeyCredentialUserEntity,
         rp: passkey::types::ctap2::make_credential::PublicKeyCredentialRpEntity,
-        _options: passkey::types::ctap2::get_assertion::Options,
+        options: passkey::types::ctap2::get_assertion::Options,
     ) -> Result<(), StatusCode> {
         #[derive(Debug, Error)]
         enum InnerError {
@@ -455,6 +455,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
             cred: Passkey,
             user: passkey::types::ctap2::make_credential::PublicKeyCredentialUserEntity,
             rp: passkey::types::ctap2::make_credential::PublicKeyCredentialRpEntity,
+            options: passkey::types::ctap2::get_assertion::Options,
         ) -> Result<(), InnerError> {
             let enc = this
                 .authenticator
@@ -462,7 +463,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .internal
                 .get_encryption_settings()?;
 
-            let cred = try_from_credential_full(cred, user, rp)?;
+            let cred = try_from_credential_full(cred, user, rp, options)?;
 
             // Get the previously selected cipher and add the new credential to it
             let mut selected: CipherView = this
@@ -494,7 +495,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
             Ok(())
         }
 
-        inner(self, cred, user, rp).await.map_err(|e| {
+        inner(self, cred, user, rp, options).await.map_err(|e| {
             error!("Error saving credential: {e:?}");
             VendorError::try_from(0xF1)
                 .expect("Valid vendor error code")

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -178,7 +178,6 @@ pub(crate) fn try_from_credential_new_view(
         counter: 0.to_string(),
         user_name: user.name.clone(),
         user_display_name: user.display_name.clone(),
-        discoverable: "true".to_owned(),
         creation_date: chrono::offset::Utc::now(),
     })
 }
@@ -187,6 +186,7 @@ pub(crate) fn try_from_credential_full(
     value: Passkey,
     user: passkey::types::ctap2::make_credential::PublicKeyCredentialUserEntity,
     rp: passkey::types::ctap2::make_credential::PublicKeyCredentialRpEntity,
+    options: passkey::types::ctap2::get_assertion::Options,
 ) -> Result<Fido2CredentialFullView, FillCredentialError> {
     let cred_id: Vec<u8> = value.credential_id.into();
     let key_value = URL_SAFE_NO_PAD.encode(cose_key_to_pkcs8(&value.key)?);
@@ -205,7 +205,7 @@ pub(crate) fn try_from_credential_full(
         counter: value.counter.unwrap_or(0).to_string(),
         user_name: user.name,
         user_display_name: user.display_name,
-        discoverable: "true".to_owned(),
+        discoverable: options.rk.to_string(),
         creation_date: chrono::offset::Utc::now(),
     })
 }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -147,7 +147,6 @@ pub struct Fido2CredentialNewView {
     pub counter: String,
     pub rp_name: Option<String>,
     pub user_display_name: Option<String>,
-    pub discoverable: String,
     pub creation_date: DateTime<Utc>,
 }
 
@@ -164,7 +163,6 @@ impl From<Fido2CredentialFullView> for Fido2CredentialNewView {
             counter: value.counter,
             rp_name: value.rp_name,
             user_display_name: value.user_display_name,
-            discoverable: value.discoverable,
             creation_date: value.creation_date,
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Like the title says, `fido2Credential.discoverable` was hardcoded, but should be set from `options`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
