### PR TITLE
[BRE-339] Fix Swift release workflow - artifact zip

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -61,11 +61,16 @@ jobs:
           # SHA Short
           echo "short-sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Zip BitwardenFFI.xcframework
+        run: |
+          cd languages/swift
+          zip -r BitwardenFFI.xcframework.zip BitwardenFFI.xcframework
+
       - name: Upload BitwardenFFI.xcframework artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: BitwardenFFI-${{ env._VERSION }}-${{ steps.build.outputs.short-sha }}.xcframework
-          path: languages/swift/BitwardenFFI.xcframework
+          path: languages/swift/BitwardenFFI.xcframework.zip
           if-no-files-found: error
 
       - name: Upload BitwardenSdk sources

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -63,14 +63,14 @@ jobs:
 
       - name: Zip BitwardenFFI.xcframework
         run: |
-          cd languages/swift
-          zip -r BitwardenFFI.xcframework.zip BitwardenFFI.xcframework
+          mkdir artifacts
+          cp -rf languages/swift/BitwardenFFI.xcframework artifacts
 
       - name: Upload BitwardenFFI.xcframework artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: BitwardenFFI-${{ env._VERSION }}-${{ steps.build.outputs.short-sha }}.xcframework
-          path: languages/swift/BitwardenFFI.xcframework.zip
+          path: artifacts
           if-no-files-found: error
 
       - name: Upload BitwardenSdk sources


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/BRE-339

## 📔 Objective

When unpack the created artifact it takes the name of the zip file. It should unpack as `BitwardenFFI.xcframework`.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
