### PR TITLE
BRE-367 - Update logic to use version only

### DIFF
--- a/languages/java/build.gradle
+++ b/languages/java/build.gradle
@@ -34,13 +34,7 @@ repositories {
                 // Main: Grab it from `crates/bitwarden/Cargo.toml`
 
                 def branchName = "git branch --show-current".execute().text.trim()
-
-                if (branchName == "main") {
-                    version = "1.0.1"
-                } else {
-                    // branchName-SNAPSHOT
-                    version = "${branchName.replaceAll('/', '-')}-SNAPSHOT"
-                }
+                version = "1.0.1"
 
                 afterEvaluate {
                     from components.java


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [Card](https://bitwarden.atlassian.net/browse/BRE-367?atlOrigin=eyJpIjoiMzIwYjU3NTRiOGE3NGE3ZWI5YWFmMTljOWFmYTNiYmMiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the `build.gradle` script to use the version number.  The way our Publish Java SDK workflow works is that it never checks out `main`, which made the Gradle script always use `-SNAPSHOT` in the URL which is not valid.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
