### PR TITLE
feat(napi): add arm64-linux build targets (gnu + musl)

### DIFF
--- a/.github/workflows/build-napi.yml
+++ b/.github/workflows/build-napi.yml
@@ -52,6 +52,27 @@ jobs:
               set -e &&
               npm run build &&
               strip *.node
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            build: |
+              set -e &&
+              npm run build &&
+              strip *.node
+
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            build: |
+              set -e &&
+              docker run --rm --platform linux/arm64 \
+                -v "$GITHUB_WORKSPACE":/src -w /src/crates/bitwarden-napi \
+                -e CARGO_TARGET_DIR=/tmp/ctarget \
+                node:lts-alpine sh -c '
+                  apk add --no-cache build-base openssl-dev openssl-libs-static pkgconfig perl rust cargo git &&
+                  npm ci --no-audit --no-fund &&
+                  npx napi build --platform --release --js binding.js --dts binding.d.ts
+                ' &&
+              strip sdk-napi.linux-arm64-musl.node || true
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -105,6 +105,8 @@ jobs:
           wget "https://github.com/bitwarden/sdk-sm/releases/download/napi-v${_PKG_VERSION}/sdk-napi.darwin-x64.node"
           wget "https://github.com/bitwarden/sdk-sm/releases/download/napi-v${_PKG_VERSION}/sdk-napi.win32-x64-msvc.node"
           wget "https://github.com/bitwarden/sdk-sm/releases/download/napi-v${_PKG_VERSION}/sdk-napi.linux-x64-gnu.node"
+          wget "https://github.com/bitwarden/sdk-sm/releases/download/napi-v${_PKG_VERSION}/sdk-napi.linux-arm64-gnu.node"
+          wget "https://github.com/bitwarden/sdk-sm/releases/download/napi-v${_PKG_VERSION}/sdk-napi.linux-arm64-musl.node"
           mv sdk-napi.*.node ${{ github.workspace }}/crates/bitwarden-napi/artifacts
 
       - name: Set up Node

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -103,4 +103,6 @@ jobs:
             dist/sdk-napi.darwin-x64.node
             dist/sdk-napi.win32-x64-msvc.node
             dist/sdk-napi.linux-x64-gnu.node
+            dist/sdk-napi.linux-arm64-gnu.node
+            dist/sdk-napi.linux-arm64-musl.node
             dist/schemas.ts

--- a/crates/bitwarden-napi/npm/linux-arm64-gnu/README.md
+++ b/crates/bitwarden-napi/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@bitwarden/sdk-napi-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@bitwarden/sdk-napi`

--- a/crates/bitwarden-napi/npm/linux-arm64-gnu/package.json
+++ b/crates/bitwarden-napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bitwarden/sdk-napi-linux-arm64-gnu",
+  "version": "1.0.0",
+  "homepage": "https://github.com/bitwarden/sdk-sm#readme",
+  "bugs": {
+    "url": "https://github.com/bitwarden/sdk-sm/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bitwarden/sdk-sm.git"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
+  "main": "sdk-napi.linux-arm64-gnu.node",
+  "files": [
+    "sdk-napi.linux-arm64-gnu.node"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/crates/bitwarden-napi/npm/linux-arm64-musl/README.md
+++ b/crates/bitwarden-napi/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@bitwarden/sdk-napi-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@bitwarden/sdk-napi`

--- a/crates/bitwarden-napi/npm/linux-arm64-musl/package.json
+++ b/crates/bitwarden-napi/npm/linux-arm64-musl/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bitwarden/sdk-napi-linux-arm64-musl",
+  "version": "1.0.0",
+  "homepage": "https://github.com/bitwarden/sdk-sm#readme",
+  "bugs": {
+    "url": "https://github.com/bitwarden/sdk-sm/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bitwarden/sdk-sm.git"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
+  "main": "sdk-napi.linux-arm64-musl.node",
+  "files": [
+    "sdk-napi.linux-arm64-musl.node"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/crates/bitwarden-napi/package.json
+++ b/crates/bitwarden-napi/package.json
@@ -43,7 +43,9 @@
     "name": "sdk-napi",
     "triples": {
       "additional": [
-        "aarch64-apple-darwin"
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl"
       ]
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

Community contribution. The `@bitwarden/sdk-napi` package currently ships native binaries for darwin-arm64/x64, win-x64 and linux-x64-gnu, but **not Linux ARM64** — so aarch64 Linux hosts and arm64 containers have no prebuilt binary to load.

## 📔 Objective

Add `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` build targets for the napi package:

- Declare both triples in `package.json` and add their per-platform npm packages (`@bitwarden/sdk-napi-linux-arm64-gnu` / `-musl`). `binding.js` already contained the arm64 loader branches — they were just never produced.
- **gnu**: builds natively on the free `ubuntu-24.04-arm` runner, mirroring the existing x64-gnu target.
- **musl**: builds inside a native arm64 Alpine container on the ARM runner (no QEMU). It intentionally omits `--target` so cargo uses Alpine's native musl toolchain instead of treating it as a cross-compile (which fails — the distro host triple is `aarch64-alpine-linux-musl`).
- Wire the two new `.node` artifacts into the release and publish workflows.

Validated end-to-end on a fork: all six platforms build green in CI, including both new arm64 jobs. The dependency tree resolves to rustls (not openssl), so the musl build needs no extra system libraries.

Closes #1154 

## 🚨 Breaking Changes

None — purely additive. Existing platforms are unaffected; the new binaries ship as per-platform `optionalDependencies` that npm resolves by `os`/`cpu`/`libc`.