### PR TITLE
[BRE-1670] update workflows with app token

### DIFF
--- a/.github/workflows/build-cli-docker.yml
+++ b/.github/workflows/build-cli-docker.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Login to Azure ACR
         run: az acr login -n "${_AZ_REGISTRY%.azurecr.io}"
 
-      - name: Retrieve github PAT secrets
-        id: retrieve-secret-pat
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
-
       - name: Setup Docker Trust
         if: ${{ env.is_publish_branch == 'true' }}
         uses: bitwarden/gh-actions/setup-docker-trust@main

--- a/.github/workflows/build-cli-docker.yml
+++ b/.github/workflows/build-cli-docker.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Login to Azure ACR
         run: az acr login -n "${_AZ_REGISTRY%.azurecr.io}"
 
+      - name: Retrieve github PAT secrets
+        id: retrieve-secret-pat
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+
       - name: Setup Docker Trust
         if: ${{ env.is_publish_branch == 'true' }}
         uses: bitwarden/gh-actions/setup-docker-trust@main

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -81,8 +81,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      _BOT_NAME: "bw-ghapp[bot]"
-      _BOT_EMAIL: "178206702+bw-ghapp[bot]@users.noreply.github.com"
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
     steps:
       - name: Checkout SDK repo
@@ -123,13 +121,7 @@ jobs:
           path: sm-sdk-php
           ref: main
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
-
-      - name: Setup Git
-        working-directory: sm-sdk-php
-        run: |
-          git config --local user.email "${{ env._BOT_EMAIL }}"
-          git config --local user.name "${{ env._BOT_NAME }}"
+          persist-credentials: true
 
       - name: Update files
         run: |
@@ -145,26 +137,25 @@ jobs:
           find . -name '*' -exec \
             sed -i -e 's/github.com\/bitwarden\/sdk/github.com\/bitwarden\/sm-sdk-php/g' {} \;
 
-      - name: Push changes
+      - name: Dry run output
+        if: ${{ inputs.release_type == 'Dry Run' }}
         working-directory: sm-sdk-php
         run: |
-          git add .
+          echo "==================================="
+          echo "[!] Dry Run - commit was skipped"
+          echo "==================================="
+          git ls-files -m
 
-          if [ -n "$(git status --porcelain)" ]; then
-            git commit -m "Update PHP SDK to ${{ github.sha }}"
-          else
-            echo "No changes to commit"
-          fi
-
-          if [[ "${{ inputs.release_type }}" == "Dry Run" ]]; then
-            echo "==================================="
-            echo "[!] Dry Run - Skipping push"
-            echo "==================================="
-            git ls-files -m
-            exit 0
-          else
-            git push origin main
-          fi
+      - name: Commit changes
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        id: commit
+        uses: bitwarden/gh-actions/api-commit@main
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: main
+          message: "Update PHP SDK to ${{ github.sha }}"
+          repo: sm-sdk-php
+          owner: bitwarden
 
       - name: Create release tag on PHP SDK repo
         if: ${{ inputs.release_type != 'Dry Run' }}
@@ -329,7 +320,7 @@ jobs:
           path: sm-sdk-php
           ref: main
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Publish version
         if: ${{ inputs.release_type != 'Dry Run' }}

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -78,18 +78,18 @@ jobs:
       - validate
       - setup-php
     permissions:
-      contents: write
+      contents: read
       id-token: write
     env:
-      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
-      _BOT_NAME: bitwarden-devops-bot
+      _BOT_NAME: "bw-ghapp[bot]"
+      _BOT_EMAIL: "178206702+bw-ghapp[bot]@users.noreply.github.com"
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: sdk
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -99,14 +99,22 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout SDK-PHP repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -114,8 +122,8 @@ jobs:
           repository: bitwarden/sm-sdk-php
           path: sm-sdk-php
           ref: main
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
-          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup Git
         working-directory: sm-sdk-php
@@ -141,7 +149,12 @@ jobs:
         working-directory: sm-sdk-php
         run: |
           git add .
-          git commit -m "Update PHP SDK to ${{ github.sha }}"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Update PHP SDK to ${{ github.sha }}"
+          else
+            echo "No changes to commit"
+          fi
 
           if [[ "${{ inputs.release_type }}" == "Dry Run" ]]; then
             echo "==================================="
@@ -189,14 +202,22 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Download x86_64-apple-darwin artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -248,7 +269,7 @@ jobs:
           tag: v${{ env._PKG_VERSION }}
           name: v${{ env._PKG_VERSION }}
           body: "<insert release notes here>"
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          token: ${{ steps.app-token.outputs.token }}
           draft: true
           repo: sm-sdk-php
           owner: bitwarden
@@ -276,16 +297,30 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Retrieve secrets
-        id: retrieve-secrets
+      - name: Retrieve packagist secrets
+        id: retrieve-packagist
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope,
-            packagist-key"
+          secrets: "packagist-key"
+
+      - name: Retrieve ghapp secrets
+        id: retrieve-secret
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout SDK-PHP repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -293,12 +328,12 @@ jobs:
           repository: bitwarden/sm-sdk-php
           path: sm-sdk-php
           ref: main
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Publish version
         if: ${{ inputs.release_type != 'Dry Run' }}
         env:
-          PACKAGIST_KEY: ${{ steps.retrieve-secrets.outputs.packagist-key }}
+          PACKAGIST_KEY: ${{ steps.retrieve-packagist.outputs.packagist-key }}
         run: curl -XPOST -H'content-type:application/json' "https://packagist.org/api/update-package?username=bitwarden&apiToken=${PACKAGIST_KEY}" -d'{"repository":{"url":"https://packagist.org/packages/bitwarden/sdk-secrets"}}'
         working-directory: sm-sdk-php

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -113,6 +113,8 @@ jobs:
           app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: sm-sdk-php
+          permission-contents: write
 
       - name: Checkout SDK-PHP repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -215,6 +215,8 @@ jobs:
           app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: sm-sdk-php
+          permission-contents: write
 
       - name: Download x86_64-apple-darwin artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -318,6 +320,8 @@ jobs:
           app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: sm-sdk-php
+          permission-contents: write
 
       - name: Checkout SDK-PHP repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -321,7 +321,6 @@ jobs:
           private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
           owner: ${{ github.repository_owner }}
           repositories: sm-sdk-php
-          permission-contents: write
 
       - name: Checkout SDK-PHP repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/publish-php.yml
+++ b/.github/workflows/publish-php.yml
@@ -163,6 +163,10 @@ jobs:
         if: ${{ inputs.release_type != 'Dry Run' }}
         working-directory: sm-sdk-php
         run: |
+          # Sync local repo with API-created commit
+          git fetch origin main
+          git checkout FETCH_HEAD
+
           # Check if tag exists, set output then exit 0 if true.
           if git log "v${_PKG_VERSION}" >/dev/null 2>&1; then
             echo "==================================="

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
- 
+
       - name: Generate GH App token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token

--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -65,14 +65,24 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+ 
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sdk
+          permission-contents: write
 
       - name: Download x86_64-apple-darwin C artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -167,7 +177,7 @@ jobs:
           tag: cpp-sdk-v${{ env._PKG_VERSION }}
           name: "C++ SDK v${{ env._PKG_VERSION }}"
           body: "<insert release notes here>"
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          token: ${{ steps.app-token.outputs.token }}
           draft: true
           repo: sdk
           owner: bitwarden

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -195,6 +195,10 @@ jobs:
         if: ${{ inputs.release_type != 'Dry Run' }}
         working-directory: sdk-go
         run: |
+          # Sync local repo with API-created commit
+          git fetch origin main
+          git checkout FETCH_HEAD
+
           # Check if tag exists, set output then exit 0 if true.
           if git log "v${_PKG_VERSION}" >/dev/null 2>&1; then
             echo "==================================="

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -54,11 +54,11 @@ jobs:
     needs: validate
     permissions:
       actions: read
-      contents: write
+      contents: read #writes go through the app token
       id-token: write
     env:
-      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
-      _BOT_NAME: bitwarden-devops-bot
+      _BOT_NAME: "bw-ghapp[bot]"
+      _BOT_EMAIL: "178206702+bw-ghapp[bot]@users.noreply.github.com"
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
 
     steps:
@@ -76,14 +76,24 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sdk-go
+          permission-contents: write
 
       - name: Checkout SDK-Go repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -91,7 +101,7 @@ jobs:
           repository: bitwarden/sdk-go
           path: sdk-go
           ref: main
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
       - name: Setup Git
@@ -209,7 +219,7 @@ jobs:
       - validate
     permissions:
       actions: read
-      contents: write
+      contents: read #writes go through the app token
       id-token: write
     env:
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
@@ -222,14 +232,24 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sdk-go
+          permission-contents: write
 
       - name: Download x86_64-apple-darwin artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -296,7 +316,7 @@ jobs:
           tag: v${{ env._PKG_VERSION }}
           name: v${{ env._PKG_VERSION }}
           body: "<insert release notes here>"
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          token: ${{ steps.app-token.outputs.token }}
           draft: true
           repo: sdk-go
           owner: bitwarden

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -57,8 +57,6 @@ jobs:
       contents: read #writes go through the app token
       id-token: write
     env:
-      _BOT_NAME: "bw-ghapp[bot]"
-      _BOT_EMAIL: "178206702+bw-ghapp[bot]@users.noreply.github.com"
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
 
     steps:
@@ -103,12 +101,6 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
-
-      - name: Setup Git
-        working-directory: sdk-go
-        run: |
-          git config --local user.email "${{ env._BOT_EMAIL }}"
-          git config --local user.name "${{ env._BOT_NAME }}"
 
       - name: Download x86_64-apple-darwin artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -180,21 +172,24 @@ jobs:
           branch: ${{ inputs.release_type == 'Dry Run' && 'main' ||  github.ref_name }}
           artifacts: schemas.go
 
-      - name: Push changes
+      - name: Dry run output
+        if: ${{ inputs.release_type == 'Dry Run' }}
         working-directory: sdk-go
         run: |
-          git add .
-          git commit -m "Update Go SDK to ${{ github.sha }}"
+          echo "==================================="
+          echo "[!] Dry Run - Skipping push"
+          echo "==================================="
+          git ls-files -m
 
-          if [[ "${{ inputs.release_type }}" == "Dry Run" ]]; then
-            echo "==================================="
-            echo "[!] Dry Run - Skipping push"
-            echo "==================================="
-            git ls-files -m
-            exit 0
-          else
-            git push origin main
-          fi
+      - name: Commit changes
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        uses: bitwarden/gh-actions/api-commit@main
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: main
+          message: "Update Go SDK to ${{ github.sha }}"
+          repo: sdk-go
+          owner: bitwarden
 
       - name: Create release tag on SDK Go repo
         if: ${{ inputs.release_type != 'Dry Run' }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Bump ${{ inputs.project }} Version to v${{ inputs.version_number }}"
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read #writes go through the app token
       pull-requests: write
       id-token: write
       actions: read
@@ -59,16 +59,25 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve secrets
-        id: retrieve-secrets
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key,
-            github-gpg-private-key-passphrase,
-            github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sdk-sm
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -76,18 +85,7 @@ jobs:
           ref: main
           repository: bitwarden/sdk-sm
           persist-credentials: true
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-        with:
-          gpg_private_key: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key }}
-          passphrase: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key-passphrase }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Create Version Branch
-        id: branch
-        run: git switch -c "sdk-${_PROJECT}_version_bump_${_VERSION}"
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Create Version Branch
         id: create-branch
@@ -210,8 +208,8 @@ jobs:
 
       - name: Setup git
         run: |
-          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-          git config --local user.name "bitwarden-devops-bot"
+          git config --local user.email "178206702+bw-ghapp[bot]@users.noreply.github.com"
+          git config --local user.name "bw-ghapp[bot]"
 
       - name: Check if version changed
         id: version-changed
@@ -243,7 +241,7 @@ jobs:
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         id: create-pr
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BRANCH: ${{ steps.create-branch.outputs.name }}
           TITLE: "Bump ${{ inputs.project }} version to ${{ inputs.version_number }}"
         run: |
@@ -272,7 +270,7 @@ jobs:
 
       - name: Merge PR
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         run: gh pr merge "$PR_NUMBER" --squash --auto --delete-branch
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           NAME="version_bump_${GITHUB_REF_NAME}_${_PROJECT}_${_VERSION}"
           git switch -c "$NAME"
+          git push -u origin "$NAME"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
       ########################
@@ -206,11 +207,6 @@ jobs:
       # VERSION BUMP SECTION END #
       ############################
 
-      - name: Setup git
-        run: |
-          git config --local user.email "178206702+bw-ghapp[bot]@users.noreply.github.com"
-          git config --local user.name "bw-ghapp[bot]"
-
       - name: Check if version changed
         id: version-changed
         run: |
@@ -229,13 +225,13 @@ jobs:
 
       - name: Commit files
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
-        run: git commit -m "Bumped sdk-${_PROJECT} version to ${_VERSION}" -a
-
-      - name: Push changes
-        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
-        env:
-          PR_BRANCH: ${{ steps.create-branch.outputs.name }}
-        run: git push -u origin "$PR_BRANCH"
+        uses: bitwarden/gh-actions/api-commit@main
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ steps.create-branch.outputs.name }}
+          message: "Bumped sdk-${{ inputs.project }} version to ${{ inputs.version_number }}"
+          repo: sdk-sm
+          owner: bitwarden
 
       - name: Create Version PR
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
@@ -263,12 +259,14 @@ jobs:
           echo "pr_number=${PR_URL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Approve PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         run: gh pr review "$PR_NUMBER" --approve
 
       - name: Merge PR
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1670](https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiYWQ0N2Q0OGIzODE5NDU3ZDg3OWI4OGE4ZTQ0ZTRhOGEiLCJwIjoiaiJ9)

## 📔 Objective

Updating github workflows that use PAT to use app token or GITHUB_TOKEN instead.

In some cases, the PAT token was being used for simple repo actions that didn't require further authentication, such as reading from or cloning a public repository.  

Some Github Token permissions were too broad where a bot token is being used

## 🚨 Breaking Changes

<!-- If this PR introduces a breaking change for any downstream consumer, call it out clearly.

For breaking changes:
1. Describe what changed in the public interface
2. Explain why the change was necessary
3. Provide migration steps for consumers
4. Link to any paired consumer PRs if needed

Otherwise, you can remove this section. -->


[BRE-1670]: https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ