### PR TITLE
Add opt out docs link to the bws changelog

### DIFF
--- a/crates/bws/CHANGELOG.md
+++ b/crates/bws/CHANGELOG.md
@@ -19,6 +19,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated MSRV `1.75.0` (#980)
 - Use state files by default. You can opt out of this behavior with the new `state_opt_out` key.
   (#930)
+  - Opt out documentation can be found
+    [here](https://bitwarden.com/help/secrets-manager-cli/#config-state)
 
 ### Removed
 


### PR DESCRIPTION
## 📔 Objective

As discussed in PR https://github.com/bitwarden/sdk/pull/1122, add a link to our docs about the opt out change.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
