### PR TITLE
breaking: Review and update Python sdk

### DIFF
--- a/languages/python/bitwarden_sdk/bitwarden_client.py
+++ b/languages/python/bitwarden_sdk/bitwarden_client.py
@@ -2,7 +2,16 @@ import json
 from typing import Any, List, Optional
 from uuid import UUID
 import bitwarden_py
-from .schemas import ClientSettings, Command, ResponseForSecretIdentifiersResponse, ResponseForSecretResponse, ResponseForSecretsDeleteResponse, SecretCreateRequest, SecretGetRequest, SecretIdentifiersRequest, SecretIdentifiersResponse, SecretPutRequest, SecretResponse, SecretsCommand, SecretsDeleteRequest, SecretsDeleteResponse, AccessTokenLoginRequest, AccessTokenLoginResponse, ResponseForAccessTokenLoginResponse, ResponseForProjectResponse, ProjectsCommand, ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectsListRequest, ResponseForProjectsResponse, ResponseForProjectsDeleteResponse, ProjectsDeleteRequest
+
+from .schemas import ClientSettings, Command, ResponseForSecretIdentifiersResponse, ResponseForSecretResponse, \
+    ResponseForSecretsResponse, ResponseForSecretsDeleteResponse, SecretCreateRequest, SecretGetRequest, \
+    SecretsGetRequest, SecretIdentifiersRequest, SecretIdentifiersResponse, SecretPutRequest, SecretResponse, \
+    SecretsCommand, SecretsDeleteRequest, SecretsDeleteResponse, SecretsSyncResponse, SecretsSyncRequest, \
+    AccessTokenLoginRequest, ResponseForSecretsSyncResponse, ResponseForAccessTokenLoginResponse, \
+    ResponseForProjectResponse, ProjectsCommand, ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, \
+    ProjectsListRequest, ResponseForProjectsResponse, ResponseForProjectsDeleteResponse, ProjectsDeleteRequest, \
+    SecretsResponse
+
 
 class BitwardenClient:
     def __init__(self, settings: ClientSettings = None):
@@ -12,11 +21,8 @@ class BitwardenClient:
             settings_json = json.dumps(settings.to_dict())
             self.inner = bitwarden_py.BitwardenClient(settings_json)
 
-    def access_token_login(self, access_token: str,
-                           state_file: str = None):
-        self._run_command(
-            Command(access_token_login=AccessTokenLoginRequest(access_token, state_file))
-        )
+    def auth(self):
+        return AuthClient(self)
 
     def secrets(self):
         return SecretsClient(self)
@@ -30,8 +36,21 @@ class BitwardenClient:
 
         if response["success"] == False:
             raise Exception(response["errorMessage"])
-        
+
         return response
+
+
+class AuthClient:
+    def __init__(self, client: BitwardenClient):
+        self.client = client
+
+    def login_access_token(self, access_token: str,
+                           state_file: str = None) -> ResponseForAccessTokenLoginResponse:
+        result = self.client._run_command(
+            Command(login_access_token=AccessTokenLoginRequest(access_token, state_file))
+        )
+        return ResponseForAccessTokenLoginResponse.from_dict(result)
+
 
 class SecretsClient:
     def __init__(self, client: BitwardenClient):
@@ -43,12 +62,24 @@ class SecretsClient:
         )
         return ResponseForSecretResponse.from_dict(result)
 
-    def create(self, key: str,
-               note: str,
-               organization_id: str,
-               value: str,
-               project_ids: Optional[List[UUID]] = None
-               ) -> ResponseForSecretResponse:
+    def get_by_ids(self, ids: List[UUID]) -> ResponseForSecretsResponse:
+        result = self.client._run_command(
+            Command(secrets=SecretsCommand(
+                get_by_ids=SecretsGetRequest(ids))
+            ))
+        return ResponseForSecretsResponse.from_dict(result)
+
+    def create(
+            self,
+            organization_id: UUID,
+            key: str,
+            value: str,
+            note: str,
+            project_ids: Optional[List[UUID]] = None,
+    ) -> ResponseForSecretResponse:
+        if note is None:
+            # secrets api does not accept empty notes
+            note = ""
         result = self.client._run_command(
             Command(secrets=SecretsCommand(
                 create=SecretCreateRequest(key, note, organization_id, value, project_ids)))
@@ -62,13 +93,18 @@ class SecretsClient:
         )
         return ResponseForSecretIdentifiersResponse.from_dict(result)
 
-    def update(self, id: str,
-               key: str,
-               note: str,
-               organization_id: str,
-               value: str,
-               project_ids: Optional[List[UUID]] = None
-               ) -> ResponseForSecretResponse:
+    def update(
+            self,
+            organization_id: str,
+            id: str,
+            key: str,
+            value: str,
+            note: str,
+            project_ids: Optional[List[UUID]] = None,
+    ) -> ResponseForSecretResponse:
+        if note is None:
+            # secrets api does not accept empty notes
+            note = ""
         result = self.client._run_command(
             Command(secrets=SecretsCommand(update=SecretPutRequest(
                 id, key, note, organization_id, value, project_ids)))
@@ -81,6 +117,13 @@ class SecretsClient:
         )
         return ResponseForSecretsDeleteResponse.from_dict(result)
 
+    def sync(self, organization_id: str, last_synced_date: Optional[str]) -> ResponseForSecretsSyncResponse:
+        result = self.client._run_command(
+            Command(secrets=SecretsCommand(sync=SecretsSyncRequest(organization_id, last_synced_date)))
+        )
+        return ResponseForSecretsSyncResponse.from_dict(result)
+
+
 class ProjectsClient:
     def __init__(self, client: BitwardenClient):
         self.client = client
@@ -92,8 +135,8 @@ class ProjectsClient:
         return ResponseForProjectResponse.from_dict(result)
 
     def create(self,
-               name: str,
                organization_id: str,
+               name: str,
                ) -> ResponseForProjectResponse:
         result = self.client._run_command(
             Command(projects=ProjectsCommand(
@@ -108,10 +151,12 @@ class ProjectsClient:
         )
         return ResponseForProjectsResponse.from_dict(result)
 
-    def update(self, id: str,
-               name: str,
-               organization_id: str,
-               ) -> ResponseForProjectResponse:
+    def update(
+            self,
+            organization_id: str,
+            id: str,
+            name: str,
+    ) -> ResponseForProjectResponse:
         result = self.client._run_command(
             Command(projects=ProjectsCommand(update=ProjectPutRequest(
                 id, name, organization_id)))

--- a/languages/python/bitwarden_sdk/bitwarden_client.py
+++ b/languages/python/bitwarden_sdk/bitwarden_client.py
@@ -3,14 +3,14 @@ from typing import Any, List, Optional
 from uuid import UUID
 import bitwarden_py
 
-from .schemas import ClientSettings, Command, ResponseForSecretIdentifiersResponse, ResponseForSecretResponse, \
-    ResponseForSecretsResponse, ResponseForSecretsDeleteResponse, SecretCreateRequest, SecretGetRequest, \
-    SecretsGetRequest, SecretIdentifiersRequest, SecretIdentifiersResponse, SecretPutRequest, SecretResponse, \
-    SecretsCommand, SecretsDeleteRequest, SecretsDeleteResponse, SecretsSyncResponse, SecretsSyncRequest, \
-    AccessTokenLoginRequest, ResponseForSecretsSyncResponse, ResponseForAccessTokenLoginResponse, \
-    ResponseForProjectResponse, ProjectsCommand, ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, \
-    ProjectsListRequest, ResponseForProjectsResponse, ResponseForProjectsDeleteResponse, ProjectsDeleteRequest, \
-    SecretsResponse
+from .schemas import (ClientSettings, Command, ResponseForSecretIdentifiersResponse, ResponseForSecretResponse,
+                      ResponseForSecretsResponse, ResponseForSecretsDeleteResponse, SecretCreateRequest,
+                      SecretGetRequest, SecretsGetRequest, SecretIdentifiersRequest, SecretPutRequest,
+                      SecretsCommand, SecretsDeleteRequest, SecretsSyncRequest, AccessTokenLoginRequest,
+                      ResponseForSecretsSyncResponse, ResponseForAccessTokenLoginResponse,
+                      ResponseForProjectResponse, ProjectsCommand, ProjectCreateRequest, ProjectGetRequest,
+                      ProjectPutRequest, ProjectsListRequest, ResponseForProjectsResponse,
+                      ResponseForProjectsDeleteResponse, ProjectsDeleteRequest)
 
 
 class BitwardenClient:
@@ -74,7 +74,7 @@ class SecretsClient:
             organization_id: UUID,
             key: str,
             value: str,
-            note: str,
+            note: Optional[str],
             project_ids: Optional[List[UUID]] = None,
     ) -> ResponseForSecretResponse:
         if note is None:
@@ -99,7 +99,7 @@ class SecretsClient:
             id: str,
             key: str,
             value: str,
-            note: str,
+            note: Optional[str],
             project_ids: Optional[List[UUID]] = None,
     ) -> ResponseForSecretResponse:
         if note is None:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1405

## 📔 Objective

Update the Python wrapper to use bindings that are consistent. This will be a breaking change, as it does the following:

- replaces `access_token_login()` with `auth().login_access_token()` to be more consistent with the newer auth method we use in the base SDK.
- reorders the `create()` and `update()` args for secrets and projects, with arguments that are most consistently required between methods (eg. `organization_id`) first.
  - `secrets.create(key, note, organization_id, value, project_ids)` -> `secrets.create(organization_id, key, value, note, project_ids)`
  - `secrets.update(id, key, note, organization_id, value, project_ids)` -> `secrets.create(organization_id, id, key, value, note, project_ids)`
  - `projects.create(name, organization_id)` -> `projects.create(organization_id, name)`
  - `projects.update(id, name, organization_id)` -> `projects.update(organization_id, id, name)`

This change also exposes `secrets.get_by_ids()` and `secrets.sync()`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
