### PR TITLE
[SM-1275] Update AccessTokenLogin to LoginAccessToken for SM

### DIFF
--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -54,7 +54,7 @@ impl Client {
             #[cfg(feature = "internal")]
             Command::PasswordLogin(req) => client.auth().login_password(&req).await.into_string(),
             #[cfg(feature = "secrets")]
-            Command::AccessTokenLogin(req) => {
+            Command::LoginAccessToken(req) => {
                 client.auth().login_access_token(&req).await.into_string()
             }
             #[cfg(feature = "internal")]

--- a/crates/bitwarden-json/src/command.rs
+++ b/crates/bitwarden-json/src/command.rs
@@ -50,7 +50,7 @@ pub enum Command {
     /// This command is for initiating an authentication handshake with Bitwarden.
     ///
     /// Returns: [ApiKeyLoginResponse](bitwarden::auth::login::ApiKeyLoginResponse)
-    AccessTokenLogin(AccessTokenLoginRequest),
+    LoginAccessToken(AccessTokenLoginRequest),
 
     #[cfg(feature = "internal")]
     /// > Requires Authentication

--- a/crates/sdk-schemas/src/main.rs
+++ b/crates/sdk-schemas/src/main.rs
@@ -99,7 +99,7 @@ struct SchemaTypes {
     // Output types for Client::run_command
     api_key_login: Response<bitwarden::auth::login::ApiKeyLoginResponse>,
     password_login: Response<bitwarden::auth::login::PasswordLoginResponse>,
-    access_token_login: Response<bitwarden::auth::login::AccessTokenLoginResponse>,
+    login_access_token: Response<bitwarden::auth::login::AccessTokenLoginResponse>,
     secret_identifiers: Response<bitwarden::secrets_manager::secrets::SecretIdentifiersResponse>,
     secret: Response<bitwarden::secrets_manager::secrets::SecretResponse>,
     secrets: Response<bitwarden::secrets_manager::secrets::SecretsResponse>,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1275

## 📔 Objective

As requested internally, this updates `AccessTokenLogin` to `LoginAccessToken` for all SM language bindings. This will break functionality for each binding on main until they are each updated (or unless they are already updated). We are reviewing all bindings now and updates for all are on deck. There are a total of ~8 bindings to verify and update for SM, so the only alternative is including all changes in one PR, which would be nice to avoid.

@Hinton please let us know if there is anything we are missing with this PR, besides subsequent PR's to fix this for each binding. Is there anything else that should be updated?

**Note**: we should not merge this if we plan to release any bindings before the subsequent updates come through.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
