### PR TITLE
ci: pull the version number from the pyproject manifest

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get Package Version
         id: retrieve-version
         run: |
-          VERSION="$(grep -o '^version = ".*"' ../../crates/bitwarden-py/Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")"
+          VERSION="$(grep -o '^version = ".*"' ../../languages/python/pyproject.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")"
           echo "package_version=$VERSION" >> $GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
## 📔 Objective

When working on #1332, I noticed that the zip artifacts still used `0.1.0` in the filename because it was deriving the version from the `bitwarden-py` cargo file. This PR updates it so that it derives the Python SDK version from the pyproject manifest instead.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
