### PR TITLE
fix: update renovate schedule minute to wildcard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config:non-pinned"],
-  "schedule": ["0 0-4 8-14 */2 1"],
+  "schedule": ["* 0-4 8-14 */2 1"],
   "timezone": "America/Chicago",
   "separateMajorMinor": true,
   "enabledManagers": ["cargo", "dockerfile", "github-actions", "gomod", "npm", "nuget"],


### PR DESCRIPTION
## 📔 Objective

> 0 in as the minutes value apparently does **not** work for cron formatting renovate schedule. Update to use the recommended wildcard value.

