### PR TITLE
[SM-1338] Add the ability to edit unassigned secrets

### DIFF
--- a/crates/bws/CHANGELOG.md
+++ b/crates/bws/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- The ability to edit unassigned secrets with direct permissions. (#906)
+
 ### Removed
 
 - The deprecated `action type` commands are now removed. Please use `type action` instead. (#836)

--- a/crates/bws/src/command/secret.rs
+++ b/crates/bws/src/command/secret.rs
@@ -175,7 +175,7 @@ pub(crate) async fn edit(
                 Some(id) => Some(vec![id]),
                 None => match old_secret.project_id {
                     Some(id) => Some(vec![id]),
-                    None => bail!("Editing a secret requires a project_id."),
+                    None => None,
                 },
             },
         })

--- a/crates/bws/src/command/secret.rs
+++ b/crates/bws/src/command/secret.rs
@@ -171,13 +171,10 @@ pub(crate) async fn edit(
             key: secret.key.unwrap_or(old_secret.key),
             value: secret.value.unwrap_or(old_secret.value),
             note: secret.note.unwrap_or(old_secret.note),
-            project_ids: match secret.project_id {
-                Some(id) => Some(vec![id]),
-                None => match old_secret.project_id {
-                    Some(id) => Some(vec![id]),
-                    None => None,
-                },
-            },
+            project_ids: secret
+                .project_id
+                .or(old_secret.project_id)
+                .map(|id| vec![id]),
         })
         .await?;
     serialize_response(new_secret, output_settings);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/SM-1338

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With the introduction of individual secret permissions, it is possible for a machine account to have **read, write** permission on an unassigned secret. 
Editing this unassigned secret should be supported by `bws`.
This removes the client side validation that restricted the edit of an unassigned secret.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
