### PR TITLE
[PM-5693] Migrate SDK to CryptoService

### DIFF
--- a/crates/bitwarden-core/src/auth/client_auth.rs
+++ b/crates/bitwarden-core/src/auth/client_auth.rs
@@ -162,9 +162,11 @@ impl<'a> ClientAuth<'a> {
 
 #[cfg(feature = "internal")]
 fn trust_device(client: &Client) -> Result<TrustDeviceResponse> {
-    let enc = client.internal.get_encryption_settings()?;
+    use crate::key_management::SymmetricKeyRef;
 
-    let user_key = enc.get_key(&None)?;
+    let ctx = client.internal.get_crypto_service().context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyRef::User)?;
 
     Ok(DeviceKey::trust_device(user_key)?)
 }

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -3,6 +3,7 @@ use bitwarden_crypto::{EncString, PinKey};
 use crate::{
     client::{LoginMethod, UserLoginMethod},
     error::{Error, Result},
+    key_management::SymmetricKeyRef,
     Client,
 };
 
@@ -24,8 +25,9 @@ pub(crate) fn validate_pin(
     match login_method {
         UserLoginMethod::Username { email, kdf, .. }
         | UserLoginMethod::ApiKey { email, kdf, .. } => {
-            let enc = client.internal.get_encryption_settings()?;
-            let user_key = enc.get_key(&None)?;
+            let ctx = client.internal.get_crypto_service().context();
+            #[allow(deprecated)]
+            let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyRef::User)?;
 
             let pin_key = PinKey::derive(pin.as_bytes(), email.as_bytes(), kdf)?;
 

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use crate::{
     auth::api::request::AccessTokenRequest,
     client::ServiceAccountLoginMethod,
+    key_management::SymmetricKeyRef,
     secrets_manager::state::{self, ClientState},
 };
 use crate::{
@@ -70,10 +71,14 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
                     .send(&config)
                     .await?;
 
-                    if let (IdentityTokenResponse::Payload(r), Some(state_file), Ok(enc_settings)) =
-                        (&result, state_file, client.get_encryption_settings())
+                    if let (IdentityTokenResponse::Payload(r), Some(state_file)) =
+                        (&result, state_file)
                     {
-                        if let Ok(enc_key) = enc_settings.get_key(&None) {
+                        let ctx = client.get_crypto_service().context();
+
+                        #[allow(deprecated)]
+                        if let Ok(enc_key) = ctx.dangerous_get_symmetric_key(SymmetricKeyRef::User)
+                        {
                             let state =
                                 ClientState::new(r.access_token.clone(), enc_key.to_base64());
                             _ = state::set(state_file, access_token, state);

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use bitwarden_crypto::service::CryptoService;
 use reqwest::header::{self, HeaderValue};
 
 use super::internal::InternalClient;
@@ -78,7 +79,7 @@ impl Client {
                     device_type: settings.device_type,
                 })),
                 external_client,
-                encryption_settings: RwLock::new(None),
+                crypto_service: CryptoService::new(),
             },
         }
     }

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -1,14 +1,15 @@
-use std::collections::HashMap;
-
-use bitwarden_crypto::{AsymmetricCryptoKey, CryptoError, KeyContainer, SymmetricCryptoKey};
+use bitwarden_crypto::{service::CryptoService, AsymmetricCryptoKey, SymmetricCryptoKey};
 #[cfg(feature = "internal")]
-use bitwarden_crypto::{AsymmetricEncString, EncString, MasterKey};
+use bitwarden_crypto::{AsymmetricEncString, EncString};
 use thiserror::Error;
 use uuid::Uuid;
 
 #[cfg(feature = "internal")]
 use crate::error::Result;
-use crate::VaultLocked;
+use crate::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    VaultLocked,
+};
 
 #[derive(Debug, Error)]
 pub enum EncryptionSettingsError {
@@ -28,32 +29,9 @@ pub enum EncryptionSettingsError {
     MissingPrivateKey,
 }
 
-#[derive(Clone)]
-pub struct EncryptionSettings {
-    user_key: SymmetricCryptoKey,
-    pub(crate) private_key: Option<AsymmetricCryptoKey>,
-    org_keys: HashMap<Uuid, SymmetricCryptoKey>,
-}
-
-impl std::fmt::Debug for EncryptionSettings {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EncryptionSettings").finish()
-    }
-}
+pub struct EncryptionSettings {}
 
 impl EncryptionSettings {
-    /// Initialize the encryption settings with the master key and the encrypted user keys
-    #[cfg(feature = "internal")]
-    pub(crate) fn new(
-        master_key: MasterKey,
-        user_key: EncString,
-        private_key: EncString,
-    ) -> Result<Self, EncryptionSettingsError> {
-        // Decrypt the user key
-        let user_key = master_key.decrypt_user_key(user_key)?;
-        Self::new_decrypted_key(user_key, private_key)
-    }
-
     /// Initialize the encryption settings with the decrypted user key and the encrypted user
     /// private key This should only be used when unlocking the vault via biometrics or when the
     /// vault is set to lock: "never" Otherwise handling the decrypted user key is dangerous and
@@ -62,7 +40,8 @@ impl EncryptionSettings {
     pub(crate) fn new_decrypted_key(
         user_key: SymmetricCryptoKey,
         private_key: EncString,
-    ) -> Result<Self, EncryptionSettingsError> {
+        crypto_service: &CryptoService<SymmetricKeyRef, AsymmetricKeyRef>,
+    ) -> Result<(), EncryptionSettingsError> {
         use bitwarden_crypto::KeyDecryptable;
         use log::warn;
 
@@ -83,76 +62,61 @@ impl EncryptionSettings {
             // )
         };
 
-        Ok(EncryptionSettings {
-            user_key,
-            private_key,
-            org_keys: HashMap::new(),
-        })
+        #[allow(deprecated)]
+        {
+            let mut ctx = crypto_service.context_mut();
+            ctx.set_symmetric_key(SymmetricKeyRef::User, user_key)?;
+            if let Some(private_key) = private_key {
+                ctx.set_asymmetric_key(AsymmetricKeyRef::UserPrivateKey, private_key)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Initialize the encryption settings with only a single decrypted key.
     /// This is used only for logging in Secrets Manager with an access token
     #[cfg(feature = "secrets")]
-    pub(crate) fn new_single_key(key: SymmetricCryptoKey) -> Self {
-        EncryptionSettings {
-            user_key: key,
-            private_key: None,
-            org_keys: HashMap::new(),
-        }
+    pub(crate) fn new_single_key(
+        key: SymmetricCryptoKey,
+        crypto_service: &CryptoService<SymmetricKeyRef, AsymmetricKeyRef>,
+    ) {
+        #[allow(deprecated)]
+        crypto_service
+            .context_mut()
+            .set_symmetric_key(SymmetricKeyRef::User, key)
+            .expect("Mutable context");
     }
 
     #[cfg(feature = "internal")]
     pub(crate) fn set_org_keys(
-        &mut self,
         org_enc_keys: Vec<(Uuid, AsymmetricEncString)>,
-    ) -> Result<&Self, EncryptionSettingsError> {
-        use bitwarden_crypto::KeyDecryptable;
+        crypto_service: &CryptoService<SymmetricKeyRef, AsymmetricKeyRef>,
+    ) -> Result<(), EncryptionSettingsError> {
+        let mut ctx = crypto_service.context_mut();
+
+        if !ctx.has_asymmetric_key(AsymmetricKeyRef::UserPrivateKey) {
+            return Err(VaultLocked.into());
+        }
 
         // Make sure we only keep the keys given in the arguments and not any of the previous
         // ones, which might be from organizations that the user is no longer a part of anymore
-        self.org_keys.clear();
+        ctx.retain_symmetric_keys(|key_ref| !matches!(key_ref, SymmetricKeyRef::Organization(_)));
 
         // FIXME: [PM-11690] - Early abort to handle private key being corrupt
         if org_enc_keys.is_empty() {
-            return Ok(self);
+            return Ok(());
         }
-
-        let private_key = self
-            .private_key
-            .as_ref()
-            .ok_or(EncryptionSettingsError::MissingPrivateKey)?;
 
         // Decrypt the org keys with the private key
         for (org_id, org_enc_key) in org_enc_keys {
-            let mut dec: Vec<u8> = org_enc_key.decrypt_with_key(private_key)?;
-
-            let org_key = SymmetricCryptoKey::try_from(dec.as_mut_slice())?;
-
-            self.org_keys.insert(org_id, org_key);
+            ctx.decrypt_symmetric_key_with_asymmetric_key(
+                AsymmetricKeyRef::UserPrivateKey,
+                SymmetricKeyRef::Organization(org_id),
+                &org_enc_key,
+            )?;
         }
 
-        Ok(self)
-    }
-
-    pub fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError> {
-        // If we don't have a private key set (to decode multiple org keys), we just use the main
-        // user key
-        if self.private_key.is_none() {
-            return Ok(&self.user_key);
-        }
-
-        match org_id {
-            Some(org_id) => self
-                .org_keys
-                .get(org_id)
-                .ok_or(CryptoError::MissingKey(*org_id)),
-            None => Ok(&self.user_key),
-        }
-    }
-}
-
-impl KeyContainer for EncryptionSettings {
-    fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError> {
-        EncryptionSettings::get_key(self, org_id)
+        Ok(())
     }
 }

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -1,0 +1,55 @@
+use bitwarden_crypto::{key_refs, service::CryptoService, SymmetricCryptoKey};
+
+key_refs! {
+    #[symmetric]
+    pub enum SymmetricKeyRef {
+        Master,
+        User,
+        Organization(uuid::Uuid),
+        #[local]
+        Local(&'static str),
+    }
+
+    #[asymmetric]
+    pub enum AsymmetricKeyRef {
+        UserPrivateKey,
+        #[local]
+        Local(&'static str),
+    }
+}
+
+pub fn create_test_crypto_with_user_key(
+    key: SymmetricCryptoKey,
+) -> CryptoService<SymmetricKeyRef, AsymmetricKeyRef> {
+    let service = CryptoService::new();
+
+    #[allow(deprecated)]
+    service
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyRef::User, key.clone())
+        .expect("Mutable context");
+
+    service
+}
+
+pub fn create_test_crypto_with_user_and_org_key(
+    key: SymmetricCryptoKey,
+    org_id: uuid::Uuid,
+    org_key: SymmetricCryptoKey,
+) -> CryptoService<SymmetricKeyRef, AsymmetricKeyRef> {
+    let service = CryptoService::new();
+
+    #[allow(deprecated)]
+    service
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyRef::User, key.clone())
+        .expect("Mutable context");
+
+    #[allow(deprecated)]
+    service
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyRef::Organization(org_id), org_key.clone())
+        .expect("Mutable context");
+
+    service
+}

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod admin_console;
 pub mod auth;
 pub mod client;
 mod error;
+pub mod key_management;
 pub use error::{validate_only_whitespaces, Error, MissingFieldError, VaultLocked};
 #[cfg(feature = "internal")]
 pub mod mobile;

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use super::{check_length, from_b64, from_b64_vec, split_enc_string};
 use crate::{
     error::{CryptoError, EncStringParseError, Result},
-    KeyDecryptable, KeyEncryptable, LocateKey, SymmetricCryptoKey,
+    KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
 };
 
 /// # Encrypted string primitive
@@ -222,7 +222,6 @@ impl EncString {
     }
 }
 
-impl LocateKey for EncString {}
 impl KeyEncryptable<SymmetricCryptoKey, EncString> for &[u8] {
     fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<EncString> {
         EncString::encrypt_aes256_hmac(

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use thiserror::Error;
-use uuid::Uuid;
 
 use crate::fingerprint::FingerprintError;
 
@@ -19,12 +18,10 @@ pub enum CryptoError {
     InvalidKeyLen,
     #[error("The value is not a valid UTF8 String")]
     InvalidUtf8String,
-    #[error("Missing Key for organization with ID {0}")]
-    MissingKey(Uuid),
+    #[error("Missing Key for Ref. {0}")]
+    MissingKey(String),
     #[error("The item was missing a required field: {0}")]
     MissingField(&'static str),
-    #[error("Missing Key for Ref. {0}")]
-    MissingKey2(String),
     #[error("Crypto store is read-only")]
     ReadOnlyCryptoStore,
 

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -15,16 +15,6 @@ impl<T: KeyContainer> KeyContainer for Arc<T> {
     }
 }
 
-pub trait LocateKey {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        org_id: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(org_id)
-    }
-}
-
 pub trait CryptoKey {}
 
 pub trait KeyEncryptable<Key: CryptoKey, Output> {

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -1,5 +1,5 @@
 mod key_encryptable;
-pub use key_encryptable::{CryptoKey, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey};
+pub use key_encryptable::{CryptoKey, KeyContainer, KeyDecryptable, KeyEncryptable};
 mod encryptable;
 pub use encryptable::{Decryptable, Encryptable, UsesKey};
 pub mod key_ref;

--- a/crates/bitwarden-crypto/src/service/context.rs
+++ b/crates/bitwarden-crypto/src/service/context.rs
@@ -239,7 +239,7 @@ impl<
         } else {
             self.global.get().symmetric_keys.get(key_ref)
         }
-        .ok_or_else(|| crate::CryptoError::MissingKey2(format!("{key_ref:?}")))
+        .ok_or_else(|| crate::CryptoError::MissingKey(format!("{key_ref:?}")))
     }
 
     fn get_asymmetric_key(&self, key_ref: AsymmKeyRef) -> Result<&AsymmetricCryptoKey> {
@@ -248,7 +248,7 @@ impl<
         } else {
             self.global.get().asymmetric_keys.get(key_ref)
         }
-        .ok_or_else(|| crate::CryptoError::MissingKey2(format!("{key_ref:?}")))
+        .ok_or_else(|| crate::CryptoError::MissingKey(format!("{key_ref:?}")))
     }
 
     #[deprecated(note = "This function should ideally never be used outside this crate")]

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::Client;
-use bitwarden_crypto::KeyDecryptable;
 use bitwarden_vault::{Cipher, CipherView, Collection, Folder, FolderView};
 
 use crate::{
@@ -13,13 +12,12 @@ pub(crate) fn export_vault(
     ciphers: Vec<Cipher>,
     format: ExportFormat,
 ) -> Result<String, ExportError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None)?;
+    let crypto = client.internal.get_crypto_service();
 
-    let folders: Vec<FolderView> = folders.decrypt_with_key(key)?;
+    let folders: Vec<FolderView> = crypto.decrypt_list(&folders)?;
     let folders: Vec<crate::Folder> = folders.into_iter().flat_map(|f| f.try_into()).collect();
 
-    let ciphers: Vec<CipherView> = ciphers.decrypt_with_key(key)?;
+    let ciphers: Vec<CipherView> = crypto.decrypt_list(&ciphers)?;
     let ciphers: Vec<crate::Cipher> = ciphers.into_iter().flat_map(|c| c.try_into()).collect();
 
     match format {

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -47,11 +47,11 @@ impl<'a> ClientFido2<'a> {
         &'a self,
         cipher_view: CipherView,
     ) -> Result<Vec<Fido2CredentialAutofillView>, DecryptFido2AutofillCredentialsError> {
-        let enc = self.client.internal.get_encryption_settings()?;
+        let crypto = self.client.internal.get_crypto_service();
 
         Ok(Fido2CredentialAutofillView::from_cipher_view(
             &cipher_view,
-            &*enc,
+            &mut crypto.context(),
         )?)
     }
 }

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -1,5 +1,6 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use bitwarden_crypto::KeyContainer;
+use bitwarden_core::key_management::{AsymmetricKeyRef, SymmetricKeyRef};
+use bitwarden_crypto::service::CryptoServiceContext;
 use bitwarden_vault::{
     CipherError, CipherView, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView,
 };
@@ -62,8 +63,11 @@ pub(crate) struct CipherViewContainer {
 }
 
 impl CipherViewContainer {
-    fn new(cipher: CipherView, enc: &dyn KeyContainer) -> Result<Self, CipherError> {
-        let fido2_credentials = cipher.get_fido2_credentials(enc)?;
+    fn new(
+        cipher: CipherView,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+    ) -> Result<Self, CipherError> {
+        let fido2_credentials = cipher.get_fido2_credentials(ctx)?;
         Ok(Self {
             cipher,
             fido2_credentials,

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use bitwarden_crypto::KeyContainer;
+use bitwarden_core::key_management::{AsymmetricKeyRef, SymmetricKeyRef};
+use bitwarden_crypto::service::CryptoServiceContext;
 use bitwarden_vault::{CipherError, CipherView};
 use passkey::types::webauthn::UserVerificationRequirement;
 use reqwest::Url;
@@ -65,9 +66,9 @@ pub enum Fido2CredentialAutofillViewError {
 impl Fido2CredentialAutofillView {
     pub fn from_cipher_view(
         cipher: &CipherView,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     ) -> Result<Vec<Fido2CredentialAutofillView>, Fido2CredentialAutofillViewError> {
-        let credentials = cipher.decrypt_fido2_credentials(enc)?;
+        let credentials = cipher.decrypt_fido2_credentials(ctx)?;
 
         credentials
             .into_iter()

--- a/crates/bitwarden-sm/src/projects/create.rs
+++ b/crates/bitwarden-sm/src/projects/create.rs
@@ -1,6 +1,6 @@
 use bitwarden_api_api::models::ProjectCreateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error};
-use bitwarden_crypto::KeyEncryptable;
+use bitwarden_core::{key_management::SymmetricKeyRef, validate_only_whitespaces, Client, Error};
+use bitwarden_crypto::Encryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -23,12 +23,20 @@ pub(crate) async fn create_project(
 ) -> Result<ProjectResponse, Error> {
     input.validate()?;
 
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&Some(input.organization_id))?;
+    let project = {
+        // Context is not Send, so we can't use it across an await point
+        let mut ctx = client.internal.get_crypto_service().context();
+        let key = SymmetricKeyRef::Organization(input.organization_id);
 
-    let project = Some(ProjectCreateRequestModel {
-        name: input.name.clone().trim().encrypt_with_key(key)?.to_string(),
-    });
+        Some(ProjectCreateRequestModel {
+            name: input
+                .name
+                .clone()
+                .trim()
+                .encrypt(&mut ctx, key)?
+                .to_string(),
+        })
+    };
 
     let config = client.internal.get_api_configurations().await;
     let res = bitwarden_api_api::apis::projects_api::organizations_organization_id_projects_post(
@@ -38,7 +46,8 @@ pub(crate) async fn create_project(
     )
     .await?;
 
-    ProjectResponse::process_response(res, &enc)
+    let mut ctx = client.internal.get_crypto_service().context();
+    ProjectResponse::process_response(res, &mut ctx)
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-sm/src/projects/get.rs
+++ b/crates/bitwarden-sm/src/projects/get.rs
@@ -20,7 +20,6 @@ pub(crate) async fn get_project(
 
     let res = bitwarden_api_api::apis::projects_api::projects_id_get(&config.api, input.id).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
-
-    ProjectResponse::process_response(res, &enc)
+    let mut ctx = client.internal.get_crypto_service().context();
+    ProjectResponse::process_response(res, &mut ctx)
 }

--- a/crates/bitwarden-sm/src/projects/project_response.rs
+++ b/crates/bitwarden-sm/src/projects/project_response.rs
@@ -1,6 +1,9 @@
 use bitwarden_api_api::models::ProjectResponseModel;
-use bitwarden_core::{client::encryption_settings::EncryptionSettings, require, Error};
-use bitwarden_crypto::{EncString, KeyDecryptable};
+use bitwarden_core::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    require, Error,
+};
+use bitwarden_crypto::{service::CryptoServiceContext, Decryptable, EncString};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -19,14 +22,14 @@ pub struct ProjectResponse {
 impl ProjectResponse {
     pub(crate) fn process_response(
         response: ProjectResponseModel,
-        enc: &EncryptionSettings,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     ) -> Result<Self, Error> {
         let organization_id = require!(response.organization_id);
-        let enc_key = enc.get_key(&Some(organization_id))?;
+        let enc_key = SymmetricKeyRef::Organization(organization_id);
 
         let name = require!(response.name)
             .parse::<EncString>()?
-            .decrypt_with_key(enc_key)?;
+            .decrypt(ctx, enc_key)?;
 
         Ok(ProjectResponse {
             id: require!(response.id),

--- a/crates/bitwarden-sm/src/secrets/get.rs
+++ b/crates/bitwarden-sm/src/secrets/get.rs
@@ -19,7 +19,7 @@ pub(crate) async fn get_secret(
     let config = client.internal.get_api_configurations().await;
     let res = bitwarden_api_api::apis::secrets_api::secrets_id_get(&config.api, input.id).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
+    let mut ctx = client.internal.get_crypto_service().context();
 
-    SecretResponse::process_response(res, &enc)
+    SecretResponse::process_response(res, &mut ctx)
 }

--- a/crates/bitwarden-sm/src/secrets/get_by_ids.rs
+++ b/crates/bitwarden-sm/src/secrets/get_by_ids.rs
@@ -24,7 +24,7 @@ pub(crate) async fn get_secrets_by_ids(
     let res =
         bitwarden_api_api::apis::secrets_api::secrets_get_by_ids_post(&config.api, request).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
+    let mut ctx = client.internal.get_crypto_service().context();
 
-    SecretsResponse::process_response(res, &enc)
+    SecretsResponse::process_response(res, &mut ctx)
 }

--- a/crates/bitwarden-sm/src/secrets/update.rs
+++ b/crates/bitwarden-sm/src/secrets/update.rs
@@ -1,6 +1,6 @@
 use bitwarden_api_api::models::SecretUpdateRequestModel;
-use bitwarden_core::{validate_only_whitespaces, Client, Error};
-use bitwarden_crypto::KeyEncryptable;
+use bitwarden_core::{key_management::SymmetricKeyRef, validate_only_whitespaces, Client, Error};
+use bitwarden_crypto::Encryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -30,22 +30,31 @@ pub(crate) async fn update_secret(
 ) -> Result<SecretResponse, Error> {
     input.validate()?;
 
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&Some(input.organization_id))?;
+    let secret = {
+        // Context is not Send, so we can't use it across an await point
+        let mut ctx = client.internal.get_crypto_service().context();
+        let key = SymmetricKeyRef::Organization(input.organization_id);
 
-    let secret = Some(SecretUpdateRequestModel {
-        key: input.key.clone().trim().encrypt_with_key(key)?.to_string(),
-        value: input.value.clone().encrypt_with_key(key)?.to_string(),
-        note: input.note.clone().trim().encrypt_with_key(key)?.to_string(),
-        project_ids: input.project_ids.clone(),
-        access_policies_requests: None,
-    });
+        Some(SecretUpdateRequestModel {
+            key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
+            value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
+            note: input
+                .note
+                .clone()
+                .trim()
+                .encrypt(&mut ctx, key)?
+                .to_string(),
+            project_ids: input.project_ids.clone(),
+            access_policies_requests: None,
+        })
+    };
 
     let config = client.internal.get_api_configurations().await;
     let res =
         bitwarden_api_api::apis::secrets_api::secrets_id_put(&config.api, input.id, secret).await?;
 
-    SecretResponse::process_response(res, &enc)
+    let mut ctx = client.internal.get_crypto_service().context();
+    SecretResponse::process_response(res, &mut ctx)
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1,8 +1,10 @@
 use bitwarden_api_api::models::CipherDetailsResponseModel;
-use bitwarden_core::{require, MissingFieldError, VaultLocked};
+use bitwarden_core::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    require, MissingFieldError, VaultLocked,
+};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey,
-    SymmetricCryptoKey,
+    service::CryptoServiceContext, CryptoError, Decryptable, EncString, Encryptable, UsesKey,
 };
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -12,7 +14,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use super::{
-    attachment, card, field, identity,
+    attachment::{self, ATTACHMENT_KEY},
+    card, field, identity,
     local_data::{LocalData, LocalDataView},
     secure_note,
 };
@@ -169,17 +172,20 @@ pub struct CipherListView {
     pub revision_date: DateTime<Utc>,
 }
 
+const CIPHER_KEY: SymmetricKeyRef = SymmetricKeyRef::Local("cipher_key");
+const NEW_CIPHER_KEY: SymmetricKeyRef = SymmetricKeyRef::Local("new_cipher_key");
+
 impl CipherListView {
+    // TODO: Don't return the TOTP key directly, store it in the context
     pub(crate) fn get_totp_key(
         self,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     ) -> Result<Option<String>, CryptoError> {
-        let key = self.locate_key(enc, &None)?;
-        let cipher_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = cipher_key.as_ref().unwrap_or(key);
+        let key = self.uses_key();
+        let cipher_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
         let totp = if let CipherListViewType::Login { totp, .. } = self.r#type {
-            totp.decrypt_with_key(key)?
+            totp.decrypt(ctx, cipher_key)?
         } else {
             None
         };
@@ -188,49 +194,57 @@ impl CipherListView {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Cipher> for CipherView {
-    fn encrypt_with_key(mut self, key: &SymmetricCryptoKey) -> Result<Cipher, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Cipher> for CipherView {
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<Cipher, CryptoError> {
+        let key: SymmetricKeyRef = Cipher::get_cipher_key(ctx, key, &self.key)?;
+
+        let mut cipher_view = self.clone();
 
         // For compatibility reasons, we only create checksums for ciphers that have a key
-        if ciphers_key.is_some() {
-            self.generate_checksums();
+        if cipher_view.key.is_some() {
+            cipher_view.generate_checksums();
         }
 
         Ok(Cipher {
-            id: self.id,
-            organization_id: self.organization_id,
-            folder_id: self.folder_id,
-            collection_ids: self.collection_ids,
-            key: self.key,
-            name: self.name.encrypt_with_key(key)?,
-            notes: self.notes.encrypt_with_key(key)?,
-            r#type: self.r#type,
-            login: self.login.encrypt_with_key(key)?,
-            identity: self.identity.encrypt_with_key(key)?,
-            card: self.card.encrypt_with_key(key)?,
-            secure_note: self.secure_note.encrypt_with_key(key)?,
-            favorite: self.favorite,
-            reprompt: self.reprompt,
-            organization_use_totp: self.organization_use_totp,
-            edit: self.edit,
-            view_password: self.view_password,
-            local_data: self.local_data.encrypt_with_key(key)?,
-            attachments: self.attachments.encrypt_with_key(key)?,
-            fields: self.fields.encrypt_with_key(key)?,
-            password_history: self.password_history.encrypt_with_key(key)?,
-            creation_date: self.creation_date,
-            deleted_date: self.deleted_date,
-            revision_date: self.revision_date,
+            id: cipher_view.id,
+            organization_id: cipher_view.organization_id,
+            folder_id: cipher_view.folder_id,
+            collection_ids: cipher_view.collection_ids.clone(),
+            key: cipher_view.key.clone(),
+            name: cipher_view.name.encrypt(ctx, key)?,
+            notes: cipher_view.notes.encrypt(ctx, key)?,
+            r#type: cipher_view.r#type,
+            login: cipher_view.login.encrypt(ctx, key)?,
+            identity: cipher_view.identity.encrypt(ctx, key)?,
+            card: cipher_view.card.encrypt(ctx, key)?,
+            secure_note: cipher_view.secure_note.encrypt(ctx, key)?,
+            favorite: cipher_view.favorite,
+            reprompt: cipher_view.reprompt,
+            organization_use_totp: cipher_view.organization_use_totp,
+            edit: cipher_view.edit,
+            view_password: cipher_view.view_password,
+            local_data: cipher_view.local_data.encrypt(ctx, key)?,
+            attachments: cipher_view.attachments.encrypt(ctx, key)?,
+            fields: cipher_view.fields.encrypt(ctx, key)?,
+            password_history: cipher_view.password_history.encrypt(ctx, key)?,
+            creation_date: cipher_view.creation_date,
+            deleted_date: cipher_view.deleted_date,
+            revision_date: cipher_view.revision_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CipherView> for Cipher {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CipherView, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, CipherView> for Cipher {
+    fn decrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<CipherView, CryptoError> {
+        let key: SymmetricKeyRef = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
         let mut cipher = CipherView {
             id: self.id,
@@ -238,29 +252,29 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherView> for Cipher {
             folder_id: self.folder_id,
             collection_ids: self.collection_ids.clone(),
             key: self.key.clone(),
-            name: self.name.decrypt_with_key(key).ok().unwrap_or_default(),
-            notes: self.notes.decrypt_with_key(key).ok().flatten(),
+            name: self.name.decrypt(ctx, key).ok().unwrap_or_default(),
+            notes: self.notes.decrypt(ctx, key).ok().flatten(),
             r#type: self.r#type,
-            login: self.login.decrypt_with_key(key).ok().flatten(),
-            identity: self.identity.decrypt_with_key(key).ok().flatten(),
-            card: self.card.decrypt_with_key(key).ok().flatten(),
-            secure_note: self.secure_note.decrypt_with_key(key).ok().flatten(),
+            login: self.login.decrypt(ctx, key).ok().flatten(),
+            identity: self.identity.decrypt(ctx, key).ok().flatten(),
+            card: self.card.decrypt(ctx, key).ok().flatten(),
+            secure_note: self.secure_note.decrypt(ctx, key).ok().flatten(),
             favorite: self.favorite,
             reprompt: self.reprompt,
             organization_use_totp: self.organization_use_totp,
             edit: self.edit,
             view_password: self.view_password,
-            local_data: self.local_data.decrypt_with_key(key).ok().flatten(),
-            attachments: self.attachments.decrypt_with_key(key).ok().flatten(),
-            fields: self.fields.decrypt_with_key(key).ok().flatten(),
-            password_history: self.password_history.decrypt_with_key(key).ok().flatten(),
+            local_data: self.local_data.decrypt(ctx, key).ok().flatten(),
+            attachments: self.attachments.decrypt(ctx, key).ok().flatten(),
+            fields: self.fields.decrypt(ctx, key).ok().flatten(),
+            password_history: self.password_history.decrypt(ctx, key).ok().flatten(),
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
         };
 
         // For compatibility we only remove URLs with invalid checksums if the cipher has a key
-        if ciphers_key.is_some() {
+        if self.key.is_some() {
             cipher.remove_invalid_checksums();
         }
 
@@ -274,25 +288,30 @@ impl Cipher {
     /// in which case this will return Ok(None) and the key associated
     /// with this cipher's user or organization must be used instead
     pub(super) fn get_cipher_key(
-        key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
         ciphers_key: &Option<EncString>,
-    ) -> Result<Option<SymmetricCryptoKey>, CryptoError> {
-        ciphers_key
-            .as_ref()
-            .map(|k| {
-                let mut key: Vec<u8> = k.decrypt_with_key(key)?;
-                SymmetricCryptoKey::try_from(key.as_mut_slice())
-            })
-            .transpose()
+    ) -> Result<SymmetricKeyRef, CryptoError> {
+        match ciphers_key {
+            Some(ciphers_key) => {
+                ctx.decrypt_symmetric_key_with_symmetric_key(key, CIPHER_KEY, ciphers_key)?;
+                Ok(CIPHER_KEY)
+            }
+            None => Ok(key),
+        }
     }
 
-    fn get_decrypted_subtitle(&self, key: &SymmetricCryptoKey) -> Result<String, CryptoError> {
+    fn get_decrypted_subtitle(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<String, CryptoError> {
         Ok(match self.r#type {
             CipherType::Login => {
                 let Some(login) = &self.login else {
                     return Ok(String::new());
                 };
-                login.username.decrypt_with_key(key)?.unwrap_or_default()
+                login.username.decrypt(ctx, key)?.unwrap_or_default()
             }
             CipherType::SecureNote => String::new(),
             CipherType::Card => {
@@ -303,11 +322,11 @@ impl Cipher {
                 build_subtitle_card(
                     card.brand
                         .as_ref()
-                        .map(|b| b.decrypt_with_key(key))
+                        .map(|b| b.decrypt(ctx, key))
                         .transpose()?,
                     card.number
                         .as_ref()
-                        .map(|n| n.decrypt_with_key(key))
+                        .map(|n| n.decrypt(ctx, key))
                         .transpose()?,
                 )
             }
@@ -320,12 +339,12 @@ impl Cipher {
                     identity
                         .first_name
                         .as_ref()
-                        .map(|f| f.decrypt_with_key(key))
+                        .map(|f| f.decrypt(ctx, key))
                         .transpose()?,
                     identity
                         .last_name
                         .as_ref()
-                        .map(|l| l.decrypt_with_key(key))
+                        .map(|l| l.decrypt(ctx, key))
                         .transpose()?,
                 )
             }
@@ -390,16 +409,18 @@ fn build_subtitle_identity(first_name: Option<String>, last_name: Option<String>
 }
 
 impl CipherView {
-    pub fn generate_cipher_key(&mut self, key: &SymmetricCryptoKey) -> Result<(), CryptoError> {
-        let old_ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let old_key = old_ciphers_key.as_ref().unwrap_or(key);
+    pub fn generate_cipher_key(
+        &mut self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<(), CryptoError> {
+        let old_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let new_key = ctx.generate_symmetric_key(NEW_CIPHER_KEY)?;
 
-        let new_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        self.reencrypt_attachment_keys(ctx, old_key, new_key)?;
+        self.reencrypt_fido2_credentials(ctx, old_key, new_key)?;
 
-        self.reencrypt_attachment_keys(old_key, &new_key)?;
-        self.reencrypt_fido2_credentials(old_key, &new_key)?;
-
-        self.key = Some(new_key.to_vec().encrypt_with_key(key)?);
+        self.key = Some(ctx.encrypt_symmetric_key_with_symmetric_key(key, NEW_CIPHER_KEY)?);
         Ok(())
     }
 
@@ -419,14 +440,20 @@ impl CipherView {
 
     fn reencrypt_attachment_keys(
         &mut self,
-        old_key: &SymmetricCryptoKey,
-        new_key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        old_key: SymmetricKeyRef,
+        new_key: SymmetricKeyRef,
     ) -> Result<(), CryptoError> {
         if let Some(attachments) = &mut self.attachments {
             for attachment in attachments {
                 if let Some(attachment_key) = &mut attachment.key {
-                    let dec_attachment_key: Vec<u8> = attachment_key.decrypt_with_key(old_key)?;
-                    *attachment_key = dec_attachment_key.encrypt_with_key(new_key)?;
+                    ctx.decrypt_symmetric_key_with_symmetric_key(
+                        old_key,
+                        ATTACHMENT_KEY,
+                        attachment_key,
+                    )?;
+                    *attachment_key =
+                        ctx.encrypt_symmetric_key_with_symmetric_key(new_key, ATTACHMENT_KEY)?;
                 }
             }
         }
@@ -435,32 +462,31 @@ impl CipherView {
 
     pub fn decrypt_fido2_credentials(
         &self,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     ) -> Result<Vec<Fido2CredentialView>, CipherError> {
-        let key = self.locate_key(enc, &None)?;
-        let cipher_key = Cipher::get_cipher_key(key, &self.key)?;
-
-        let key = cipher_key.as_ref().unwrap_or(key);
+        let key = self.uses_key();
+        let cipher_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
         Ok(self
             .login
             .as_ref()
             .and_then(|l| l.fido2_credentials.as_ref())
-            .map(|f| f.decrypt_with_key(key))
+            .map(|f| f.decrypt(ctx, cipher_key))
             .transpose()?
             .unwrap_or_default())
     }
 
     fn reencrypt_fido2_credentials(
         &mut self,
-        old_key: &SymmetricCryptoKey,
-        new_key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        old_key: SymmetricKeyRef,
+        new_key: SymmetricKeyRef,
     ) -> Result<(), CryptoError> {
         if let Some(login) = self.login.as_mut() {
             if let Some(fido2_credentials) = &mut login.fido2_credentials {
                 let dec_fido2_credentials: Vec<Fido2CredentialFullView> =
-                    fido2_credentials.decrypt_with_key(old_key)?;
-                *fido2_credentials = dec_fido2_credentials.encrypt_with_key(new_key)?;
+                    fido2_credentials.decrypt(ctx, old_key)?;
+                *fido2_credentials = dec_fido2_credentials.encrypt(ctx, new_key)?;
             }
         }
         Ok(())
@@ -468,12 +494,12 @@ impl CipherView {
 
     pub fn move_to_organization(
         &mut self,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
         organization_id: Uuid,
     ) -> Result<(), CipherError> {
-        let old_key = enc.get_key(&self.organization_id)?;
+        let old_key = self.uses_key();
 
-        let new_key = enc.get_key(&Some(organization_id))?;
+        let new_key = SymmetricKeyRef::Organization(organization_id);
 
         // If any attachment is missing a key we can't reencrypt the attachment keys
         if self.attachments.iter().flatten().any(|a| a.key.is_none()) {
@@ -482,12 +508,12 @@ impl CipherView {
 
         // If the cipher has a key, we need to re-encrypt it with the new organization key
         if let Some(cipher_key) = &mut self.key {
-            let dec_cipher_key: Vec<u8> = cipher_key.decrypt_with_key(old_key)?;
-            *cipher_key = dec_cipher_key.encrypt_with_key(new_key)?;
+            ctx.decrypt_symmetric_key_with_symmetric_key(old_key, CIPHER_KEY, cipher_key)?;
+            *cipher_key = ctx.encrypt_symmetric_key_with_symmetric_key(new_key, CIPHER_KEY)?;
         } else {
             // If the cipher does not have a key, we need to reencrypt all attachment keys
-            self.reencrypt_attachment_keys(old_key, new_key)?;
-            self.reencrypt_fido2_credentials(old_key, new_key)?;
+            self.reencrypt_attachment_keys(ctx, old_key, new_key)?;
+            self.reencrypt_fido2_credentials(ctx, old_key, new_key)?;
         }
 
         self.organization_id = Some(organization_id);
@@ -496,40 +522,38 @@ impl CipherView {
 
     pub fn set_new_fido2_credentials(
         &mut self,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
         creds: Vec<Fido2CredentialFullView>,
     ) -> Result<(), CipherError> {
-        let key = enc.get_key(&self.organization_id)?;
+        let key = self.uses_key();
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
-
-        require!(self.login.as_mut()).fido2_credentials =
-            Some(creds.encrypt_with_key(ciphers_key)?);
+        require!(self.login.as_mut()).fido2_credentials = Some(creds.encrypt(ctx, ciphers_key)?);
 
         Ok(())
     }
 
     pub fn get_fido2_credentials(
         &self,
-        enc: &dyn KeyContainer,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     ) -> Result<Vec<Fido2CredentialFullView>, CipherError> {
-        let key = enc.get_key(&self.organization_id)?;
-
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
+        let key = self.uses_key();
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
         let login = require!(self.login.as_ref());
         let creds = require!(login.fido2_credentials.as_ref());
-        let res = creds.decrypt_with_key(ciphers_key)?;
+        let res = creds.decrypt(ctx, ciphers_key)?;
         Ok(res)
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CipherListView, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, CipherListView> for Cipher {
+    fn decrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<CipherListView, CryptoError> {
+        let key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
         Ok(CipherListView {
             id: self.id,
@@ -537,8 +561,11 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
             folder_id: self.folder_id,
             collection_ids: self.collection_ids.clone(),
             key: self.key.clone(),
-            name: self.name.decrypt_with_key(key).ok().unwrap_or_default(),
-            sub_title: self.get_decrypted_subtitle(key).ok().unwrap_or_default(),
+            name: self.name.decrypt(ctx, key).ok().unwrap_or_default(),
+            sub_title: self
+                .get_decrypted_subtitle(ctx, key)
+                .ok()
+                .unwrap_or_default(),
             r#type: match self.r#type {
                 CipherType::Login => {
                     let login = self
@@ -570,31 +597,30 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
     }
 }
 
-impl LocateKey for Cipher {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+impl UsesKey<SymmetricKeyRef> for Cipher {
+    fn uses_key(&self) -> SymmetricKeyRef {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyRef::Organization(organization_id),
+            None => SymmetricKeyRef::User,
+        }
     }
 }
-impl LocateKey for CipherView {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+
+impl UsesKey<SymmetricKeyRef> for CipherView {
+    fn uses_key(&self) -> SymmetricKeyRef {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyRef::Organization(organization_id),
+            None => SymmetricKeyRef::User,
+        }
     }
 }
-impl LocateKey for CipherListView {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+
+impl UsesKey<SymmetricKeyRef> for CipherListView {
+    fn uses_key(&self) -> SymmetricKeyRef {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyRef::Organization(organization_id),
+            None => SymmetricKeyRef::User,
+        }
     }
 }
 
@@ -665,10 +691,11 @@ impl From<bitwarden_api_api::models::CipherRepromptType> for CipherRepromptType 
 
 #[cfg(test)]
 mod tests {
-
-    use std::collections::HashMap;
-
     use attachment::AttachmentView;
+    use bitwarden_core::key_management::{
+        create_test_crypto_with_user_and_org_key, create_test_crypto_with_user_key,
+    };
+    use bitwarden_crypto::SymmetricCryptoKey;
 
     use super::*;
     use crate::Fido2Credential;
@@ -710,20 +737,23 @@ mod tests {
         }
     }
 
-    fn generate_fido2(key: &SymmetricCryptoKey) -> Fido2Credential {
+    fn generate_fido2(
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Fido2Credential {
         Fido2Credential {
-            credential_id: "123".to_string().encrypt_with_key(key).unwrap(),
-            key_type: "public-key".to_string().encrypt_with_key(key).unwrap(),
-            key_algorithm: "ECDSA".to_string().encrypt_with_key(key).unwrap(),
-            key_curve: "P-256".to_string().encrypt_with_key(key).unwrap(),
-            key_value: "123".to_string().encrypt_with_key(key).unwrap(),
-            rp_id: "123".to_string().encrypt_with_key(key).unwrap(),
+            credential_id: "123".to_string().encrypt(ctx, key).unwrap(),
+            key_type: "public-key".to_string().encrypt(ctx, key).unwrap(),
+            key_algorithm: "ECDSA".to_string().encrypt(ctx, key).unwrap(),
+            key_curve: "P-256".to_string().encrypt(ctx, key).unwrap(),
+            key_value: "123".to_string().encrypt(ctx, key).unwrap(),
+            rp_id: "123".to_string().encrypt(ctx, key).unwrap(),
             user_handle: None,
             user_name: None,
-            counter: "123".to_string().encrypt_with_key(key).unwrap(),
+            counter: "123".to_string().encrypt(ctx, key).unwrap(),
             rp_name: None,
             user_display_name: None,
-            discoverable: "true".to_string().encrypt_with_key(key).unwrap(),
+            discoverable: "true".to_string().encrypt(ctx, key).unwrap(),
             creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
         }
     }
@@ -731,6 +761,8 @@ mod tests {
     #[test]
     fn test_decrypt_cipher_list_view() {
         let key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(key.clone());
+        let mut ctx = crypto.context();
 
         let cipher = Cipher {
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
@@ -748,7 +780,7 @@ mod tests {
                 uris: None,
                 totp: Some("2.hqdioUAc81FsKQmO1XuLQg==|oDRdsJrQjoFu9NrFVy8tcJBAFKBx95gHaXZnWdXbKpsxWnOr2sKipIG43pKKUFuq|3gKZMiboceIB5SLVOULKg2iuyu6xzos22dfJbvx0EHk=".parse().unwrap()),
                 autofill_on_page_load: None,
-                fido2_credentials: Some(vec![generate_fido2(&key)]),
+                fido2_credentials: Some(vec![generate_fido2(&mut ctx, SymmetricKeyRef::User)]),
             }),
             identity: None,
             card: None,
@@ -767,7 +799,7 @@ mod tests {
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
         };
 
-        let view: CipherListView = cipher.decrypt_with_key(&key).unwrap();
+        let view: CipherListView = cipher.decrypt(&mut ctx, SymmetricKeyRef::User).unwrap();
 
         assert_eq!(
             view,
@@ -798,22 +830,30 @@ mod tests {
     #[test]
     fn test_generate_cipher_key() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let crypto = create_test_crypto_with_user_key(key.clone());
+        let mut ctx = crypto.context();
 
         let original_cipher = generate_cipher();
 
         // Check that the cipher gets encrypted correctly without it's own key
         let cipher = generate_cipher();
-        let no_key_cipher_enc = cipher.encrypt_with_key(&key).unwrap();
-        let no_key_cipher_dec: CipherView = no_key_cipher_enc.decrypt_with_key(&key).unwrap();
+        let no_key_cipher_enc = cipher.encrypt(&mut ctx, SymmetricKeyRef::User).unwrap();
+        let no_key_cipher_dec: CipherView = no_key_cipher_enc
+            .decrypt(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
         assert!(no_key_cipher_dec.key.is_none());
         assert_eq!(no_key_cipher_dec.name, original_cipher.name);
 
         let mut cipher = generate_cipher();
-        cipher.generate_cipher_key(&key).unwrap();
+        cipher
+            .generate_cipher_key(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
 
         // Check that the cipher gets encrypted correctly when it's assigned it's own key
-        let key_cipher_enc = cipher.encrypt_with_key(&key).unwrap();
-        let key_cipher_dec: CipherView = key_cipher_enc.decrypt_with_key(&key).unwrap();
+        let key_cipher_enc = cipher.encrypt(&mut ctx, SymmetricKeyRef::User).unwrap();
+        let key_cipher_dec: CipherView = key_cipher_enc
+            .decrypt(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
         assert!(key_cipher_dec.key.is_some());
         assert_eq!(key_cipher_dec.name, original_cipher.name);
     }
@@ -821,22 +861,36 @@ mod tests {
     #[test]
     fn test_generate_cipher_key_when_a_cipher_key_already_exists() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let crypto = create_test_crypto_with_user_key(key.clone());
+        let mut ctx = crypto.context();
 
         let cipher_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let cipher_key = cipher_key.to_vec().encrypt_with_key(&key).unwrap();
+        let cipher_key = cipher_key
+            .to_vec()
+            .as_slice()
+            .encrypt(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
 
         let mut original_cipher = generate_cipher();
         original_cipher.key = Some(cipher_key.clone());
 
-        original_cipher.generate_cipher_key(&key).unwrap();
+        original_cipher
+            .generate_cipher_key(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
 
         // Make sure that the cipher key is decryptable
-        let _: Vec<u8> = original_cipher.key.unwrap().decrypt_with_key(&key).unwrap();
+        let _: Vec<u8> = original_cipher
+            .key
+            .unwrap()
+            .decrypt(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
     }
 
     #[test]
     fn test_generate_cipher_key_ignores_attachments_without_key() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let crypto = create_test_crypto_with_user_key(key.clone());
+        let mut ctx = crypto.context();
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {
@@ -849,44 +903,39 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        cipher.generate_cipher_key(&key).unwrap();
+        cipher
+            .generate_cipher_key(&mut ctx, SymmetricKeyRef::User)
+            .unwrap();
         assert!(cipher.attachments.unwrap()[0].key.is_none());
-    }
-
-    struct MockKeyContainer(HashMap<Option<Uuid>, SymmetricCryptoKey>);
-    impl KeyContainer for MockKeyContainer {
-        fn get_key<'a>(
-            &'a self,
-            org_id: &Option<Uuid>,
-        ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-            self.0
-                .get(org_id)
-                .ok_or(CryptoError::MissingKey(org_id.unwrap_or_default()))
-        }
     }
 
     #[test]
     fn test_move_user_cipher_to_org() {
         let org = uuid::Uuid::new_v4();
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let crypto = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+            org,
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+        );
+        let mut ctx = crypto.context();
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
         cipher
-            .generate_cipher_key(enc.get_key(&None).unwrap())
+            .generate_cipher_key(&mut ctx, SymmetricKeyRef::User)
             .unwrap();
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher.move_to_organization(&mut ctx, org).unwrap();
         assert_eq!(cipher.organization_id, Some(org));
 
         // Check that the cipher can be encrypted/decrypted with the new org key
-        let org_key = enc.get_key(&Some(org)).unwrap();
-        let cipher_enc = cipher.encrypt_with_key(org_key).unwrap();
-        let cipher_dec: CipherView = cipher_enc.decrypt_with_key(org_key).unwrap();
+        let cipher_enc = cipher
+            .encrypt(&mut ctx, SymmetricKeyRef::Organization(org))
+            .unwrap();
+        let cipher_dec: CipherView = cipher_enc
+            .decrypt(&mut ctx, SymmetricKeyRef::Organization(org))
+            .unwrap();
 
         assert_eq!(cipher_dec.name, "My test login");
     }
@@ -895,33 +944,38 @@ mod tests {
     fn test_move_user_cipher_to_org_manually() {
         let org = uuid::Uuid::new_v4();
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let crypto = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+            org,
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+        );
+        let mut ctx = crypto.context();
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
         cipher
-            .generate_cipher_key(enc.get_key(&None).unwrap())
+            .generate_cipher_key(&mut ctx, SymmetricKeyRef::User)
             .unwrap();
 
         cipher.organization_id = Some(org);
 
         // Check that the cipher can not be encrypted, as the
         // cipher key is tied to the user key and not the org key
-        let org_key = enc.get_key(&Some(org)).unwrap();
-        assert!(cipher.encrypt_with_key(org_key).is_err());
+        assert!(cipher
+            .encrypt(&mut ctx, SymmetricKeyRef::Organization(org))
+            .is_err());
     }
 
     #[test]
     fn test_move_user_cipher_with_attachment_without_key_to_org() {
         let org = uuid::Uuid::new_v4();
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let crypto = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+            org,
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+        );
+        let mut ctx = crypto.context();
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {
@@ -935,23 +989,26 @@ mod tests {
         cipher.attachments = Some(vec![attachment]);
 
         // Neither cipher nor attachment have keys, so the cipher can't be moved
-        assert!(cipher.move_to_organization(&enc, org).is_err());
+        assert!(cipher.move_to_organization(&mut ctx, org).is_err());
     }
 
     #[test]
     fn test_move_user_cipher_with_attachment_with_key_to_org() {
         let org = uuid::Uuid::new_v4();
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let crypto = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+            org,
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+        );
+        let mut ctx = crypto.context();
 
         // Attachment has a key that is encrypted with the user key, as the cipher has no key itself
         let attachment_key = SymmetricCryptoKey::generate(rand::thread_rng());
         let attachment_key_enc = attachment_key
             .to_vec()
-            .encrypt_with_key(enc.get_key(&None).unwrap())
+            .as_slice()
+            .encrypt(&mut ctx, SymmetricKeyRef::User)
             .unwrap();
 
         let mut cipher = generate_cipher();
@@ -964,10 +1021,10 @@ mod tests {
             key: Some(attachment_key_enc),
         };
         cipher.attachments = Some(vec![attachment]);
-        let cred = generate_fido2(enc.get_key(&None).unwrap());
+        let cred = generate_fido2(&mut ctx, SymmetricKeyRef::User);
         cipher.login.as_mut().unwrap().fido2_credentials = Some(vec![cred]);
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher.move_to_organization(&mut ctx, org).unwrap();
 
         assert!(cipher.key.is_none());
 
@@ -975,7 +1032,7 @@ mod tests {
         // and the value matches with the original attachment key
         let new_attachment_key = cipher.attachments.unwrap()[0].key.clone().unwrap();
         let new_attachment_key_dec: Vec<_> = new_attachment_key
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut ctx, SymmetricKeyRef::Organization(org))
             .unwrap();
         let new_attachment_key_dec: SymmetricCryptoKey = new_attachment_key_dec.try_into().unwrap();
         assert_eq!(new_attachment_key_dec.to_vec(), attachment_key.to_vec());
@@ -987,7 +1044,7 @@ mod tests {
             .unwrap()
             .first()
             .unwrap()
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut ctx, SymmetricKeyRef::Organization(org))
             .unwrap();
 
         assert_eq!(cred2.credential_id, "123");
@@ -997,22 +1054,25 @@ mod tests {
     fn test_move_user_cipher_with_key_with_attachment_with_key_to_org() {
         let org = uuid::Uuid::new_v4();
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let crypto = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+            org,
+            SymmetricCryptoKey::generate(rand::thread_rng()),
+        );
+        let mut ctx = crypto.context();
 
-        let cipher_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let cipher_key_enc = cipher_key
-            .to_vec()
-            .encrypt_with_key(enc.get_key(&None).unwrap())
+        let cipher_key = SymmetricKeyRef::Local("test_cipher_key");
+        ctx.generate_symmetric_key(cipher_key).unwrap();
+
+        let cipher_key_enc = ctx
+            .encrypt_symmetric_key_with_symmetric_key(SymmetricKeyRef::User, cipher_key)
             .unwrap();
 
-        // Attachment has a key that is encrypted with the cipher key
-        let attachment_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let attachment_key_enc = attachment_key
-            .to_vec()
-            .encrypt_with_key(&cipher_key)
+        let attachment_key = SymmetricKeyRef::Local("test_attachment_key");
+        ctx.generate_symmetric_key(attachment_key).unwrap();
+
+        let attachment_key_enc = ctx
+            .encrypt_symmetric_key_with_symmetric_key(cipher_key, attachment_key)
             .unwrap();
 
         let mut cipher = generate_cipher();
@@ -1028,21 +1088,23 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        let cred = generate_fido2(&cipher_key);
+        let cred = generate_fido2(&mut ctx, cipher_key);
         cipher.login.as_mut().unwrap().fido2_credentials = Some(vec![cred.clone()]);
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher.move_to_organization(&mut ctx, org).unwrap();
 
         // Check that the cipher key has been re-encrypted with the org key,
         let new_cipher_key_dec: Vec<_> = cipher
             .key
             .clone()
             .unwrap()
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut ctx, SymmetricKeyRef::Organization(org))
             .unwrap();
 
         let new_cipher_key_dec: SymmetricCryptoKey = new_cipher_key_dec.try_into().unwrap();
 
+        #[allow(deprecated)]
+        let cipher_key = ctx.dangerous_get_symmetric_key(cipher_key).unwrap();
         assert_eq!(new_cipher_key_dec.to_vec(), cipher_key.to_vec());
 
         // Check that the attachment key hasn't changed

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -1,6 +1,7 @@
 use bitwarden_api_api::models::CipherIdentityModel;
+use bitwarden_core::key_management::{AsymmetricKeyRef, SymmetricKeyRef};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
+    service::CryptoServiceContext, CryptoError, Decryptable, EncString, Encryptable,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -55,52 +56,60 @@ pub struct IdentityView {
     pub license_number: Option<String>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Identity> for IdentityView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Identity, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Identity> for IdentityView {
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<Identity, CryptoError> {
         Ok(Identity {
-            title: self.title.encrypt_with_key(key)?,
-            first_name: self.first_name.encrypt_with_key(key)?,
-            middle_name: self.middle_name.encrypt_with_key(key)?,
-            last_name: self.last_name.encrypt_with_key(key)?,
-            address1: self.address1.encrypt_with_key(key)?,
-            address2: self.address2.encrypt_with_key(key)?,
-            address3: self.address3.encrypt_with_key(key)?,
-            city: self.city.encrypt_with_key(key)?,
-            state: self.state.encrypt_with_key(key)?,
-            postal_code: self.postal_code.encrypt_with_key(key)?,
-            country: self.country.encrypt_with_key(key)?,
-            company: self.company.encrypt_with_key(key)?,
-            email: self.email.encrypt_with_key(key)?,
-            phone: self.phone.encrypt_with_key(key)?,
-            ssn: self.ssn.encrypt_with_key(key)?,
-            username: self.username.encrypt_with_key(key)?,
-            passport_number: self.passport_number.encrypt_with_key(key)?,
-            license_number: self.license_number.encrypt_with_key(key)?,
+            title: self.title.encrypt(ctx, key)?,
+            first_name: self.first_name.encrypt(ctx, key)?,
+            middle_name: self.middle_name.encrypt(ctx, key)?,
+            last_name: self.last_name.encrypt(ctx, key)?,
+            address1: self.address1.encrypt(ctx, key)?,
+            address2: self.address2.encrypt(ctx, key)?,
+            address3: self.address3.encrypt(ctx, key)?,
+            city: self.city.encrypt(ctx, key)?,
+            state: self.state.encrypt(ctx, key)?,
+            postal_code: self.postal_code.encrypt(ctx, key)?,
+            country: self.country.encrypt(ctx, key)?,
+            company: self.company.encrypt(ctx, key)?,
+            email: self.email.encrypt(ctx, key)?,
+            phone: self.phone.encrypt(ctx, key)?,
+            ssn: self.ssn.encrypt(ctx, key)?,
+            username: self.username.encrypt(ctx, key)?,
+            passport_number: self.passport_number.encrypt(ctx, key)?,
+            license_number: self.license_number.encrypt(ctx, key)?,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, IdentityView> for Identity {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<IdentityView, CryptoError> {
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, IdentityView> for Identity {
+    fn decrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<IdentityView, CryptoError> {
         Ok(IdentityView {
-            title: self.title.decrypt_with_key(key).ok().flatten(),
-            first_name: self.first_name.decrypt_with_key(key).ok().flatten(),
-            middle_name: self.middle_name.decrypt_with_key(key).ok().flatten(),
-            last_name: self.last_name.decrypt_with_key(key).ok().flatten(),
-            address1: self.address1.decrypt_with_key(key).ok().flatten(),
-            address2: self.address2.decrypt_with_key(key).ok().flatten(),
-            address3: self.address3.decrypt_with_key(key).ok().flatten(),
-            city: self.city.decrypt_with_key(key).ok().flatten(),
-            state: self.state.decrypt_with_key(key).ok().flatten(),
-            postal_code: self.postal_code.decrypt_with_key(key).ok().flatten(),
-            country: self.country.decrypt_with_key(key).ok().flatten(),
-            company: self.company.decrypt_with_key(key).ok().flatten(),
-            email: self.email.decrypt_with_key(key).ok().flatten(),
-            phone: self.phone.decrypt_with_key(key).ok().flatten(),
-            ssn: self.ssn.decrypt_with_key(key).ok().flatten(),
-            username: self.username.decrypt_with_key(key).ok().flatten(),
-            passport_number: self.passport_number.decrypt_with_key(key).ok().flatten(),
-            license_number: self.license_number.decrypt_with_key(key).ok().flatten(),
+            title: self.title.decrypt(ctx, key).ok().flatten(),
+            first_name: self.first_name.decrypt(ctx, key).ok().flatten(),
+            middle_name: self.middle_name.decrypt(ctx, key).ok().flatten(),
+            last_name: self.last_name.decrypt(ctx, key).ok().flatten(),
+            address1: self.address1.decrypt(ctx, key).ok().flatten(),
+            address2: self.address2.decrypt(ctx, key).ok().flatten(),
+            address3: self.address3.decrypt(ctx, key).ok().flatten(),
+            city: self.city.decrypt(ctx, key).ok().flatten(),
+            state: self.state.decrypt(ctx, key).ok().flatten(),
+            postal_code: self.postal_code.decrypt(ctx, key).ok().flatten(),
+            country: self.country.decrypt(ctx, key).ok().flatten(),
+            company: self.company.decrypt(ctx, key).ok().flatten(),
+            email: self.email.decrypt(ctx, key).ok().flatten(),
+            phone: self.phone.decrypt(ctx, key).ok().flatten(),
+            ssn: self.ssn.decrypt(ctx, key).ok().flatten(),
+            username: self.username.decrypt(ctx, key).ok().flatten(),
+            passport_number: self.passport_number.decrypt(ctx, key).ok().flatten(),
+            license_number: self.license_number.decrypt(ctx, key).ok().flatten(),
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/local_data.rs
+++ b/crates/bitwarden-vault/src/cipher/local_data.rs
@@ -1,4 +1,5 @@
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use bitwarden_core::key_management::{AsymmetricKeyRef, SymmetricKeyRef};
+use bitwarden_crypto::{service::CryptoServiceContext, CryptoError, Decryptable, Encryptable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +19,12 @@ pub struct LocalDataView {
     last_launched: Option<u32>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<LocalData, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, LocalData> for LocalDataView {
+    fn encrypt(
+        &self,
+        _ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        _key: SymmetricKeyRef,
+    ) -> Result<LocalData, CryptoError> {
         Ok(LocalData {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,
@@ -27,8 +32,12 @@ impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, LocalDataView> for LocalData {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<LocalDataView, CryptoError> {
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, LocalDataView> for LocalData {
+    fn decrypt(
+        &self,
+        _ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        _key: SymmetricKeyRef,
+    ) -> Result<LocalDataView, CryptoError> {
         Ok(LocalDataView {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -1,8 +1,11 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use bitwarden_api_api::models::{CipherLoginModel, CipherLoginUriModel};
-use bitwarden_core::require;
+use bitwarden_core::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    require,
+};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
+    service::CryptoServiceContext, CryptoError, Decryptable, EncString, Encryptable,
 };
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -168,63 +171,72 @@ impl From<Fido2CredentialFullView> for Fido2CredentialNewView {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Fido2Credential> for Fido2CredentialFullView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Fido2Credential, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Fido2Credential>
+    for Fido2CredentialFullView
+{
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<Fido2Credential, CryptoError> {
         Ok(Fido2Credential {
-            credential_id: self.credential_id.encrypt_with_key(key)?,
-            key_type: self.key_type.encrypt_with_key(key)?,
-            key_algorithm: self.key_algorithm.encrypt_with_key(key)?,
-            key_curve: self.key_curve.encrypt_with_key(key)?,
-            key_value: self.key_value.encrypt_with_key(key)?,
-            rp_id: self.rp_id.encrypt_with_key(key)?,
-            user_handle: self
-                .user_handle
-                .map(|h| h.encrypt_with_key(key))
-                .transpose()?,
-            user_name: self.user_name.encrypt_with_key(key)?,
-            counter: self.counter.encrypt_with_key(key)?,
-            rp_name: self.rp_name.encrypt_with_key(key)?,
-            user_display_name: self.user_display_name.encrypt_with_key(key)?,
-            discoverable: self.discoverable.encrypt_with_key(key)?,
+            credential_id: self.credential_id.encrypt(ctx, key)?,
+            key_type: self.key_type.encrypt(ctx, key)?,
+            key_algorithm: self.key_algorithm.encrypt(ctx, key)?,
+            key_curve: self.key_curve.encrypt(ctx, key)?,
+            key_value: self.key_value.encrypt(ctx, key)?,
+            rp_id: self.rp_id.encrypt(ctx, key)?,
+            user_handle: self.user_handle.encrypt(ctx, key)?,
+            user_name: self.user_name.encrypt(ctx, key)?,
+            counter: self.counter.encrypt(ctx, key)?,
+            rp_name: self.rp_name.encrypt(ctx, key)?,
+            user_display_name: self.user_display_name.encrypt(ctx, key)?,
+            discoverable: self.discoverable.encrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, Fido2CredentialFullView> for Fido2Credential {
-    fn decrypt_with_key(
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Fido2CredentialFullView>
+    for Fido2Credential
+{
+    fn decrypt(
         &self,
-        key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
     ) -> Result<Fido2CredentialFullView, CryptoError> {
         Ok(Fido2CredentialFullView {
-            credential_id: self.credential_id.decrypt_with_key(key)?,
-            key_type: self.key_type.decrypt_with_key(key)?,
-            key_algorithm: self.key_algorithm.decrypt_with_key(key)?,
-            key_curve: self.key_curve.decrypt_with_key(key)?,
-            key_value: self.key_value.decrypt_with_key(key)?,
-            rp_id: self.rp_id.decrypt_with_key(key)?,
-            user_handle: self.user_handle.decrypt_with_key(key)?,
-            user_name: self.user_name.decrypt_with_key(key)?,
-            counter: self.counter.decrypt_with_key(key)?,
-            rp_name: self.rp_name.decrypt_with_key(key)?,
-            user_display_name: self.user_display_name.decrypt_with_key(key)?,
-            discoverable: self.discoverable.decrypt_with_key(key)?,
+            credential_id: self.credential_id.decrypt(ctx, key)?,
+            key_type: self.key_type.decrypt(ctx, key)?,
+            key_algorithm: self.key_algorithm.decrypt(ctx, key)?,
+            key_curve: self.key_curve.decrypt(ctx, key)?,
+            key_value: self.key_value.decrypt(ctx, key)?,
+            rp_id: self.rp_id.decrypt(ctx, key)?,
+            user_handle: self.user_handle.decrypt(ctx, key)?,
+            user_name: self.user_name.decrypt(ctx, key)?,
+            counter: self.counter.decrypt(ctx, key)?,
+            rp_name: self.rp_name.decrypt(ctx, key)?,
+            user_display_name: self.user_display_name.decrypt(ctx, key)?,
+            discoverable: self.discoverable.decrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, Fido2CredentialFullView> for Fido2CredentialView {
-    fn decrypt_with_key(
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Fido2CredentialFullView>
+    for Fido2CredentialView
+{
+    fn decrypt(
         &self,
-        key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
     ) -> Result<Fido2CredentialFullView, CryptoError> {
         Ok(Fido2CredentialFullView {
             credential_id: self.credential_id.clone(),
             key_type: self.key_type.clone(),
             key_algorithm: self.key_algorithm.clone(),
             key_curve: self.key_curve.clone(),
-            key_value: self.key_value.decrypt_with_key(key)?,
+            key_value: self.key_value.decrypt(ctx, key)?,
             rp_id: self.rp_id.clone(),
             user_handle: self.user_handle.clone(),
             user_name: self.user_name.clone(),
@@ -268,98 +280,117 @@ pub struct LoginView {
     pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, LoginUri> for LoginUriView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<LoginUri, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, LoginUri> for LoginUriView {
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<LoginUri, CryptoError> {
         Ok(LoginUri {
-            uri: self.uri.encrypt_with_key(key)?,
+            uri: self.uri.encrypt(ctx, key)?,
             r#match: self.r#match,
-            uri_checksum: self.uri_checksum.encrypt_with_key(key)?,
+            uri_checksum: self.uri_checksum.encrypt(ctx, key)?,
         })
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Login> for LoginView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Login, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Login> for LoginView {
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<Login, CryptoError> {
         Ok(Login {
-            username: self.username.encrypt_with_key(key)?,
-            password: self.password.encrypt_with_key(key)?,
+            username: self.username.encrypt(ctx, key)?,
+            password: self.password.encrypt(ctx, key)?,
             password_revision_date: self.password_revision_date,
-            uris: self.uris.encrypt_with_key(key)?,
-            totp: self.totp.encrypt_with_key(key)?,
-            autofill_on_page_load: self.autofill_on_page_load,
-            fido2_credentials: self.fido2_credentials,
-        })
-    }
-}
-
-impl KeyDecryptable<SymmetricCryptoKey, LoginUriView> for LoginUri {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<LoginUriView, CryptoError> {
-        Ok(LoginUriView {
-            uri: self.uri.decrypt_with_key(key)?,
-            r#match: self.r#match,
-            uri_checksum: self.uri_checksum.decrypt_with_key(key)?,
-        })
-    }
-}
-
-impl KeyDecryptable<SymmetricCryptoKey, LoginView> for Login {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<LoginView, CryptoError> {
-        Ok(LoginView {
-            username: self.username.decrypt_with_key(key).ok().flatten(),
-            password: self.password.decrypt_with_key(key).ok().flatten(),
-            password_revision_date: self.password_revision_date,
-            uris: self.uris.decrypt_with_key(key).ok().flatten(),
-            totp: self.totp.decrypt_with_key(key).ok().flatten(),
+            uris: self.uris.encrypt(ctx, key)?,
+            totp: self.totp.encrypt(ctx, key)?,
             autofill_on_page_load: self.autofill_on_page_load,
             fido2_credentials: self.fido2_credentials.clone(),
         })
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Fido2Credential> for Fido2CredentialView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Fido2Credential, CryptoError> {
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, LoginUriView> for LoginUri {
+    fn decrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<LoginUriView, CryptoError> {
+        Ok(LoginUriView {
+            uri: self.uri.decrypt(ctx, key)?,
+            r#match: self.r#match,
+            uri_checksum: self.uri_checksum.decrypt(ctx, key)?,
+        })
+    }
+}
+
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, LoginView> for Login {
+    fn decrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<LoginView, CryptoError> {
+        Ok(LoginView {
+            username: self.username.decrypt(ctx, key).ok().flatten(),
+            password: self.password.decrypt(ctx, key).ok().flatten(),
+            password_revision_date: self.password_revision_date,
+            uris: self.uris.decrypt(ctx, key).ok().flatten(),
+            totp: self.totp.decrypt(ctx, key).ok().flatten(),
+            autofill_on_page_load: self.autofill_on_page_load,
+            fido2_credentials: self.fido2_credentials.clone(),
+        })
+    }
+}
+
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Fido2Credential>
+    for Fido2CredentialView
+{
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<Fido2Credential, CryptoError> {
         Ok(Fido2Credential {
-            credential_id: self.credential_id.encrypt_with_key(key)?,
-            key_type: self.key_type.encrypt_with_key(key)?,
-            key_algorithm: self.key_algorithm.encrypt_with_key(key)?,
-            key_curve: self.key_curve.encrypt_with_key(key)?,
-            key_value: self.key_value,
-            rp_id: self.rp_id.encrypt_with_key(key)?,
-            user_handle: self
-                .user_handle
-                .map(|h| h.encrypt_with_key(key))
-                .transpose()?,
-            user_name: self
-                .user_name
-                .map(|n| n.encrypt_with_key(key))
-                .transpose()?,
-            counter: self.counter.encrypt_with_key(key)?,
-            rp_name: self.rp_name.encrypt_with_key(key)?,
-            user_display_name: self.user_display_name.encrypt_with_key(key)?,
-            discoverable: self.discoverable.encrypt_with_key(key)?,
+            credential_id: self.credential_id.encrypt(ctx, key)?,
+            key_type: self.key_type.encrypt(ctx, key)?,
+            key_algorithm: self.key_algorithm.encrypt(ctx, key)?,
+            key_curve: self.key_curve.encrypt(ctx, key)?,
+            key_value: self.key_value.clone(),
+            rp_id: self.rp_id.encrypt(ctx, key)?,
+            user_handle: self.user_handle.encrypt(ctx, key)?,
+            user_name: self.user_name.encrypt(ctx, key)?,
+            counter: self.counter.encrypt(ctx, key)?,
+            rp_name: self.rp_name.encrypt(ctx, key)?,
+            user_display_name: self.user_display_name.encrypt(ctx, key)?,
+            discoverable: self.discoverable.encrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, Fido2CredentialView> for Fido2Credential {
-    fn decrypt_with_key(
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, Fido2CredentialView>
+    for Fido2Credential
+{
+    fn decrypt(
         &self,
-        key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
     ) -> Result<Fido2CredentialView, CryptoError> {
         Ok(Fido2CredentialView {
-            credential_id: self.credential_id.decrypt_with_key(key)?,
-            key_type: self.key_type.decrypt_with_key(key)?,
-            key_algorithm: self.key_algorithm.decrypt_with_key(key)?,
-            key_curve: self.key_curve.decrypt_with_key(key)?,
+            credential_id: self.credential_id.decrypt(ctx, key)?,
+            key_type: self.key_type.decrypt(ctx, key)?,
+            key_algorithm: self.key_algorithm.decrypt(ctx, key)?,
+            key_curve: self.key_curve.decrypt(ctx, key)?,
             key_value: self.key_value.clone(),
-            rp_id: self.rp_id.decrypt_with_key(key)?,
-            user_handle: self.user_handle.decrypt_with_key(key)?,
-            user_name: self.user_name.decrypt_with_key(key)?,
-            counter: self.counter.decrypt_with_key(key)?,
-            rp_name: self.rp_name.decrypt_with_key(key)?,
-            user_display_name: self.user_display_name.decrypt_with_key(key)?,
-            discoverable: self.discoverable.decrypt_with_key(key)?,
+            rp_id: self.rp_id.decrypt(ctx, key)?,
+            user_handle: self.user_handle.decrypt(ctx, key)?,
+            user_name: self.user_name.decrypt(ctx, key)?,
+            counter: self.counter.decrypt(ctx, key)?,
+            rp_name: self.rp_name.decrypt(ctx, key)?,
+            user_display_name: self.user_display_name.decrypt(ctx, key)?,
+            discoverable: self.discoverable.decrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -1,6 +1,9 @@
 use bitwarden_api_api::models::CipherSecureNoteModel;
-use bitwarden_core::require;
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use bitwarden_core::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    require,
+};
+use bitwarden_crypto::{service::CryptoServiceContext, CryptoError, Decryptable, Encryptable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -28,16 +31,28 @@ pub struct SecureNoteView {
     pub r#type: SecureNoteType,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SecureNote> for SecureNoteView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<SecureNote, CryptoError> {
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, SecureNote>
+    for SecureNoteView
+{
+    fn encrypt(
+        &self,
+        _ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        _key: SymmetricKeyRef,
+    ) -> Result<SecureNote, CryptoError> {
         Ok(SecureNote {
             r#type: self.r#type,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SecureNoteView> for SecureNote {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<SecureNoteView, CryptoError> {
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, SecureNoteView>
+    for SecureNote
+{
+    fn decrypt(
+        &self,
+        _ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        _key: SymmetricKeyRef,
+    ) -> Result<SecureNoteView, CryptoError> {
         Ok(SecureNoteView {
             r#type: self.r#type,
         })

--- a/crates/bitwarden-vault/src/client_totp.rs
+++ b/crates/bitwarden-vault/src/client_totp.rs
@@ -25,8 +25,8 @@ impl<'a> ClientVault<'a> {
         view: CipherListView,
         time: Option<DateTime<Utc>>,
     ) -> Result<TotpResponse, TotpError> {
-        let enc = self.client.internal.get_encryption_settings()?;
+        let mut ctx = self.client.internal.get_crypto_service().context();
 
-        generate_totp_cipher_view(&enc, view, time)
+        generate_totp_cipher_view(&mut ctx, view, time)
     }
 }

--- a/crates/bitwarden-vault/src/mobile/client_collection.rs
+++ b/crates/bitwarden-vault/src/mobile/client_collection.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{KeyDecryptable, LocateKey};
 
 use crate::{ClientVault, Collection, CollectionView};
 
@@ -9,26 +8,23 @@ pub struct ClientCollections<'a> {
 
 impl<'a> ClientCollections<'a> {
     pub fn decrypt(&self, collection: Collection) -> Result<CollectionView, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = collection.locate_key(&enc, &None)?;
-
-        let view = collection.decrypt_with_key(key)?;
+        let view = self
+            .client
+            .internal
+            .get_crypto_service()
+            .decrypt(&collection)?;
 
         Ok(view)
     }
 
     pub fn decrypt_list(&self, collections: Vec<Collection>) -> Result<Vec<CollectionView>, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
+        let views = self
+            .client
+            .internal
+            .get_crypto_service()
+            .decrypt_list(&collections)?;
 
-        let views: Result<Vec<CollectionView>, _> = collections
-            .iter()
-            .map(|c| -> Result<CollectionView, _> {
-                let key = c.locate_key(&enc, &None)?;
-                Ok(c.decrypt_with_key(key)?)
-            })
-            .collect();
-
-        views
+        Ok(views)
     }
 }
 

--- a/crates/bitwarden-vault/src/mobile/client_folders.rs
+++ b/crates/bitwarden-vault/src/mobile/client_folders.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{ClientVault, Folder, FolderView};
 
@@ -9,28 +8,25 @@ pub struct ClientFolders<'a> {
 
 impl<'a> ClientFolders<'a> {
     pub fn encrypt(&self, folder_view: FolderView) -> Result<Folder, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
+        let crypto = self.client.internal.get_crypto_service();
 
-        let folder = folder_view.encrypt_with_key(key)?;
+        let folder = crypto.encrypt(folder_view)?;
 
         Ok(folder)
     }
 
     pub fn decrypt(&self, folder: Folder) -> Result<FolderView, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
+        let crypto = self.client.internal.get_crypto_service();
 
-        let folder_view = folder.decrypt_with_key(key)?;
+        let folder_view = crypto.decrypt(&folder)?;
 
         Ok(folder_view)
     }
 
     pub fn decrypt_list(&self, folders: Vec<Folder>) -> Result<Vec<FolderView>, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
+        let crypto = self.client.internal.get_crypto_service();
 
-        let views = folders.decrypt_with_key(key)?;
+        let views = crypto.decrypt_list(&folders)?;
 
         Ok(views)
     }

--- a/crates/bitwarden-vault/src/mobile/client_password_history.rs
+++ b/crates/bitwarden-vault/src/mobile/client_password_history.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::{Client, Error};
-use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{ClientVault, PasswordHistory, PasswordHistoryView};
 
@@ -9,10 +8,11 @@ pub struct ClientPasswordHistory<'a> {
 
 impl<'a> ClientPasswordHistory<'a> {
     pub fn encrypt(&self, history_view: PasswordHistoryView) -> Result<PasswordHistory, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let history = history_view.encrypt_with_key(key)?;
+        let history = self
+            .client
+            .internal
+            .get_crypto_service()
+            .encrypt(history_view)?;
 
         Ok(history)
     }
@@ -21,10 +21,11 @@ impl<'a> ClientPasswordHistory<'a> {
         &self,
         history: Vec<PasswordHistory>,
     ) -> Result<Vec<PasswordHistoryView>, Error> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let history_view = history.decrypt_with_key(key)?;
+        let history_view = self
+            .client
+            .internal
+            .get_crypto_service()
+            .decrypt_list(&history)?;
 
         Ok(history_view)
     }

--- a/crates/bitwarden-vault/src/password_history.rs
+++ b/crates/bitwarden-vault/src/password_history.rs
@@ -1,6 +1,7 @@
 use bitwarden_api_api::models::CipherPasswordHistoryModel;
+use bitwarden_core::key_management::{AsymmetricKeyRef, SymmetricKeyRef};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
+    service::CryptoServiceContext, CryptoError, Decryptable, EncString, Encryptable, UsesKey,
 };
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -24,22 +25,43 @@ pub struct PasswordHistoryView {
     last_used_date: DateTime<Utc>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, PasswordHistory> for PasswordHistoryView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<PasswordHistory, CryptoError> {
+impl UsesKey<SymmetricKeyRef> for PasswordHistory {
+    fn uses_key(&self) -> SymmetricKeyRef {
+        SymmetricKeyRef::User
+    }
+}
+
+impl UsesKey<SymmetricKeyRef> for PasswordHistoryView {
+    fn uses_key(&self) -> SymmetricKeyRef {
+        SymmetricKeyRef::User
+    }
+}
+
+impl Encryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, PasswordHistory>
+    for PasswordHistoryView
+{
+    fn encrypt(
+        &self,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
+    ) -> Result<PasswordHistory, CryptoError> {
         Ok(PasswordHistory {
-            password: self.password.encrypt_with_key(key)?,
+            password: self.password.encrypt(ctx, key)?,
             last_used_date: self.last_used_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, PasswordHistoryView> for PasswordHistory {
-    fn decrypt_with_key(
+impl Decryptable<SymmetricKeyRef, AsymmetricKeyRef, SymmetricKeyRef, PasswordHistoryView>
+    for PasswordHistory
+{
+    fn decrypt(
         &self,
-        key: &SymmetricCryptoKey,
+        ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
+        key: SymmetricKeyRef,
     ) -> Result<PasswordHistoryView, CryptoError> {
         Ok(PasswordHistoryView {
-            password: self.password.decrypt_with_key(key).ok().unwrap_or_default(),
+            password: self.password.decrypt(ctx, key).ok().unwrap_or_default(),
             last_used_date: self.last_used_date,
         })
     }

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, str::FromStr};
 
-use bitwarden_core::VaultLocked;
-use bitwarden_crypto::{CryptoError, KeyContainer};
+use bitwarden_core::{
+    key_management::{AsymmetricKeyRef, SymmetricKeyRef},
+    VaultLocked,
+};
+use bitwarden_crypto::{service::CryptoServiceContext, CryptoError};
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use reqwest::Url;
@@ -76,11 +79,11 @@ pub fn generate_totp(key: String, time: Option<DateTime<Utc>>) -> Result<TotpRes
 ///
 /// See [generate_totp] for more information.
 pub fn generate_totp_cipher_view(
-    enc: &dyn KeyContainer,
+    ctx: &mut CryptoServiceContext<SymmetricKeyRef, AsymmetricKeyRef>,
     view: CipherListView,
     time: Option<DateTime<Utc>>,
 ) -> Result<TotpResponse, TotpError> {
-    let key = view.get_totp_key(enc)?.ok_or(TotpError::MissingSecret)?;
+    let key = view.get_totp_key(ctx)?.ok_or(TotpError::MissingSecret)?;
 
     generate_totp(key, time)
 }
@@ -259,9 +262,8 @@ fn decode_b32(s: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_crypto::{CryptoError, SymmetricCryptoKey};
+    use bitwarden_core::key_management::create_test_crypto_with_user_key;
     use chrono::Utc;
-    use uuid::Uuid;
 
     use super::*;
     use crate::{cipher::cipher::CipherListViewType, CipherRepromptType};
@@ -359,22 +361,14 @@ mod tests {
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
         };
 
-        struct MockKeyContainer(SymmetricCryptoKey);
-        impl KeyContainer for MockKeyContainer {
-            fn get_key<'a>(
-                &'a self,
-                _: &Option<Uuid>,
-            ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-                Ok(&self.0)
-            }
-        }
+        let key= "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(key);
 
-        let enc = MockKeyContainer("w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap());
         let time = DateTime::parse_from_rfc3339("2023-01-01T00:00:00.000Z")
             .unwrap()
             .with_timezone(&Utc);
 
-        let response = generate_totp_cipher_view(&enc, view, Some(time)).unwrap();
+        let response = generate_totp_cipher_view(&mut crypto.context(), view, Some(time)).unwrap();
         assert_eq!(response.code, "559388".to_string());
         assert_eq!(response.period, 30);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5693

## 📔 Objective

Migrate the codebase to the new CryptoService introduced in https://github.com/bitwarden/sdk/pull/979.

EncryptedSettings was removed from Client, though it is still used to initialize the CryptoService. Ideally we'd move that initialization code over directly into the service but this PR is big enough as it is.

There are still some things using keys directly and KeyEncryptable/KeyDecryptable, like MasterKey, PinKey, DeviceKey, private key fingerprint. Those would need to be migrated over on a separate PR. 

We need to remove the rest of the uses of SymmetricCryptoKey from the client crates, then we can remove the internal boxing they are doing, as the keys would be protected by the KeyStore instead.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
