### PR TITLE
Fix panic handling during memory testing

### DIFF
--- a/crates/memory-testing/cases.json
+++ b/crates/memory-testing/cases.json
@@ -72,7 +72,7 @@
         "kdf": {
           "argon2id": {
             "iterations": 3,
-            "memory": 4,
+            "memory": 16,
             "parallelism": 1
           }
         }
@@ -80,15 +80,15 @@
       "memory_lookups": [
         {
           "name": "Key",
-          "hex": "3bc0520a0abff0097d521ce0ee5e5b1cee301939a84742623c0c1697d7a4bd46"
+          "hex": "59079cd7134409c6882c2701de8357a3d8aabb2dad2da19eea5f1b8081dfb51c"
         },
         {
           "name": "Hash B64",
-          "string": "lHkprdORlICVJ4Umwi94Uz/nATK6Y7If7e+iFoabzh0="
+          "string": "P1ZT6T80zOfEqXj/kPbtON3yszf7xLNGCxWjdO2xfjU="
         },
         {
           "name": "Hash bytes",
-          "hex": "947929add391948095278526c22f78533fe70132ba63b21fedefa216869bce1d"
+          "hex": "3f5653e93f34cce7c4a978ff90f6ed38ddf2b337fbc4b3460b15a374edb17e35"
         }
       ]
     },

--- a/crates/memory-testing/src/bin/capture-dumps.rs
+++ b/crates/memory-testing/src/bin/capture-dumps.rs
@@ -37,6 +37,11 @@ fn wait_dump_and_continue(
     loop {
         let mut buf = [0u8; 1024];
         let read = stdout.read(&mut buf).unwrap();
+
+        if read == 0 {
+            panic!("Process exited unexpectedly");
+        }
+
         let buf_str = std::str::from_utf8(&buf[..read]).unwrap();
         if buf_str.contains("Waiting for dump...") {
             break;


### PR DESCRIPTION
## 📔 Objective

Previously the memory testing program wouldn't detect when the binary being executed panicked unexpectedly, which caused the program to run indefinitely while waiting for the binary to notify it to continue. 

This started appearing when adding the validation for KDF minimums, as one of the tests we run is under the minimum, which causes CI to run until timeout: https://github.com/bitwarden/sdk/actions/runs/11109271931

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
