### PR TITLE
feat: allow getting org id based on access token

### DIFF
--- a/crates/bitwarden-json/src/client.rs
+++ b/crates/bitwarden-json/src/client.rs
@@ -1,4 +1,4 @@
-use bitwarden::ClientSettings;
+use bitwarden::{ClientSettings, OrganizationId};
 #[cfg(feature = "secrets")]
 use bitwarden::{
     generators::GeneratorClientsExt,
@@ -18,6 +18,11 @@ impl Client {
     pub fn new(settings_input: Option<String>) -> Self {
         let settings = Self::parse_settings(settings_input);
         Self(bitwarden::Client::new(settings))
+    }
+
+    pub fn get_access_token_organization(&self) -> Option<OrganizationId> {
+        let client = &self.0;
+        client.internal.get_access_token_organization()
     }
 
     pub async fn run_command(&self, input_str: &str) -> String {

--- a/crates/bitwarden-py/Cargo.toml
+++ b/crates/bitwarden-py/Cargo.toml
@@ -15,6 +15,7 @@ name = "bitwarden_py"
 crate-type = ["cdylib"]
 
 [dependencies]
+bitwarden = { workspace = true }
 bitwarden-json = { path = "../bitwarden-json", features = ["secrets"] }
 pyo3 = { version = "0.27.0", features = ["extension-module", "abi3"] }
 pyo3-log = "0.13.2"

--- a/crates/bitwarden-py/src/client.rs
+++ b/crates/bitwarden-py/src/client.rs
@@ -25,4 +25,13 @@ impl BitwardenClient {
     fn run_command(&self, command_input: String) -> String {
         self.0.block_on(self.1.run_command(&command_input))
     }
+
+    #[pyo3(text_signature = "($self")]
+    fn get_access_token_organization(&self) -> String {
+        if let Some(organization_id) = self.1.get_access_token_organization() {
+            organization_id.to_string()
+        } else {
+            "".to_string()
+        }
+    }
 }

--- a/languages/python/bitwarden_sdk/bitwarden_client.py
+++ b/languages/python/bitwarden_sdk/bitwarden_client.py
@@ -145,6 +145,9 @@ class SecretsClient:
         note: Optional[str],
         project_ids: Optional[List[UUID]] = None,
     ) -> ResponseForSecretResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         if note is None:
             # secrets api does not accept empty notes
             note = ""

--- a/languages/python/bitwarden_sdk/bitwarden_client.py
+++ b/languages/python/bitwarden_sdk/bitwarden_client.py
@@ -100,12 +100,15 @@ class SecretsClient:
 
     def create(
         self,
-        organization_id: UUID,
+        organization_id: Optional[UUID],
         key: str,
         value: str,
         note: Optional[str],
         project_ids: Optional[List[UUID]] = None,
     ) -> ResponseForSecretResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         if note is None:
             # secrets api does not accept empty notes
             note = ""
@@ -120,7 +123,12 @@ class SecretsClient:
         )
         return ResponseForSecretResponse.from_dict(result)
 
-    def list(self, organization_id: str) -> ResponseForSecretIdentifiersResponse:
+    def list(
+        self, organization_id: Optional[UUID]
+    ) -> ResponseForSecretIdentifiersResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         result = self.client._run_command(
             Command(
                 secrets=SecretsCommand(list=SecretIdentifiersRequest(organization_id))
@@ -130,7 +138,7 @@ class SecretsClient:
 
     def update(
         self,
-        organization_id: str,
+        organization_id: Optional[UUID],
         id: str,
         key: str,
         value: str,
@@ -158,8 +166,11 @@ class SecretsClient:
         return ResponseForSecretsDeleteResponse.from_dict(result)
 
     def sync(
-        self, organization_id: str, last_synced_date: Optional[str]
+        self, organization_id: Optional[UUID], last_synced_date: Optional[str]
     ) -> ResponseForSecretsSyncResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         result = self.client._run_command(
             Command(
                 secrets=SecretsCommand(
@@ -182,9 +193,12 @@ class ProjectsClient:
 
     def create(
         self,
-        organization_id: str,
+        organization_id: Optional[UUID],
         name: str,
     ) -> ResponseForProjectResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         result = self.client._run_command(
             Command(
                 projects=ProjectsCommand(
@@ -194,7 +208,10 @@ class ProjectsClient:
         )
         return ResponseForProjectResponse.from_dict(result)
 
-    def list(self, organization_id: str) -> ResponseForProjectsResponse:
+    def list(self, organization_id: Optional[UUID]) -> ResponseForProjectsResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         result = self.client._run_command(
             Command(projects=ProjectsCommand(list=ProjectsListRequest(organization_id)))
         )
@@ -202,10 +219,13 @@ class ProjectsClient:
 
     def update(
         self,
-        organization_id: str,
+        organization_id: Optional[UUID],
         id: str,
         name: str,
     ) -> ResponseForProjectResponse:
+        if organization_id is None:
+            organization_id = self.client.inner.get_access_token_organization()
+
         result = self.client._run_command(
             Command(
                 projects=ProjectsCommand(

--- a/languages/python/example.py
+++ b/languages/python/example.py
@@ -19,7 +19,6 @@ client = BitwardenClient(
 
 # Add some logging & set the org id
 logging.basicConfig(level=logging.DEBUG)
-organization_id = os.getenv("ORGANIZATION_ID")
 
 # -- Example Generator Commands --
 # Note: using the generator does not require authentication with a server
@@ -49,44 +48,44 @@ client.auth().login_access_token(os.getenv("ACCESS_TOKEN"), state_path)
 
 # -- Example Project Commands --
 
-project = client.projects().create(organization_id, "ProjectName")
-project2 = client.projects().create(organization_id, "AnotherProject")
+project = client.projects().create(None, "ProjectName")
+project2 = client.projects().create(None, "AnotherProject")
 updated_project = client.projects().update(
-    organization_id, project.data.id, "Cool New Project Name"
+    None, project.data.id, "Cool New Project Name"
 )
 get_that_project = client.projects().get(project.data.id)
 
 input("Press Enter to delete the project...")
 client.projects().delete([project.data.id])
 
-print(client.projects().list(organization_id))
+print(client.projects().list(None))
 
 # -- Example Secret Commands --
 
-if client.secrets().sync(organization_id, None).data.has_changes is True:
+if client.secrets().sync(None, None).data.has_changes is True:
     print("There are changes to sync")
 else:
     print("No changes to sync")
 
 last_synced_date = datetime.now(tz=timezone.utc)
-print(client.secrets().sync(organization_id, last_synced_date))
+print(client.secrets().sync(None, last_synced_date))
 
 secret = client.secrets().create(
-    organization_id,
+    None,
     "TEST_SECRET",
     "This is a test secret",
     "Secret1234!",
     [project2.data.id],
 )
 secret2 = client.secrets().create(
-    organization_id,
+    None,
     "ANOTHER_SECRET",
     "Secret1234!",
     None,
     [project2.data.id],
 )
 secret_updated = client.secrets().update(
-    organization_id,
+    None,
     secret.data.id,
     "TEST_SECRET_UPDATED",
     "This as an updated test secret",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Non-breaking, but less convenient version of #1419.

The Rust SDK can automatically get the organization ID from the client. This allows the `bws` CLI to work without forcing the user to supply their org ID for every command. However, this functionality is not exposed in the language wrappers, which makes using them somewhat tedious. This PR makes the org ID retrieval available to the Python wrapper, removing the need to supply it when CRUDing projects and secrets.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
