### PR TITLE
Release Python Workflow - Fix logic

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      # - name: Branch check
-      #   if: ${{ inputs.release_type != 'Dry Run' }}
-      #   run: |
-      #     if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-      #       echo "==================================="
-      #       echo "[!] Can only release from the 'main' branch"
-      #       echo "==================================="
-      #       exit 1
-      #     fi
+      - name: Branch check
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'main' branch"
+            echo "==================================="
+            exit 1
+          fi
 
       - name: Get version
         id: version
@@ -58,11 +58,10 @@ jobs:
           name: bitwarden_sdk(.*)
           name_is_regexp: true
 
-      - name: TEST
+      - name: Move all whl files to single directory
         run: |
           shopt -s globstar
           mv **/*.whl .
-          ls -alh .
         working-directory: ${{ github.workspace }}/target/wheels/dist
 
       - name: Create GitHub release

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -59,7 +59,11 @@ jobs:
           name_is_regexp: true
 
       - name: TEST
-        run: ls -alh ${{ github.workspace }}/target/wheels/dist
+        run: |
+          shopt -s globstar
+          mv **/*.whl .
+          ls -alh .
+        working-directory: ${{ github.workspace }}/target/wheels/dist
 
       - name: Create GitHub release
         if: ${{ inputs.release_type != 'Dry Run' }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -38,7 +38,7 @@ jobs:
         id: version
         run: |
           VERSION=$(cat languages/python/pyproject.toml | grep -Eo 'version = "[0-9]+\.[0-9]+\.[0-9]+"' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   release:
     name: Release

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Branch check
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'main' branch"
-            echo "==================================="
-            exit 1
-          fi
+      # - name: Branch check
+      #   if: ${{ inputs.release_type != 'Dry Run' }}
+      #   run: |
+      #     if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+      #       echo "==================================="
+      #       echo "[!] Can only release from the 'main' branch"
+      #       echo "==================================="
+      #       exit 1
+      #     fi
 
       - name: Get version
         id: version

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -58,6 +58,9 @@ jobs:
           name: bitwarden_sdk(.*)
           name_is_regexp: true
 
+      - name: TEST
+        run: ls -alh ${{ github.workspace }}/target/wheels/dist
+
       - name: Create GitHub release
         if: ${{ inputs.release_type != 'Dry Run' }}
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the Release Python SDK workflow to fix some logic. The version in the `setup` job was being echoed to `GITHUB_ENV` instead of `GITHUB_OUTPUT`. The downloaded artifacts were all in separate directories, so I moved them all to a single directory to allow them to be uploaded to the GitHub release draft.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
