### PR TITLE
misc: add Bitwarden SDK license to cargo-about manifest

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -1,4 +1,5 @@
 accepted = [
+    "LicenseRef-Bitwarden-SDK",
     "MIT",
     "ISC",
     "BSD-2-Clause",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-2043

## 📔 Objective

https://github.com/bitwarden/sdk-internal/pull/1246 added licenses to the Bitwarden-owned crates. We need to allow this license to fix our SBOM workflow.