### PR TITLE
Remove direct dependency to bitwarden in wasm-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 name = "bitwarden-wasm-internal"
 version = "0.1.0"
 dependencies = [
- "bitwarden",
+ "bitwarden-core",
  "console_error_panic_hook",
  "console_log",
  "js-sys",

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-bitwarden = { workspace = true, features = ["wasm"] }
+bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 js-sys = "0.3.68"

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -1,7 +1,7 @@
 extern crate console_error_panic_hook;
 use std::rc::Rc;
 
-use bitwarden::{Client, ClientSettings};
+use bitwarden_core::{Client, ClientSettings};
 use log::{set_max_level, Level};
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In preparation for the bitwarden crate being removes we can stop depending on it in wasm-internal.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
