### PR TITLE
Use Arc::make_mut to try to avoid unnecessary clones

### DIFF
--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -113,11 +113,9 @@ impl InternalClient {
             .write()
             .expect("RwLock is not poisoned");
 
-        let mut inner: ApiConfigurations = guard.as_ref().clone();
+        let inner = Arc::make_mut(&mut guard);
         inner.identity.oauth_access_token = Some(token.clone());
         inner.api.oauth_access_token = Some(token);
-
-        *guard = Arc::new(inner);
     }
 
     #[cfg(feature = "internal")]
@@ -244,12 +242,9 @@ impl InternalClient {
             return Err(VaultLocked.into());
         };
 
-        let mut enc: EncryptionSettings = enc.as_ref().clone();
-        enc.set_org_keys(org_keys)?;
-        let enc = Arc::new(enc);
+        let inner = Arc::make_mut(enc);
+        inner.set_org_keys(org_keys)?;
 
-        *guard = Some(enc.clone());
-
-        Ok(enc)
+        Ok(enc.clone())
     }
 }


### PR DESCRIPTION

## 📔 Objective

Just discovered that [`Arc::make_mut`](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.make_mut) exists, and it will reuse the `Arc` if it's the only strong reference to it, or clone it if there's more.

Previously we were always cloning the value, so this should help avoid some clones, as I don't expect any references to these arcs to be held long.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
