### PR TITLE
fix: `cargo about` not found or whatever

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -445,7 +445,7 @@ jobs:
           key: cargo-cli-about
 
       - name: Install cargo-about
-        run: cargo install cargo-about
+        run: cargo install cargo-about --locked --features cli
 
       - name: Generate THIRDPARTY.html
         working-directory: ./crates/bws


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1995

## 📔 Objective

Fix the "generate thirdparty" workflow failures. The `cargo about` command is now gated behind the `cli` feature flag: https://github.com/EmbarkStudios/cargo-about/releases/tag/0.9.0.