### PR TITLE
[BRE-1894] Add new build-python-wheels-dev workflow

### DIFF
--- a/.github/workflows/build-python-wheels-dev.yml
+++ b/.github/workflows/build-python-wheels-dev.yml
@@ -1,0 +1,41 @@
+name: Build Python Wheels (Dev)
+run-name: Build Python Wheels (Dev)
+
+on:
+  workflow_dispatch:
+  # NOTE: Push trigger disabled until we verify the new workflow works
+  # push:
+  #   branches:
+  #     - "main"
+
+concurrency:
+  group: build-python-dev
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build-dev:
+    name: Build Dev
+    uses: ./.github/workflows/build-python-wheels.yml
+    permissions:
+      contents: read
+    with:
+      dev_version: true
+
+  trigger-publish:
+    name: Trigger publish
+    runs-on: ubuntu-24.04
+    needs: build-dev
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Trigger publish to Test PyPI
+        uses: bitwarden/gh-actions/trigger-actions@main
+        with:
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          task: publish-python-wheels-dev
+          data: '{"version": "${{ needs.build-dev.outputs.package_version }}", "run_id": "${{ github.run_id }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-1894

## 📔 Objective

Build and deploy re-arch. Extracts build portion from build-publish-python-wheels-dev workflow. Publishes to Test PyPI through deploy repo using trigger-actions pattern.

## 🚨 Breaking Changes

<!-- If this PR introduces a breaking change for any downstream consumer, call it out clearly.

For breaking changes:
1. Describe what changed in the public interface
2. Explain why the change was necessary
3. Provide migration steps for consumers
4. Link to any paired consumer PRs if needed

Otherwise, you can remove this section. -->
