### PR TITLE
BRE-367 - Update regex in Publish Java workflow

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -37,15 +37,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-      # - name: Branch check
-      #   if: ${{ inputs.release_type != 'Dry Run' }}
-      #   run: |
-      #     if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-      #       echo "==================================="
-      #       echo "[!] Can only release from the 'main' branch"
-      #       echo "==================================="
-      #       exit 1
-      #     fi
+      - name: Branch check
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'main' branch"
+            echo "==================================="
+            exit 1
+          fi
 
       - name: Version output
         id: version-output

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -37,15 +37,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-      - name: Branch check
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'main' branch"
-            echo "==================================="
-            exit 1
-          fi
+      # - name: Branch check
+      #   if: ${{ inputs.release_type != 'Dry Run' }}
+      #   run: |
+      #     if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+      #       echo "==================================="
+      #       echo "[!] Can only release from the 'main' branch"
+      #       echo "==================================="
+      #       exit 1
+      #     fi
 
       - name: Version output
         id: version-output

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -51,8 +51,8 @@ jobs:
         id: version-output
         run: |
           if [[ "${{ inputs.version }}" == "latest" || "${{ inputs.version }}" == "" ]]; then
-            TAG_NAME=$(curl  "https://api.github.com/repos/bitwarden/sdk/releases" | jq -c '.[] | select(.tag_name | contains("java")) | .tag_name' | head -1)
-            VERSION=$(echo $TAG_NAME | grep -ohE '20[0-9]{2}\.([1-9]|1[0-2])\.[0-9]+')
+            TAG_NAME=$(curl  "https://api.github.com/repos/bitwarden/sdk/releases" | jq -rc '.[] | select(.tag_name | contains("java")) | .tag_name' | head -1)
+            VERSION=$(echo $TAG_NAME | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
             echo "Latest Released Version: $VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/languages/java/build.gradle
+++ b/languages/java/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
                 def branchName = "git branch --show-current".execute().text.trim()
 
-                if (branchName == "main" || branchName == "rc" || branchName == "hotfix-rc") {
+                if (branchName == "main") {
                     version = "1.0.1"
                 } else {
                     // branchName-SNAPSHOT


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [Card](https://bitwarden.atlassian.net/browse/BRE-367?atlOrigin=eyJpIjoiOWYxNzVkNWI1ZGVmNDdkZDk2Y2E4MTg5NGQ2MTgwMTEiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the regex in the Publish Java workflow to match semver instead of calver. I also updated the `build.gralde` file to remove the `rc` branch references.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
