### PR TITLE
[SM-1413] Temporary PR to Showcase 'hyper' Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,17 +38,17 @@ unwrap_used = "deny"
 # This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster
 # As clean builds won't occur very often, this won't slow down the development process
 [profile.dev.package."*"]
-opt-level = 2
+opt-level = 0
 
 # Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
 # if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
 [profile.dev]
-opt-level = 1
+opt-level = 0
 
 # Turn on LTO on release mode
-[profile.release]
-lto = "thin"
-codegen-units = 1
+# [profile.release]
+# lto = "thin"
+# codegen-units = 1
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true

--- a/crates/bitwarden-sm/src/client_projects.rs
+++ b/crates/bitwarden-sm/src/client_projects.rs
@@ -24,6 +24,7 @@ impl<'a> ClientProjects<'a> {
     }
 
     pub async fn list(&self, input: &ProjectsListRequest) -> Result<ProjectsResponse, Error> {
+        println!("list the projects");
         list_projects(self.client, input).await
     }
 

--- a/crates/bitwarden-sm/src/client_secrets.rs
+++ b/crates/bitwarden-sm/src/client_secrets.rs
@@ -33,6 +33,7 @@ impl<'a> ClientSecrets<'a> {
         &self,
         input: &SecretIdentifiersRequest,
     ) -> Result<SecretIdentifiersResponse, Error> {
+        println!("list the secrets");
         list_secrets(self.client, input).await
     }
 
@@ -40,6 +41,7 @@ impl<'a> ClientSecrets<'a> {
         &self,
         input: &SecretIdentifiersByProjectRequest,
     ) -> Result<SecretIdentifiersResponse, Error> {
+        println!("list the secrets by project");
         list_secrets_by_project(self.client, input).await
     }
 

--- a/crates/bitwarden-sm/src/projects/list.rs
+++ b/crates/bitwarden-sm/src/projects/list.rs
@@ -25,11 +25,22 @@ pub(crate) async fn list_projects(
         &config.api,
         input.organization_id,
     )
-    .await?;
+    .await;
+
+    let r = match res {
+        Ok(r) => {
+            println!("{:?}", r);
+            r
+        }
+        Err(e) => {
+            println!("{:?}", e);
+            return Err(e.into());
+        }
+    };
 
     let enc = client.internal.get_encryption_settings()?;
 
-    ProjectsResponse::process_response(res, &enc)
+    ProjectsResponse::process_response(r, &enc)
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/crates/bitwarden-sm/src/secrets/list.rs
+++ b/crates/bitwarden-sm/src/secrets/list.rs
@@ -26,11 +26,22 @@ pub(crate) async fn list_secrets(
         &config.api,
         input.organization_id,
     )
-    .await?;
+    .await;
+
+    let r = match res {
+        Ok(r) => {
+            println!("{:?}", r);
+            r
+        }
+        Err(e) => {
+            println!("{:?}", e);
+            return Err(e.into());
+        }
+    };
 
     let enc = client.internal.get_encryption_settings()?;
 
-    SecretIdentifiersResponse::process_response(res, &enc)
+    SecretIdentifiersResponse::process_response(r, &enc)
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -49,11 +60,22 @@ pub(crate) async fn list_secrets_by_project(
         &config.api,
         input.project_id,
     )
-    .await?;
+    .await;
+
+    let r = match res {
+        Ok(r) => {
+            println!("{:?}", r);
+            r
+        }
+        Err(e) => {
+            println!("{:?}", e);
+            return Err(e.into());
+        }
+    };
 
     let enc = client.internal.get_encryption_settings()?;
 
-    SecretIdentifiersResponse::process_response(res, &enc)
+    SecretIdentifiersResponse::process_response(r, &enc)
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/languages/go/example/example.go
+++ b/languages/go/example/example.go
@@ -1,116 +1,71 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
-	"os"
+	"sync"
 
 	sdk "github.com/bitwarden/sdk-go"
-	"github.com/gofrs/uuid"
+)
+
+var (
+	ApiUrl         = "http://localhost:4000"
+	IdentityUrl    = "http://localhost:33656"
+	OrganizationId = ""
+	AccessToken    = ""
+	statePath      = ""
 )
 
 func main() {
-	// Configuring the URLS is optional, set them to nil to use the default values
-	apiURL := os.Getenv("API_URL")
-	identityURL := os.Getenv("IDENTITY_URL")
-
-	bitwardenClient, _ := sdk.NewBitwardenClient(&apiURL, &identityURL)
-
-	accessToken := os.Getenv("ACCESS_TOKEN")
-	organizationIDStr := os.Getenv("ORGANIZATION_ID")
-	projectName := os.Getenv("PROJECT_NAME")
-
-	// Configuring the stateFile is optional, pass nil
-	// in AccessTokenLogin() to not use state
-	stateFile := os.Getenv("STATE_FILE")
-
-	if projectName == "" {
-		projectName = "NewTestProject" // default value
-	}
-
-	err := bitwardenClient.AccessTokenLogin(accessToken, &stateFile)
+	// create the client
+	bitwardenClient, err := sdk.NewBitwardenClient(&ApiUrl, &IdentityUrl)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	organizationID, err := uuid.FromString(organizationIDStr)
+	// access token login
+	err = bitwardenClient.AccessTokenLogin(AccessToken, &statePath)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	project, err := bitwardenClient.Projects().Create(organizationID.String(), projectName)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(project)
-	projectID := project.ID
-	fmt.Println(projectID)
+	// build the waitgroup
+	var wg sync.WaitGroup
+	wg.Add(2)
 
-	if _, err = bitwardenClient.Projects().List(organizationID.String()); err != nil {
-		panic(err)
-	}
+	// build the goroutines
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			projects, err := bitwardenClient.Projects().List(OrganizationId)
+			if err != nil {
+				log.Println("Error listing projects:", err)
+				return
+			}
 
-	if _, err = bitwardenClient.Projects().Get(projectID); err != nil {
-		panic(err)
-	}
+			fmt.Printf("# of Projects (iteration %d): %d\n", i+1, len(projects.Data))
+			for _, project := range projects.Data {
+				fmt.Printf("ID: %s\n", project.ID)
+				fmt.Printf("Name: %s\n", project.Name)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			secrets, err := bitwardenClient.Secrets().List(OrganizationId)
+			if err != nil {
+				log.Println("Error listing secrets:", err)
+				return
+			}
 
-	if _, err = bitwardenClient.Projects().Update(projectID, organizationID.String(), projectName+"2"); err != nil {
-		panic(err)
-	}
+			fmt.Printf("# of Secrets (iteration %d): %d\n", i+1, len(secrets.Data))
+			for _, secret := range secrets.Data {
+				fmt.Printf("ID: %s\n", secret.ID)
+				fmt.Printf("Name: %s\n", secret.Key)
+			}
+		}
+	}()
 
-	key := "key"
-	value := "value"
-	note := "note"
-
-	secret, err := bitwardenClient.Secrets().Create(key, value, note, organizationID.String(), []string{projectID})
-	if err != nil {
-		panic(err)
-	}
-	secretID := secret.ID
-
-	if _, err = bitwardenClient.Secrets().List(organizationID.String()); err != nil {
-		panic(err)
-	}
-
-	if _, err = bitwardenClient.Secrets().Get(secretID); err != nil {
-		panic(err)
-	}
-
-	if _, err = bitwardenClient.Secrets().Update(secretID, key, value, note, organizationID.String(), []string{projectID}); err != nil {
-		panic(err)
-	}
-
-	if _, err = bitwardenClient.Secrets().Delete([]string{secretID}); err != nil {
-		panic(err)
-	}
-
-	if _, err = bitwardenClient.Projects().Delete([]string{projectID}); err != nil {
-		panic(err)
-	}
-
-	secretIdentifiers, err := bitwardenClient.Secrets().List(organizationID.String())
-	if err != nil {
-		panic(err)
-	}
-
-	// Get secrets with a list of IDs
-	secretIDs := make([]string, len(secretIdentifiers.Data))
-	for i, identifier := range secretIdentifiers.Data {
-		secretIDs[i] = identifier.ID
-	}
-
-	secrets, err := bitwardenClient.Secrets().GetByIDS(secretIDs)
-	if err != nil {
-		log.Fatalf("Error getting secrets: %v", err)
-	}
-
-	jsonSecrets, err := json.MarshalIndent(secrets, "", "  ")
-	if err != nil {
-		log.Fatalf("Error marshalling secrets to JSON: %v", err)
-	}
-
-	fmt.Println(string(jsonSecrets))
-
-	defer bitwardenClient.Close()
+	wg.Wait()
 }

--- a/languages/go/example/go.mod
+++ b/languages/go/example/go.mod
@@ -4,7 +4,4 @@ replace github.com/bitwarden/sdk-go => ../
 
 go 1.21
 
-require (
-	github.com/bitwarden/sdk-go v0.0.0-00010101000000-000000000000
-	github.com/gofrs/uuid v4.4.0+incompatible
-)
+require github.com/bitwarden/sdk-go v0.0.0-00010101000000-000000000000

--- a/languages/go/example/go.sum
+++ b/languages/go/example/go.sum
@@ -1,2 +1,0 @@
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1413

## 📔 Objective

🚨 **Do Not Merge This PR** 🚨

The goal of this PR is to allow a developer to easily reproduce a _potential_ bug with [hyper](https://crates.io/crates/hyper) that we are running into.

**Description**

When running concurrent requests using the same client from the Go SDK binding, execution stops for at least one of the threads at runtime with the following error: `runtime dropped the dispatch task`.

**Replication Steps**
- `cargo build` from root
- `npm run schemas` from root
- Move the built `sdk/target/debug/libbitwarden_c.a` to the `sdk/languages/go/internal/cinterface/lib/{arch}` folder, where `{arch}` is your CPU architecture.
  - For Mac arm CPU's: `darwin-arm64`
  - Other examples of potential folder names can be found [here](https://github.com/bitwarden/sdk-go/tree/main/internal/cinterface/lib)
- Update the following variables for your environment in the `sdk/languages/go/example/example.go` file:
  - `OrganizationId`
  - `AccessToken`
  - `statePath`
- From `sdk/languages/go/example`, run `go build`
- From `sdk/languages/go/example`, run `./example > go-log.txt 2>&1`

Open the `go-log.txt` file and you should find something similar to the following (certain data redacted and replaced with `x`):

```
[2024-08-13T23:04:01Z DEBUG reqwest::connect] starting new connection: http://localhost:4000/
SecretWithProjectsListResponseModel { object: Some("SecretsWithProjectsList"), secrets: Some([SecretsWithProjectsInnerSecret { id: Some(x), organization_id: Some(x), key: Some("x"), creation_date: Some("2024-08-01T20:09:48.024313Z"), revision_date: Some("2024-08-01T20:09:48.024313Z"), projects: Some([SecretWithProjectsInnerProject { id: Some(x), name: Some("x") }]), read: Some(true), write: Some(true) }]), projects: Some([SecretWithProjectsInnerProject { id: Some(x), name: Some("x") }]) }
Reqwest(reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(4000), path: "/organizations/x/projects", query: None, fragment: None }, source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(User(DispatchGone), "runtime dropped the dispatch task")) })
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
