### PR TITLE
[BRE-2024] Fix x86_64 macOS NAPI build producing ARM64 binaries

### DIFF
--- a/.github/workflows/build-napi.yml
+++ b/.github/workflows/build-napi.yml
@@ -33,7 +33,7 @@ jobs:
           - os: macos-15
             target: x86_64-apple-darwin
             build: |
-              npm run build
+              npm run build-x64
               strip -x *.node
 
           - os: macos-15

--- a/crates/bitwarden-napi/package.json
+++ b/crates/bitwarden-napi/package.json
@@ -23,6 +23,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release --js binding.js --dts binding.d.ts && tsc",
     "build-arm64": "napi build --target aarch64-apple-darwin --platform --release --js binding.js --dts binding.d.ts && tsc",
+    "build-x64": "napi build --target x86_64-apple-darwin --platform --release --js binding.js --dts binding.d.ts && tsc",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish --skip-gh-release",
     "tsc": "tsc",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2024

## 📔 Objective

When [BRE-1302](https://bitwarden.atlassian.net/browse/BRE-1302) upgraded the macOS runner from `macos-13` (Intel) to `macos-15` (ARM64), the `x86_64` build job began running on ARM64 hardware. The build command `npm run build` uses the `--platform` flag, which auto-detects the host architecture rather than respecting the target triple. This caused the `x86_64` job to build `ARM64` binaries instead.

Changes:
- Add `build-x64` script to `package.json` that explicitly targets `x86_64-apple-darwin`, mirroring the existing `build-arm64` pattern
- Update `build-napi.yml` to use `npm run build-x64` for the `x86_64` job

This ensures the `x86_64 job` produces `sdk-napi.darwin-x64.node` (Intel) instead of incorrectly producing `sdk-napi.darwin-arm64.node` (ARM).

## 🚨 Breaking Changes

<!-- If this PR introduces a breaking change for any downstream consumer, call it out clearly.

For breaking changes:
1. Describe what changed in the public interface
2. Explain why the change was necessary
3. Provide migration steps for consumers
4. Link to any paired consumer PRs if needed

Otherwise, you can remove this section. -->


[BRE-1302]: https://bitwarden.atlassian.net/browse/BRE-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ