### PR TITLE
Add explicit error for no private key

### DIFF
--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -234,7 +234,7 @@ impl InternalClient {
     pub fn initialize_org_crypto(
         &self,
         org_keys: Vec<(Uuid, AsymmetricEncString)>,
-    ) -> Result<Arc<EncryptionSettings>> {
+    ) -> Result<Arc<EncryptionSettings>, EncryptionSettingsError> {
         let mut guard = self
             .encryption_settings
             .write()

--- a/crates/bitwarden-core/src/mobile/client_crypto.rs
+++ b/crates/bitwarden-core/src/mobile/client_crypto.rs
@@ -25,7 +25,10 @@ impl<'a> ClientCrypto<'a> {
         initialize_user_crypto(self.client, req).await
     }
 
-    pub async fn initialize_org_crypto(&self, req: InitOrgCryptoRequest) -> Result<()> {
+    pub async fn initialize_org_crypto(
+        &self,
+        req: InitOrgCryptoRequest,
+    ) -> Result<(), EncryptionSettingsError> {
         initialize_org_crypto(self.client, req).await
     }
 

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -190,7 +190,10 @@ pub struct InitOrgCryptoRequest {
     pub organization_keys: HashMap<uuid::Uuid, AsymmetricEncString>,
 }
 
-pub async fn initialize_org_crypto(client: &Client, req: InitOrgCryptoRequest) -> Result<()> {
+pub async fn initialize_org_crypto(
+    client: &Client,
+    req: InitOrgCryptoRequest,
+) -> Result<(), EncryptionSettingsError> {
     let organization_keys = req.organization_keys.into_iter().collect();
     client.internal.initialize_org_crypto(organization_keys)?;
     Ok(())

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -31,7 +31,13 @@ impl ClientCrypto {
     /// Initialization method for the organization crypto. Needs to be called after
     /// `initialize_user_crypto` but before any other crypto operations.
     pub async fn initialize_org_crypto(&self, req: InitOrgCryptoRequest) -> Result<()> {
-        Ok(self.0 .0.crypto().initialize_org_crypto(req).await?)
+        Ok(self
+            .0
+             .0
+            .crypto()
+            .initialize_org_crypto(req)
+            .await
+            .map_err(Error::EncryptionSettings)?)
     }
 
     /// Get the uses's decrypted encryption key. Note: It's very important

--- a/crates/bitwarden-vault/src/sync.rs
+++ b/crates/bitwarden-vault/src/sync.rs
@@ -44,7 +44,10 @@ pub(crate) async fn sync(client: &Client, input: &SyncRequest) -> Result<SyncRes
         .filter_map(|o| o.id.zip(o.key.as_deref().and_then(|k| k.parse().ok())))
         .collect();
 
-    let enc = client.internal.initialize_org_crypto(org_keys)?;
+    let enc = client
+        .internal
+        .initialize_org_crypto(org_keys)
+        .map_err(bitwarden_core::Error::EncryptionSettings)?;
 
     SyncResponse::process_response(sync, &enc)
 }


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follow up to #1024, which improves the error message when missing a private key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
