### PR TITLE
Remove locked security framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "reqwest",
  "rustls-platform-verifier",
  "schemars",
- "security-framework",
  "serde",
  "serde_json",
  "serde_qs",
@@ -3459,11 +3458,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -81,11 +81,6 @@ reqwest = { version = ">=0.12.5, <0.13", features = [
     "rustls-tls-webpki-roots",
 ], default-features = false }
 
-# This is a workaround to fix a bug with version 2.11.0 that added some symbols that are not available on iOS
-# The bug is fixed already but the fix is not released yet. https://github.com/kornelski/rust-security-framework/pull/204
-[target.'cfg(target_os = "ios")'.dependencies]
-security-framework = { version = "=2.10" }
-
 [dev-dependencies]
 bitwarden-crypto = { workspace = true }
 rand_chacha = "0.3.1"


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

There is a new release of security-framework available which removes the need for us to manually specify the version.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
