### PR TITLE
[SM-1174] Access Token Login State by Default in bws

### DIFF
--- a/crates/bws/src/cli.rs
+++ b/crates/bws/src/cli.rs
@@ -11,7 +11,7 @@ pub(crate) const PROFILE_KEY_VAR_NAME: &str = "BWS_PROFILE";
 pub(crate) const SERVER_URL_KEY_VAR_NAME: &str = "BWS_SERVER_URL";
 
 pub(crate) const DEFAULT_CONFIG_FILENAME: &str = "config";
-pub(crate) const DEFAULT_CONFIG_DIRECTORY: &str = ".bws";
+pub(crate) const DEFAULT_CONFIG_DIRECTORY: &str = ".config/bws";
 
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -20,6 +20,7 @@ pub(crate) enum ProfileKey {
     server_api,
     server_identity,
     state_dir,
+    state_opt_out,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/crates/bws/src/command/mod.rs
+++ b/crates/bws/src/command/mod.rs
@@ -6,9 +6,9 @@ use std::{path::PathBuf, str::FromStr};
 use bitwarden::auth::AccessToken;
 use clap::CommandFactory;
 use clap_complete::Shell;
-use color_eyre::eyre::{bail, eyre, Result};
+use color_eyre::eyre::{bail, Result};
 
-use crate::{config, Cli, ProfileKey};
+use crate::{config, util, Cli, ProfileKey};
 
 pub(crate) fn completions(shell: Option<Shell>) -> Result<()> {
     let Some(shell) = shell.or_else(Shell::from_env) else {
@@ -44,33 +44,23 @@ pub(crate) fn config(
         config::delete_profile(config_file.as_deref(), profile)?;
         println!("Profile deleted successfully!");
     } else {
-        let (name, mut value) = match (name, value) {
+        let (name, value) = match (name, value) {
             (None, None) => bail!("Missing `name` and `value`"),
             (None, Some(_)) => bail!("Missing `value`"),
             (Some(_), None) => bail!("Missing `name`"),
+            (Some(ProfileKey::state_opt_out), Some(value)) => {
+                if util::string_to_bool(value.as_str()).is_err() {
+                    bail!("Profile key \"state_opt_out\" must be \"true\" or \"false\"");
+                } else {
+                    (ProfileKey::state_opt_out, value)
+                }
+            }
             (Some(name), Some(value)) => (name, value),
         };
-
-        // If state_opt_out is being set,
-        // verify it's a boolean or 1 or 0, otherwise bail
-        if let ProfileKey::state_opt_out = name {
-            value = match string_to_bool_string(value) {
-                Ok(value) => value,
-                Err(_) => bail!("Profile key \"state_opt_out\" must be \"true\" or \"false\""),
-            }
-        }
 
         config::update_profile(config_file.as_deref(), profile, name, value)?;
         println!("Profile updated successfully!");
     };
 
     Ok(())
-}
-
-fn string_to_bool_string(value: String) -> Result<String> {
-    match value.trim().to_lowercase().as_str() {
-        "true" | "1" => Ok(String::from("true")),
-        "false" | "0" => Ok(String::from("false")),
-        _ => Err(eyre!("Failed to convert string to bool")),
-    }
 }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -21,6 +21,7 @@ pub(crate) struct Profile {
     pub server_api: Option<String>,
     pub server_identity: Option<String>,
     pub state_dir: Option<String>,
+    pub state_opt_out: Option<String>,
 }
 
 impl ProfileKey {
@@ -30,6 +31,7 @@ impl ProfileKey {
             ProfileKey::server_api => p.server_api = Some(value),
             ProfileKey::server_identity => p.server_identity = Some(value),
             ProfileKey::state_dir => p.state_dir = Some(value),
+            ProfileKey::state_opt_out => p.state_opt_out = Some(value),
         }
     }
 }
@@ -118,6 +120,7 @@ impl Profile {
             server_api: None,
             server_identity: None,
             state_dir: None,
+            state_opt_out: None,
         })
     }
     pub(crate) fn api_url(&self) -> Result<String> {

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -16,6 +16,7 @@ mod command;
 mod config;
 mod render;
 mod state;
+mod util;
 
 use crate::cli::*;
 
@@ -157,11 +158,8 @@ fn get_config_profile(
 
 fn get_state_opt_out(profile: &Option<Profile>) -> bool {
     if let Some(profile) = profile {
-        if let Some(state_opt_out) = profile.state_opt_out.as_ref() {
-            match state_opt_out.trim().to_lowercase().as_str() {
-                "true" | "1" => return true,
-                _ => return false,
-            }
+        if let Some(state_opt_out) = &profile.state_opt_out {
+            return util::string_to_bool(state_opt_out).unwrap_or(false);
         }
     }
 

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -88,10 +88,16 @@ async fn process_commands() -> Result<()> {
 
     let state_file = match get_state_opt_out(&profile) {
         true => None,
-        false => Some(state::get_state_file(
+        false => match state::get_state_file(
             profile.and_then(|p| p.state_dir).map(Into::into),
             access_token_obj.access_token_id.to_string(),
-        )?),
+        ) {
+            Ok(state_file) => Some(state_file),
+            Err(e) => {
+                eprintln!("Error: {}\nAttempting to continue without using state. Please set \"state_dir\" in your config file to avoid authentication limits.", e);
+                None
+            }
+        },
     };
 
     let client = bitwarden::Client::new(settings);

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -94,7 +94,7 @@ async fn process_commands() -> Result<()> {
         ) {
             Ok(state_file) => Some(state_file),
             Err(e) => {
-                eprintln!("Error: {}\nAttempting to continue without using state. Please set \"state_dir\" in your config file to avoid authentication limits.", e);
+                eprintln!("Warning: {}\nRetrieving the state file failed. Attempting to continue without using state. Please set \"state_dir\" in your config file to avoid authentication limits.", e);
                 None
             }
         },

--- a/crates/bws/src/state.rs
+++ b/crates/bws/src/state.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use color_eyre::eyre::{bail, Result};
 use directories::BaseDirs;
 
-pub(crate) const DEFAULT_STATE_DIRECTORY: &str = ".config/bws/state";
+use crate::DEFAULT_CONFIG_DIRECTORY;
+
+pub(crate) const DEFAULT_STATE_DIRECTORY: &str = "state";
 
 pub(crate) fn get_state_file(
     state_dir: Option<PathBuf>,
@@ -13,7 +15,10 @@ pub(crate) fn get_state_file(
         Some(state_dir) => state_dir,
         None => {
             if let Some(base_dirs) = BaseDirs::new() {
-                base_dirs.home_dir().join(DEFAULT_STATE_DIRECTORY)
+                base_dirs
+                    .home_dir()
+                    .join(DEFAULT_CONFIG_DIRECTORY)
+                    .join(DEFAULT_STATE_DIRECTORY)
             } else {
                 bail!("A valid home directory doesn't exist");
             }

--- a/crates/bws/src/state.rs
+++ b/crates/bws/src/state.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
+use directories::BaseDirs;
 
 pub(crate) const DEFAULT_STATE_DIRECTORY: &str = ".config/bws/state";
 
@@ -10,7 +11,13 @@ pub(crate) fn get_state_file(
 ) -> Result<PathBuf> {
     let mut state_dir = match state_dir {
         Some(state_dir) => state_dir,
-        None => PathBuf::from(DEFAULT_STATE_DIRECTORY),
+        None => {
+            let Some(base_dirs) = BaseDirs::new() else {
+                return Err(eyre!("A valid home directory doesn't exist"));
+            };
+
+            base_dirs.home_dir().join(DEFAULT_STATE_DIRECTORY)
+        }
     };
 
     std::fs::create_dir_all(&state_dir)?;

--- a/crates/bws/src/state.rs
+++ b/crates/bws/src/state.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use color_eyre::eyre::{eyre, Result};
+use color_eyre::eyre::{bail, Result};
 use directories::BaseDirs;
 
 pub(crate) const DEFAULT_STATE_DIRECTORY: &str = ".config/bws/state";
@@ -12,11 +12,11 @@ pub(crate) fn get_state_file(
     let mut state_dir = match state_dir {
         Some(state_dir) => state_dir,
         None => {
-            let Some(base_dirs) = BaseDirs::new() else {
-                return Err(eyre!("A valid home directory doesn't exist"));
-            };
-
-            base_dirs.home_dir().join(DEFAULT_STATE_DIRECTORY)
+            if let Some(base_dirs) = BaseDirs::new() {
+                base_dirs.home_dir().join(DEFAULT_STATE_DIRECTORY)
+            } else {
+                bail!("A valid home directory doesn't exist");
+            }
         }
     };
 

--- a/crates/bws/src/state.rs
+++ b/crates/bws/src/state.rs
@@ -2,16 +2,19 @@ use std::path::PathBuf;
 
 use color_eyre::eyre::Result;
 
+pub(crate) const DEFAULT_STATE_DIRECTORY: &str = ".config/bws/state";
+
 pub(crate) fn get_state_file(
     state_dir: Option<PathBuf>,
     access_token_id: String,
-) -> Result<Option<PathBuf>> {
-    if let Some(mut state_dir) = state_dir {
-        std::fs::create_dir_all(&state_dir)?;
-        state_dir.push(access_token_id);
+) -> Result<PathBuf> {
+    let mut state_dir = match state_dir {
+        Some(state_dir) => state_dir,
+        None => PathBuf::from(DEFAULT_STATE_DIRECTORY),
+    };
 
-        return Ok(Some(state_dir));
-    }
+    std::fs::create_dir_all(&state_dir)?;
+    state_dir.push(access_token_id);
 
-    Ok(None)
+    Ok(state_dir)
 }

--- a/crates/bws/src/util.rs
+++ b/crates/bws/src/util.rs
@@ -1,0 +1,44 @@
+const STRING_TO_BOOL_ERROR_MESSAGE: &str = "Could not convert string to bool";
+
+pub(crate) fn string_to_bool(value: &str) -> Result<bool, &str> {
+    match value.trim().to_lowercase().as_str() {
+        "true" | "1" => Ok(true),
+        "false" | "0" => Ok(false),
+        _ => Err(STRING_TO_BOOL_ERROR_MESSAGE),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_to_bool_true_true() {
+        let result = string_to_bool("true");
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn test_string_to_bool_one_true() {
+        let result = string_to_bool("1");
+        assert_eq!(result, Ok(true));
+    }
+
+    #[test]
+    fn test_string_to_bool_false_false() {
+        let result = string_to_bool("false");
+        assert_eq!(result, Ok(false));
+    }
+
+    #[test]
+    fn test_string_to_bool_zero_false() {
+        let result = string_to_bool("0");
+        assert_eq!(result, Ok(false));
+    }
+
+    #[test]
+    fn test_string_to_bool_bad_string_errors() {
+        let result = string_to_bool("hello world");
+        assert_eq!(result, Err(STRING_TO_BOOL_ERROR_MESSAGE));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1174

## 📔 Objective

This PR switches `bws` to use access token login state by default. This will help prevent many users from running into rate limiting issues. The two related config keys in a profile:

- `state_dir` -> this is the same as it has been; a custom directory for where state files will be stored
- `state_opt_out` -> this is a new key. If it's `true` or `1`, state files will not be used

**Note**: the `gnu` build failures are already happening on `main` and have been brought up internally

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
