### PR TITLE
[SM-1370] Update QuickType version

### DIFF
--- a/languages/go/secrets.go
+++ b/languages/go/secrets.go
@@ -134,17 +134,11 @@ func (s *Secrets) Delete(ids []string) (*SecretsDeleteResponse, error) {
 }
 
 func (s *Secrets) Sync(organizationID string, lastSyncedDate *time.Time) (*SecretsSyncResponse, error) {
-	var lastSyncedDateString *string
-	if lastSyncedDate != nil {
-		tempRfc3339 := lastSyncedDate.UTC().Format(time.RFC3339)
-		lastSyncedDateString = &tempRfc3339
-	}
-
 	command := Command{
 		Secrets: &SecretsCommand{
 			Sync: &SecretsSyncRequest{
 				OrganizationID: organizationID,
-				LastSyncedDate: lastSyncedDateString,
+				LastSyncedDate: lastSyncedDate,
 			},
 		},
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@openapitools/openapi-generator-cli": "2.13.4",
         "handlebars": "^4.7.8",
         "prettier": "3.3.3",
-        "quicktype-core": "23.0.81",
+        "quicktype-core": "23.0.170",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.3.3"
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@glideapps/ts-necessities": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@glideapps/ts-necessities/-/ts-necessities-2.1.3.tgz",
-      "integrity": "sha512-q9U8v/n9qbkd2zDYjuX3qtlbl+OIyI9zF+zQhZjfYOE9VMDH7tfcUSJ9p0lXoY3lxmGFne09yi4iiNeQUwV7AA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@glideapps/ts-necessities/-/ts-necessities-2.2.3.tgz",
+      "integrity": "sha512-gXi0awOZLHk3TbW55GZLCPP6O+y/b5X1pBXKBVckFONSwF1z1E5ND2BGJsghQFah+pW7pkkyFb2VhUQI2qhL5w==",
       "dev": true,
       "license": "MIT"
     },
@@ -380,13 +380,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/urijs": {
-      "version": "1.19.25",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
-      "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -559,9 +552,9 @@
       }
     },
     "node_modules/browser-or-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
-      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
+      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1695,27 +1688,26 @@
       "license": "MIT"
     },
     "node_modules/quicktype-core": {
-      "version": "23.0.81",
-      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.81.tgz",
-      "integrity": "sha512-iJQpCEzSQIkffJPS5NC+0w+Rq9faGgz09L+WIbseu1toFfj+M/3KTG5jhzdY/uN88fWosAom2fMoEADA403+rQ==",
+      "version": "23.0.170",
+      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.170.tgz",
+      "integrity": "sha512-ZsjveG0yJUIijUx4yQshzyQ5EAXKbFSBTQJHnJ+KoSZVxcS+m3GcmDpzrdUIRYMhgLaF11ZGvLSYi5U0xcwemw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@glideapps/ts-necessities": "2.1.3",
-        "@types/urijs": "^1.19.19",
-        "browser-or-node": "^2.1.1",
+        "@glideapps/ts-necessities": "2.2.3",
+        "browser-or-node": "^3.0.0",
         "collection-utils": "^1.0.1",
         "cross-fetch": "^4.0.0",
         "is-url": "^1.2.4",
-        "js-base64": "^3.7.5",
+        "js-base64": "^3.7.7",
         "lodash": "^4.17.21",
         "pako": "^1.0.6",
         "pluralize": "^8.0.0",
-        "readable-stream": "4.4.2",
+        "readable-stream": "4.5.2",
         "unicode-properties": "^1.4.1",
         "urijs": "^1.19.1",
         "wordwrap": "^1.0.0",
-        "yaml": "^2.3.1"
+        "yaml": "^2.4.1"
       }
     },
     "node_modules/quicktype-core/node_modules/buffer": {
@@ -1744,9 +1736,9 @@
       }
     },
     "node_modules/quicktype-core/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@openapitools/openapi-generator-cli": "2.13.4",
     "handlebars": "^4.7.8",
     "prettier": "3.3.3",
-    "quicktype-core": "23.0.81",
+    "quicktype-core": "23.0.170",
     "rimraf": "6.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"

--- a/support/scripts/schemas.ts
+++ b/support/scripts/schemas.ts
@@ -95,7 +95,7 @@ async function main() {
     lang: "go",
     rendererOptions: {
       package: "sdk",
-      "just-types-and-package": true,
+      "omit-empty": true,
     },
   });
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/SM-1370

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The purpose of this PR is to update the`QuickType` version.

Most language generated schemas were not effected. 

### C++

A minor change in the error message for enum parsing.

```
 default: throw std::runtime_error("This should not happen");
```

to

```
default: throw std::runtime_error("Unexpected value in enumeration \"[object Object]\": " + std::to_string(static_cast<int>(x)));
```

### Go

Has several breaking changes.

#### omit-empty

Previously, the `omit-empty` feature was enabled by default.
QuickType's description: `If set, all non-required objects will be tagged with ",omitempty"`

For example, the `SecretsSyncRequest` struct `LastSyncedDate` is optional and uses `emitempty`.

```
type SecretsSyncRequest struct {
	// Optional date time a sync last occurred        
	LastSyncedDate                            *string `json:"lastSyncedDate,omitempty"`
	// Organization to sync secrets from              
	OrganizationID                            string  `json:"organizationId"`
}
```

To continue this behavior, I added and enabled it in the render options `support/scripts/schemas.ts`.

#### just-types-and-package & time

Previously, model properties that were `DateTime` types in Bitwarden server models were translated to Go `string` properties. 

With this newer version of QuickType these `DateTime` properties are now `time.Time` in Go.
This required changes to the Sync function `languages/go/secrets.go`.

With the `just-types-and-package` render option, `import "time"` is added to the file at the first occurrence of a `time.Time` property. 
This is most likely a bug and causes build errors.

```
go % go build
# github.com/bitwarden/sdk-go
./schema.go:288:1: syntax error: imports must appear before other declarations
```
Removing the `just-types-and-package` render option fixes this problem and has the import moved to the top of the file.
This does cause adding some unnecessary marshal & un-marshal functions, that won't be used, into the `schema.go` file.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
