### PR TITLE
BRE-328 - Simplify logic and apply linting suggestions in Publish Ruby workflow

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -18,30 +18,22 @@ permissions:
   id-token: write
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Branch check
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
-            echo "==================================="
-            exit 1
-          fi
-
   publish_ruby:
     name: Publish Ruby
     runs-on: ubuntu-22.04
-    needs: setup
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      
+      - name: Branch check
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'main' branch"
+            echo "==================================="
+            exit 1
+          fi
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@52753b7da854d5c07df37391a986c76ab4615999 # v1.191.0
@@ -54,7 +46,7 @@ jobs:
           workflow: generate_schemas.yml
           path: languages/ruby/bitwarden_sdk_secrets/lib
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: main
           artifacts: schemas.rb
 
       - name: Download x86_64-apple-darwin artifact
@@ -63,7 +55,7 @@ jobs:
           workflow: build-rust-cross-platform.yml
           path: temp/macos-x64
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: main
           artifacts: libbitwarden_c_files-x86_64-apple-darwin
 
       - name: Download aarch64-apple-darwin artifact
@@ -71,7 +63,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: main
           artifacts: libbitwarden_c_files-aarch64-apple-darwin
           path: temp/macos-arm64
 
@@ -80,7 +72,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: main
           artifacts: libbitwarden_c_files-x86_64-unknown-linux-gnu
           path: temp/linux-x64
 
@@ -89,7 +81,7 @@ jobs:
         with:
           workflow: build-rust-cross-platform.yml
           workflow_conclusion: success
-          branch: ${{ github.event.inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
+          branch: main
           artifacts: libbitwarden_c_files-x86_64-pc-windows-msvc
           path: temp/windows-x64
 
@@ -128,6 +120,7 @@ jobs:
         working-directory: languages/ruby/bitwarden_sdk_secrets
 
       - name: Push gem to Rubygems
+        if: ${{ inputs.release_type != 'Dry Run' }}
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [Card](https://bitwarden.atlassian.net/browse/BRE-328?atlOrigin=eyJpIjoiZTgyOGJlZmFjMTU2NGZmOWJlNDBkNDIwYWY0NDFkZmUiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the Publish Ruby workflow with linting suggestions and allows releasing from the `main` branch only.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
