### PR TITLE
chore(codeowners): update ownership of various github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,36 +9,14 @@
 
 # Shared workflows ownership
 
-## BRE & SM teams shared ownership
-.github/workflows/build-cli-docker.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-cli.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-cpp.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-dotnet.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-go.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-java.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-napi.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-python-wheels.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/build-ruby.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-bws.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-cpp.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-dotnet.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-go.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-java.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-napi.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-python.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
-.github/workflows/release-ruby.yml @bitwarden/dept-bre @bitwarden/team-secrets-manager-dev
+## BRE & Platform teams shared ownership
+.github/workflows/release-* @bitwarden/dept-bre @bitwarden/team-platform-dev
 
-## Multiple owners
-.github/workflows/build-rust-crates.yml
-.github/workflows/build-rust-cross-platform.yml
-.github/workflows/build-wasm.yml
-.github/workflows/release-rust-crates.yml
-.github/workflows/release-wasm.yml
-.github/workflows/version-bump.yml
-
-# Secrets Manager team
-crates/bitwarden-sm @bitwarden/team-secrets-manager-dev
-crates/bws @bitwarden/team-secrets-manager-dev
+# Platform team
+.github/workflows/build-* @bitwarden/team-platform-dev
+.github/workflows/version-bump.yml @bitwarden/team-platform-dev
+crates/bitwarden-sm @bitwarden/team-platform-dev
+crates/bws @bitwarden/team-platform-dev
 
 # BRE Automations
 crates/bws/Cargo.toml


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14839

## 📔 Objective

Update the ownership of various Github actions such that:

1. Platform is responsible for build jobs
2. BRE and Platform are responsible for release jobs

This lines up with the CI/CD Partnership Model initiative.

CI jobs are failing, but they are on `main` too and the failures are unrelated to this work. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes