### PR TITLE
[PM-10929] Support Key Connector

### DIFF
--- a/crates/bitwarden-core/src/auth/client_auth.rs
+++ b/crates/bitwarden-core/src/auth/client_auth.rs
@@ -1,18 +1,18 @@
-use bitwarden_crypto::CryptoError;
 #[cfg(feature = "internal")]
-use bitwarden_crypto::{AsymmetricEncString, DeviceKey, EncString, Kdf, TrustDeviceResponse};
+use bitwarden_crypto::{
+    AsymmetricEncString, CryptoError, DeviceKey, EncString, Kdf, TrustDeviceResponse,
+};
 
-use super::key_connector::{make_key_connector_keys, KeyConnectorResponse};
-#[cfg(feature = "internal")]
-use crate::auth::login::NewAuthRequestResponse;
 #[cfg(feature = "secrets")]
 use crate::auth::login::{login_access_token, AccessTokenLoginRequest, AccessTokenLoginResponse};
 #[cfg(feature = "internal")]
 use crate::auth::{
     auth_request::{approve_auth_request, new_auth_request},
+    key_connector::{make_key_connector_keys, KeyConnectorResponse},
     login::{
         login_api_key, login_password, send_two_factor_email, ApiKeyLoginRequest,
-        ApiKeyLoginResponse, PasswordLoginRequest, PasswordLoginResponse, TwoFactorEmailRequest,
+        ApiKeyLoginResponse, NewAuthRequestResponse, PasswordLoginRequest, PasswordLoginResponse,
+        TwoFactorEmailRequest,
     },
     password::{
         password_strength, satisfies_policy, validate_password, validate_password_user_key,

--- a/crates/bitwarden-core/src/auth/client_auth.rs
+++ b/crates/bitwarden-core/src/auth/client_auth.rs
@@ -2,6 +2,7 @@ use bitwarden_crypto::CryptoError;
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{AsymmetricEncString, DeviceKey, EncString, Kdf, TrustDeviceResponse};
 
+use super::key_connector::{make_key_connector_keys, KeyConnectorResponse};
 #[cfg(feature = "internal")]
 use crate::auth::login::NewAuthRequestResponse;
 #[cfg(feature = "secrets")]
@@ -23,8 +24,6 @@ use crate::auth::{
     AuthRequestResponse, RegisterKeyResponse, RegisterRequest,
 };
 use crate::{auth::renew::renew_token, error::Result, Client};
-
-use super::key_connector::{make_key_connector_keys, KeyConnectorResponse};
 
 pub struct ClientAuth<'a> {
     pub(crate) client: &'a crate::Client,

--- a/crates/bitwarden-core/src/auth/client_auth.rs
+++ b/crates/bitwarden-core/src/auth/client_auth.rs
@@ -1,3 +1,4 @@
+use bitwarden_crypto::CryptoError;
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{AsymmetricEncString, DeviceKey, EncString, Kdf, TrustDeviceResponse};
 
@@ -22,6 +23,8 @@ use crate::auth::{
     AuthRequestResponse, RegisterKeyResponse, RegisterRequest,
 };
 use crate::{auth::renew::renew_token, error::Result, Client};
+
+use super::key_connector::{make_key_connector_keys, KeyConnectorResponse};
 
 pub struct ClientAuth<'a> {
     pub(crate) client: &'a crate::Client,
@@ -77,6 +80,11 @@ impl<'a> ClientAuth<'a> {
         remember_device: bool,
     ) -> Result<RegisterTdeKeyResponse> {
         make_register_tde_keys(self.client, email, org_public_key, remember_device)
+    }
+
+    pub fn make_key_connector_keys(&self) -> Result<KeyConnectorResponse, CryptoError> {
+        let mut rng = rand::thread_rng();
+        make_key_connector_keys(&mut rng)
     }
 
     pub async fn register(&self, input: &RegisterRequest) -> Result<()> {

--- a/crates/bitwarden-core/src/auth/key_connector.rs
+++ b/crates/bitwarden-core/src/auth/key_connector.rs
@@ -1,0 +1,41 @@
+use bitwarden_crypto::{CryptoError, MasterKey, RsaKeyPair};
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct KeyConnectorResponse {
+    pub master_key: String,
+    pub encrypted_user_key: String,
+    pub keys: RsaKeyPair,
+}
+
+pub(super) fn make_key_connector_keys(
+    mut rng: impl rand::RngCore,
+) -> Result<KeyConnectorResponse, CryptoError> {
+    let master_key = MasterKey::generate(&mut rng);
+    let (user_key, encrypted_user_key) = master_key.make_user_key()?;
+    let keys = user_key.make_key_pair()?;
+
+    Ok(KeyConnectorResponse {
+        master_key: master_key.to_base64(),
+        encrypted_user_key: encrypted_user_key.to_string(),
+        keys,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn test_make_key_connector_keys() {
+        let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
+
+        let result = make_key_connector_keys(&mut rng).unwrap();
+
+        assert_eq!(
+            result.master_key,
+            "PgDvL4lfQNZ/W7joHwmloSyEDsPOmn87GBvhiO9xGh4="
+        );
+    }
+}

--- a/crates/bitwarden-core/src/auth/key_connector.rs
+++ b/crates/bitwarden-core/src/auth/key_connector.rs
@@ -23,9 +23,10 @@ pub(super) fn make_key_connector_keys(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
+
+    use super::*;
 
     #[test]
     fn test_make_key_connector_keys() {

--- a/crates/bitwarden-core/src/auth/mod.rs
+++ b/crates/bitwarden-core/src/auth/mod.rs
@@ -30,6 +30,8 @@ pub use register::{RegisterKeyResponse, RegisterRequest};
 mod tde;
 #[cfg(feature = "internal")]
 pub use tde::RegisterTdeKeyResponse;
+#[cfg(feature = "internal")]
+mod key_connector;
 
 #[cfg(feature = "internal")]
 use crate::error::Result;

--- a/crates/bitwarden-core/src/auth/mod.rs
+++ b/crates/bitwarden-core/src/auth/mod.rs
@@ -32,6 +32,8 @@ mod tde;
 pub use tde::RegisterTdeKeyResponse;
 #[cfg(feature = "internal")]
 mod key_connector;
+#[cfg(feature = "internal")]
+pub use key_connector::KeyConnectorResponse;
 
 #[cfg(feature = "internal")]
 use crate::error::Result;

--- a/crates/bitwarden-core/src/mobile/client_crypto.rs
+++ b/crates/bitwarden-core/src/mobile/client_crypto.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{AsymmetricEncString, EncString};
 
+use super::crypto::{derive_key_connector, DeriveKeyConnectorRequest};
 use crate::Client;
 #[cfg(feature = "internal")]
 use crate::{
@@ -11,8 +12,6 @@ use crate::{
         InitOrgCryptoRequest, InitUserCryptoRequest, UpdatePasswordResponse,
     },
 };
-
-use super::crypto::{derive_key_connector, DeriveKeyConnectorRequest};
 
 pub struct ClientCrypto<'a> {
     pub(crate) client: &'a crate::Client,

--- a/crates/bitwarden-core/src/mobile/client_crypto.rs
+++ b/crates/bitwarden-core/src/mobile/client_crypto.rs
@@ -12,44 +12,44 @@ use crate::{
     },
 };
 
+use super::crypto::{derive_key_connector, DeriveKeyConnectorRequest};
+
 pub struct ClientCrypto<'a> {
     pub(crate) client: &'a crate::Client,
 }
 
 impl<'a> ClientCrypto<'a> {
-    #[cfg(feature = "internal")]
     pub async fn initialize_user_crypto(&self, req: InitUserCryptoRequest) -> Result<()> {
         initialize_user_crypto(self.client, req).await
     }
 
-    #[cfg(feature = "internal")]
     pub async fn initialize_org_crypto(&self, req: InitOrgCryptoRequest) -> Result<()> {
         initialize_org_crypto(self.client, req).await
     }
 
-    #[cfg(feature = "internal")]
     pub async fn get_user_encryption_key(&self) -> Result<String> {
         get_user_encryption_key(self.client).await
     }
 
-    #[cfg(feature = "internal")]
     pub fn update_password(&self, new_password: String) -> Result<UpdatePasswordResponse> {
         update_password(self.client, new_password)
     }
 
-    #[cfg(feature = "internal")]
     pub fn derive_pin_key(&self, pin: String) -> Result<DerivePinKeyResponse> {
         derive_pin_key(self.client, pin)
     }
 
-    #[cfg(feature = "internal")]
     pub fn derive_pin_user_key(&self, encrypted_pin: EncString) -> Result<EncString> {
         derive_pin_user_key(self.client, encrypted_pin)
     }
 
-    #[cfg(feature = "internal")]
     pub fn enroll_admin_password_reset(&self, public_key: String) -> Result<AsymmetricEncString> {
         enroll_admin_password_reset(self.client, public_key)
+    }
+
+    /// Derive the master key for migrating to the key connector
+    pub fn derive_key_connector(&self, request: DeriveKeyConnectorRequest) -> Result<String> {
+        derive_key_connector(request)
     }
 }
 

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -340,6 +340,8 @@ pub(super) fn derive_key_connector(request: DeriveKeyConnectorRequest) -> Result
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use super::*;
     use crate::Client;
 
@@ -521,8 +523,6 @@ mod tests {
 
     #[test]
     fn test_enroll_admin_password_reset() {
-        use std::num::NonZeroU32;
-
         use base64::{engine::general_purpose::STANDARD, Engine};
         use bitwarden_crypto::AsymmetricCryptoKey;
 
@@ -556,5 +556,21 @@ mod tests {
         let enc = client.internal.get_encryption_settings().unwrap();
         let expected = enc.get_key(&None).unwrap();
         assert_eq!(&decrypted, &expected.to_vec());
+    }
+
+    #[test]
+    fn test_derive_key_connector() {
+        let request = DeriveKeyConnectorRequest {
+            password: "asdfasdfasdf".to_string(),
+            email: "test@bitwarden.com".to_string(),
+            kdf: Kdf::PBKDF2 {
+                iterations: NonZeroU32::new(600_000).unwrap(),
+            },
+            user_key_encrypted: "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=".parse().unwrap(),
+        };
+
+        let result = derive_key_connector(request).unwrap();
+
+        assert_eq!(result, "ySXq1RVLKEaV1eoQE/ui9aFKIvXTl9PAXwp1MljfF50=");
     }
 }

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
-use bitwarden::auth::{
-    password::MasterPasswordPolicyOptions, AuthRequestResponse, RegisterKeyResponse,
-    RegisterTdeKeyResponse,
+use bitwarden::{
+    auth::{
+        password::MasterPasswordPolicyOptions, AuthRequestResponse, KeyConnectorResponse,
+        RegisterKeyResponse, RegisterTdeKeyResponse,
+    },
+    Error,
 };
 use bitwarden_crypto::{AsymmetricEncString, EncString, HashPurpose, Kdf, TrustDeviceResponse};
 
@@ -77,6 +80,16 @@ impl ClientAuth {
              .0
             .auth()
             .make_register_tde_keys(email, org_public_key, remember_device)?)
+    }
+
+    /// Generate keys needed to onboard a new user without master key to key connector
+    pub fn make_key_connector_keys(&self) -> Result<KeyConnectorResponse> {
+        Ok(self
+            .0
+             .0
+            .auth()
+            .make_key_connector_keys()
+            .map_err(Error::Crypto)?)
     }
 
     /// Validate the user password

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use bitwarden::mobile::crypto::{
-    DerivePinKeyResponse, InitOrgCryptoRequest, InitUserCryptoRequest, UpdatePasswordResponse,
+    DeriveKeyConnectorRequest, DerivePinKeyResponse, InitOrgCryptoRequest, InitUserCryptoRequest,
+    UpdatePasswordResponse,
 };
 use bitwarden_crypto::{AsymmetricEncString, EncString};
 
@@ -51,5 +52,10 @@ impl ClientCrypto {
 
     pub fn enroll_admin_password_reset(&self, public_key: String) -> Result<AsymmetricEncString> {
         Ok(self.0 .0.crypto().enroll_admin_password_reset(public_key)?)
+    }
+
+    /// Derive the master key for migrating to the key connector
+    pub fn derive_key_connector(&self, request: DeriveKeyConnectorRequest) -> Result<String> {
+        Ok(self.0 .0.crypto().derive_key_connector(request)?)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-10929

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add support for Key Connector.

- Adds support for `KeyConnector` to `initialize_user_crypto`.
- Support generating a random master key that can be sent to the key connector.
- Support getting the current master key and sending it to the key connector.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
