### PR TITLE
Bundle platform-verifier

### DIFF
--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -28,7 +28,7 @@ use vault::ClientVault;
 #[derive(uniffi::Object)]
 pub struct Client(bitwarden::Client);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl Client {
     /// Initialize a new instance of the SDK client
     #[uniffi::constructor]
@@ -78,6 +78,18 @@ impl Client {
     /// Test method, echoes back the input
     pub fn echo(&self, msg: String) -> String {
         msg
+    }
+
+    /// Test method, calls http endpoint
+    pub async fn http_get(&self, url: String) -> Result<String> {
+        let client = self.0.internal.get_http_client();
+        let res = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(bitwarden::Error::Reqwest)?;
+
+        Ok(res.text().await.map_err(bitwarden::Error::Reqwest)?)
     }
 }
 

--- a/languages/kotlin/sdk/build.gradle
+++ b/languages/kotlin/sdk/build.gradle
@@ -12,8 +12,8 @@ android {
         minSdk 28
         targetSdk 34
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        consumerProguardFiles 'consumer-rules.pro'
     }
 
     buildTypes {
@@ -31,7 +31,7 @@ android {
     }
 
     lint {
-        baseline = file("lint-baseline.xml")
+        baseline = file('lint-baseline.xml')
     }
 
     publishing {
@@ -52,9 +52,9 @@ publishing {
             // PRs: use the branch name.
             // Main: Grab it from `crates/bitwarden/Cargo.toml`
 
-            def branchName = "git branch --show-current".execute().text.trim()
+            def branchName = 'git branch --show-current'.execute().text.trim()
 
-            if (branchName == "main") {
+            if (branchName == 'main') {
                 def content = ['grep', '-o', '^version = ".*"', '../../Cargo.toml'].execute().text.trim()
                 def match = ~/version = "(.*)"/
                 def matcher = match.matcher(content)
@@ -73,19 +73,38 @@ publishing {
     }
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/bitwarden/sdk"
+            name = 'GitHubPackages'
+            url = 'https://maven.pkg.github.com/bitwarden/sdk'
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = System.getenv('GITHUB_ACTOR')
+                password = System.getenv('GITHUB_TOKEN')
             }
         }
     }
 }
 
+// Find and include the classes.jar from platform-verifier.
+//
+// Based on the instructions from the readme in https://github.com/rustls/rustls-platform-verifier
+// and issue details from https://github.com/rustls/rustls-platform-verifier/issues/115.
+File findRustlsPlatformVerifierClassesJar() {
+    def dependencyText = providers.exec {
+        it.workingDir = new File('../../')
+        commandLine('cargo', 'metadata', '--format-version', '1', '--manifest-path', 'crates/bitwarden-uniffi/Cargo.toml')
+    }.standardOutput.asText.get()
+
+    def dependencyJson = new groovy.json.JsonSlurper().parseText(dependencyText)
+    def manifestPath = file(dependencyJson.packages.find { it.name == "rustls-platform-verifier-android" }.manifest_path)
+
+    def aar = fileTree(manifestPath.parentFile).matching {
+        include "maven/rustls/rustls-platform-verifier/*/rustls-platform-verifier-*.aar"
+    }.getSingleFile()
+    return zipTree(aar).matching { include 'classes.jar'}.getSingleFile()
+}
+
 dependencies {
     implementation 'net.java.dev.jna:jna:5.14.0@aar'
-    implementation 'rustls:rustls-platform-verifier:latest.release'
+    implementation files(findRustlsPlatformVerifierClassesJar())
 
     implementation 'androidx.core:core-ktx:1.13.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'

--- a/languages/kotlin/settings.gradle
+++ b/languages/kotlin/settings.gradle
@@ -10,25 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-
-        maven {
-            url = findRustlsPlatformVerifierProject()
-            metadataSources.artifact()
-        }
     }
 }
 
-String findRustlsPlatformVerifierProject() {
-    def dependencyText = providers.exec {
-        it.workingDir = new File("../../")
-        commandLine("cargo", "metadata", "--format-version", "1", "--manifest-path", "crates/bitwarden-uniffi/Cargo.toml")
-    }.standardOutput.asText.get()
-
-    def dependencyJson = new groovy.json.JsonSlurper().parseText(dependencyText)
-    def manifestPath = file(dependencyJson.packages.find { it.name == "rustls-platform-verifier-android" }.manifest_path)
-    return new File(manifestPath.parentFile, "maven").path
-}
-
-rootProject.name = "My Application"
+rootProject.name = 'My Application'
 include ':app'
 include ':sdk'


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We've run into some issues related to rustls-platform-verifier distributing an android library through their crate, which works great if you use platform-verifier within an application. However since we distribute an sdk, the application have difficulties locating the android specific platform-verifier library.

To resolve this we follow the method established in https://github.com/rustls/rustls-platform-verifier/issues/115 and bundle the classes with the library.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
