### PR TITLE
[SM-1434] - Dynamically-linked bitwarden-c not working for older supported OS versions

### DIFF
--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -68,8 +68,7 @@ jobs:
         if: ${{ !contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
-          CGO_CFLAGS: "-mmacosx-version-min=10.12"
-          CGO_LDFLAGS: "-mmacosx-version-min=10.12"
+          MACOSX_DEPLOYMENT_TARGET: "10.6"
         run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         settings:
           # we must use the oldest supported runner when building dynamically-linked libbitwarden_c
-          - os: macos-12 # use older runner for dynamically-linked libbitwarden_c
+          - os: macos-13
             target: x86_64-apple-darwin
-          - os: macos-12 # use older runner for dynamically-linked libbitwarden_c
+          - os: macos-13
             target: aarch64-apple-darwin
           - os: windows-2022
             target: x86_64-pc-windows-msvc
@@ -68,6 +68,8 @@ jobs:
         if: ${{ !contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
+          CGO_CFLAGS: "-mmacosx-version-min=10.12"
+          CGO_LDFLAGS: "-mmacosx-version-min=10.12"
         run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # we must use the oldest supported runner when building dynamically-linked libbitwarden_c
+          # caution: updating the runner OS version for dynamically-linked
+          #   targets will likely break libbitwarden_c for older OS versions.
+          #   prefer using oldest supported runner for for these targets
           - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-13
@@ -68,7 +70,7 @@ jobs:
         if: ${{ !contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
-          MACOSX_DEPLOYMENT_TARGET: "10.6"
+          MACOSX_DEPLOYMENT_TARGET: "10.6" # allows using new macos runner versions while still supporting older systems
         run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -27,7 +27,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-2022
             target: x86_64-pc-windows-gnu
-          - os: ubuntu-20.04 # use older runner for dynamically-linked libbitwarden_c
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -18,9 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # caution: updating the runner OS version for dynamically-linked
-          #   targets will likely break libbitwarden_c for older OS versions.
-          #   prefer using oldest supported runner for for these targets
           - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-13
@@ -29,6 +26,9 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: windows-2022
             target: x86_64-pc-windows-gnu
+          # caution: updating the linux runner OS version for GNU
+          #   targets will likely break libbitwarden_c for older OS versions.
+          #   prefer using oldest supported runner for for these targets
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
@@ -70,7 +70,7 @@ jobs:
         if: ${{ !contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
-          MACOSX_DEPLOYMENT_TARGET: "10.6" # allows using new macos runner versions while still supporting older systems
+          MACOSX_DEPLOYMENT_TARGET: "10.10" # allows using new macos runner versions while still supporting older systems
         run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ !contains(matrix.settings.target, 'musl') }}
         env:
           RUSTFLAGS: "-D warnings"
-          MACOSX_DEPLOYMENT_TARGET: "10.10" # allows using new macos runner versions while still supporting older systems
+          MACOSX_DEPLOYMENT_TARGET: "10.14" # allows using new macos runner versions while still supporting older systems
         run: cargo build -p bitwarden-c --target ${{ matrix.settings.target }} --release
 
       - name: Upload Artifact

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -18,15 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - os: macos-13
+          # we must use the oldest supported runner when building dynamically-linked libbitwarden_c
+          - os: macos-12 # use older runner for dynamically-linked libbitwarden_c
             target: x86_64-apple-darwin
-          - os: macos-13
+          - os: macos-12 # use older runner for dynamically-linked libbitwarden_c
             target: aarch64-apple-darwin
           - os: windows-2022
             target: x86_64-pc-windows-msvc
           - os: windows-2022
             target: x86_64-pc-windows-gnu
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04 # use older runner for dynamically-linked libbitwarden_c
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl


### PR DESCRIPTION
[//]: # (https://bitwarden.atlassian.net/browse/SM-1434)

## 📔 Objective

The bitwarden-c lib is dynamically-linked with the version of GCC/Clang that is installed on the GitHub runner. Using newer runners will result in errors like this, for those that are running older, but still-supported versions of macOS:

```
object file (/Users/user/go/pkg/mod/github.com/bitwarden/sdk-go@v1.0.0/internal/cinterface/lib/darwin-x64/libbitwarden_c.a[216](8912af01511d326c-sha256-x86_64-macosx.o)) was built for newer 'macOS' version (14.2) than being linked (14.0)
```

This PR uses `MACOSX_DEPLOYMENT_TARGET` to support older versions of macOS.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
